### PR TITLE
FIX: ADMIN environment variable should be ADMIN_USER in instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ cat > integration_config.json <<EOF
 { "apps_domain": "10.244.0.34.xip.io" }
 EOF
 
-export ADMIN=admin-username
+export ADMIN_USER=admin-username
 export ADMIN_PASSWORD=admin-password
 export CF_USER=cf-user-username
 export CF_USER_PASSWORD=cf-user-password


### PR DESCRIPTION
The functions expect ADMIN_USER environment variable for this to run, fixing the readme to reflect this.

NOTE: Debugging this was not fun, the output was not helpful as to what failed.
