### PR TITLE
Make staging logs test a bit less flakey

### DIFF
--- a/apps/staging_log_test.go
+++ b/apps/staging_log_test.go
@@ -28,7 +28,7 @@ var _ = Describe("An application being staged", func() {
 		stagingLogsShown := false
 		Expect(push).To(SayBranches(
 			cmdtest.ExpectBranch{
-				Pattern: "Downloading app package",
+				Pattern: "Downloaded app package",
 				Callback: func() {
 					stagingLogsShown = true
 				},


### PR DESCRIPTION
This was previously asserting that the LAST line of output from the staging process
would be seen in the CLI's output, but this is not guaranteed based on how v6.0
reads logs. As soon as the first app instance is up, we stop reading and printing
staging logs. With that in mind, it made more sense to write a matcher that would
attempt to match one of several staging log lines.
