### PR TITLE
Fix unintentional overwrite of BROKER_START_TIMEOUT

### DIFF
--- a/services/init_test.go
+++ b/services/init_test.go
@@ -31,7 +31,7 @@ func TestApplications(t *testing.T) {
 		CF_PUSH_TIMEOUT = config.CfPushTimeout * time.Second
 	}
 
-	if config.CfPushTimeout > 0 {
+	if config.BrokerStartTimeout > 0 {
 		BROKER_START_TIMEOUT = config.BrokerStartTimeout * time.Second
 	}
 


### PR DESCRIPTION
When the CATs config file (eg. integration_config.json)

- have `cf_push_timeout` and
- does not have `broker_start_timeout`

`BROKER_START_TIMEOUT` will be set to _ZERO_.
This seems an unintentional behavior.