### PR TITLE
Use admin context for buildpack management

### DIFF
--- a/apps/admin_buildpack_lifecycle_test.go
+++ b/apps/admin_buildpack_lifecycle_test.go
@@ -32,6 +32,7 @@ var _ = Describe("An application using an admin buildpack", func() {
 	}
 
 	BeforeEach(func() {
+                helpers.LoginAsAdmin()
 		BuildpackName = RandomName()
 		appName = RandomName()
 
@@ -63,10 +64,13 @@ var _ = Describe("An application using an admin buildpack", func() {
 		Expect(createBuildpack).To(Say("OK"))
 		Expect(createBuildpack).To(Say("Uploading"))
 		Expect(createBuildpack).To(Say("OK"))
+                helpers.LoginAsUser()
 	})
 
 	AfterEach(func() {
+                helpers.LoginAsAdmin()
 		Expect(Cf("delete-buildpack", BuildpackName, "-f")).To(Say("OK"))
+                helpers.LoginAsUser()
 	})
 
 	Context("when the buildpack is detected", func() {
@@ -90,7 +94,9 @@ var _ = Describe("An application using an admin buildpack", func() {
 
 	Context("when the buildpack is deleted", func() {
 		BeforeEach(func() {
-			Expect(Cf("delete-buildpack", BuildpackName, "-f")).To(Say("OK"))
+                        helpers.LoginAsAdmin()
+		        Expect(Cf("delete-buildpack", BuildpackName, "-f")).To(Say("OK"))
+                        helpers.LoginAsUser()
 		})
 
 		It("fails to stage", func() {

--- a/apps/helpers/buildpack.go
+++ b/apps/helpers/buildpack.go
@@ -4,7 +4,19 @@ import (
 	"fmt"
 	"os"
 	"path"
+        . "github.com/cloudfoundry/cf-acceptance-tests/helpers"
+        . "github.com/onsi/gomega"
+        . "github.com/pivotal-cf-experimental/cf-test-helpers/cf"
+        . "github.com/vito/cmdtest/matchers"
 )
+
+func LoginAsAdmin() {
+     Expect(Cf("login", "-u", AdminUserContext.Username, "-p", AdminUserContext.Password, "-o", AdminUserContext.Org, "-s", AdminUserContext.Space)).To(ExitWith(0))
+}
+
+func LoginAsUser() {
+     Expect(Cf("login", "-u", RegularUserContext.Username, "-p", RegularUserContext.Password, "-o", RegularUserContext.Org, "-s", RegularUserContext.Space)).To(ExitWith(0))
+}
 
 func GenerateBuildpack(destination, matchingFilename string) error {
 	err := os.Mkdir(path.Join(destination, "bin"), 0755)


### PR DESCRIPTION
When running the acceptance tests against bosh-lite I would keep getting `You are not authorized to perform the requested action`. The cause of this was that for create, update and delete actions on build packs you need to be an admin. This PR fixes this by using `LoginAsAdmin`.
