### PR TITLE
replace curls with cf-quota commands in setting test context

### DIFF
--- a/helpers/context.go
+++ b/helpers/context.go
@@ -74,7 +74,7 @@ func (context *ConfiguredContext) Setup() {
 			TotalRoutes:   "1000",
 			MemoryLimit: "10G",
 
-			NonBasicServicesAllowed: true, //TODO:Needs to be added once CLI gets updated
+			NonBasicServicesAllowed: true,
 		}
 
 		args := []string {
@@ -87,6 +87,7 @@ func (context *ConfiguredContext) Setup() {
 		if (definition.NonBasicServicesAllowed) {
 			args = append(args, "--allow-paid-service-plans")
 		}
+
 		Expect(cf.Cf(args...)).To(Say("OK"))
 
 		Expect(cf.Cf("create-user", context.regularUserUsername, context.regularUserPassword)).To(SayBranches(


### PR DESCRIPTION
Now that [CF 6.1.1](https://github.com/cloudfoundry/cli/releases/tag/v6.1.1) has been released, the CATS test can take advantage of the new cf quota commands. 

To pull in this change, CATS test must be run using CF 6.1.1 and up.
