### PR TITLE
Adding Test Case for memory quota management

### DIFF
--- a/apps/staging_log_test.go
+++ b/apps/staging_log_test.go
@@ -5,10 +5,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/onsi/gomega/gbytes"
 )
 
 var _ = Describe("An application being staged", func() {
@@ -35,5 +38,23 @@ var _ = Describe("An application being staged", func() {
 			}
 		}
 		Expect(found).To(BeTrue(), "Did not find one of the expected log lines: %s", expected)
+	})
+
+	Context("when staging fails, error logs should be streamed", func() {
+
+		It("fails when memory limit required by app exceeds org memory", func() {
+			push := cf.Cf("push", appName, "-p", assets.NewAssets().Dora, "-m", helpers.RUNAWAY_QUOTA_MEM_LIMIT).Wait(CF_PUSH_TIMEOUT)
+
+			output := string(push.Buffer().Contents())
+			Eventually(push).Should(Exit(1))
+			Expect(output).To(ContainSubstring("FAILED"))
+			Expect(output).To(ContainSubstring("100005"))
+			Expect(output).To(ContainSubstring("You have exceeded your organization's memory limit"))
+
+			app := cf.Cf("app", appName)
+			Eventually(app).Should(Exit(0))
+			Eventually(app.Out).Should(gbytes.Say("requested state: stopped"))
+		})
+
 	})
 })


### PR DESCRIPTION
As quota management is a very important feature of CF so there should be a test case in CATS to validate this feature.

If a user pushes an app which needs a memory quota more than that of organization memory quota then it should fail while starting the app.

A similar type of test case for this is already there in [diego-acceptance-tests](https://github.com/cloudfoundry-incubator/diego-acceptance-tests/blob/master/diego/staging_failure_test.go#L45)