### PR TITLE
'An application being staged has its staging log streamed during a push' fails with newer go cli

### DIFF
--- a/apps/staging_log_test.go
+++ b/apps/staging_log_test.go
@@ -20,7 +20,6 @@ var _ = Describe("An application being staged", func() {
 	It("has its staging log streamed during a push", func() {
 		push := Cf("push", AppName, "-p", doraPath)
 
-		Expect(push).To(Say("Staging..."))
 		Expect(push).To(Say("Installing dependencies"))
 		Expect(push).To(Say("Uploading droplet"))
 		Expect(push).To(Say("Started"))


### PR DESCRIPTION
Go cli commit cloudfoundry/cli@e41c9e5376773132580a363ed127a0faa51da15d removed the 'Staging...' message but the test still expects it.  This removes that expectation.
