### PR TITLE
More reliable version of loggregator CATs

### DIFF
--- a/apps/loggregator_test.go
+++ b/apps/loggregator_test.go
@@ -1,0 +1,45 @@
+package apps
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/vito/cmdtest/matchers"
+
+	. "github.com/pivotal-cf-experimental/cf-acceptance-tests/helpers"
+	"time"
+)
+
+var _ = Describe("loggregator", func() {
+	BeforeEach(func() {
+		AppName = RandomName()
+
+		PushApp(AppName, doraPath)
+	})
+
+	AfterEach(func() {
+		DeleteApp(AppName)
+	})
+
+	Context("gcf logs", func() {
+		It("blocks and exercises basic loggregator behavior", func() {
+			logs := Cf("logs", AppName)
+
+			Expect(logs).To(SayWithTimeout("Connected, tailing logs for app", time.Second*15))
+
+			Eventually(Curling("/")).Should(Say("Hi, I'm Dora!"))
+
+			Expect(logs).To(SayWithTimeout("OUT "+AppName+"."+IntegrationConfig.AppsDomain, time.Second*15))
+		})
+	})
+
+	Context("gcf logs --recent", func() {
+		It("makes loggregator buffer and dump log messages", func() {
+		   	logs := Cf("logs", AppName, "--recent")
+
+			Expect(logs).To(Say("Connected, dumping recent logs for app"))
+
+			Expect(logs).To(Say("OUT Created app"))
+			Expect(logs).To(Say("OUT Starting app instance"))
+		})
+	})
+})

--- a/helpers/app_commands.go
+++ b/helpers/app_commands.go
@@ -1,0 +1,15 @@
+package helpers
+
+import (
+	. "github.com/onsi/gomega"
+	. "github.com/vito/cmdtest/matchers"
+	"time"
+)
+
+func PushApp(appName string, appPath string) {
+	Expect(Cf("push", appName, "-p", appPath)).To(SayWithTimeout("App started", time.Minute*2))
+}
+
+func DeleteApp(appName string) {
+	Expect(Cf("delete", appName, "-f")).To(SayWithTimeout("OK", time.Minute*2))
+}


### PR DESCRIPTION
This reverts commit 26eeae14d6eb4f90420f7ba54ae846c4b7ce60ff. 

These tests consistently pass with the latest CLI (f21f2187d416a5180450d1b8c28cfe9c464d407e)
