### PR TITLE
reduce app memory usage to 128M unless previously specified

### DIFF
--- a/apps/admin_buildpack_lifecycle_test.go
+++ b/apps/admin_buildpack_lifecycle_test.go
@@ -109,7 +109,7 @@ EOF
 
 	Context("when the buildpack is detected", func() {
 		It("is used for the app", func() {
-			push := Cf("push", appName, "-p", appPath).Wait(CF_PUSH_TIMEOUT)
+			push := Cf("push", appName, "-m", "128M", "-p", appPath).Wait(CF_PUSH_TIMEOUT)
 			Expect(push).To(Exit(0))
 			Expect(push).To(Say("Staging with Simple Buildpack"))
 		})
@@ -122,7 +122,7 @@ EOF
 		})
 
 		It("fails to stage", func() { // diego doesn't support the particular error value
-			push := Cf("push", appName, "-p", appPath, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
+			push := Cf("push", appName, "-m", "128M", "-p", appPath, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
 			Expect(push).To(Exit(1))
 			Expect(push).To(Say("NoAppDetectedError"))
 		})
@@ -136,7 +136,7 @@ EOF
 		})
 
 		It("fails to stage", func() { // diego doesn't support the particular error value
-			push := Cf("push", appName, "-p", appPath).Wait(CF_PUSH_TIMEOUT)
+			push := Cf("push", appName, "-m", "128M", "-p", appPath).Wait(CF_PUSH_TIMEOUT)
 			Expect(push).To(Exit(1))
 			Expect(push).To(Say("NoAppDetectedError"))
 		})
@@ -164,7 +164,7 @@ EOF
 		})
 
 		It("fails to stage", func() { // diego doesn't support the particular error value
-			push := Cf("push", appName, "-p", appPath, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
+			push := Cf("push", appName, "-m", "128M", "-p", appPath, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
 			Expect(push).To(Exit(1))
 			Expect(push).To(Say("NoAppDetectedError"))
 		})

--- a/apps/app_bits_copy_test.go
+++ b/apps/app_bits_copy_test.go
@@ -19,8 +19,8 @@ var _ = Describe("Copy app bits", func() {
 		golangAppName = generator.PrefixedRandomName("CATS-APP-")
 		helloWorldAppName = generator.PrefixedRandomName("CATS-APP-")
 
-		Expect(cf.Cf("push", golangAppName, "-p", assets.NewAssets().Golang, "--no-start", "-d", config.AppsDomain).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
-		Expect(cf.Cf("push", helloWorldAppName, "-p", assets.NewAssets().HelloWorld, "--no-start", "-d", config.AppsDomain).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", golangAppName, "-m", "128M", "-p", assets.NewAssets().Golang, "--no-start", "-d", config.AppsDomain).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", helloWorldAppName, "-m", "128M", "-p", assets.NewAssets().HelloWorld, "--no-start", "-d", config.AppsDomain).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 	})
 
 	AfterEach(func() {

--- a/apps/app_stack_test.go
+++ b/apps/app_stack_test.go
@@ -115,7 +115,7 @@ EOF
 		stackName := "cflinuxfs2"
 		expected_lsb_release := "DISTRIB_CODENAME=trusty"
 
-		push := Cf("push", appName, "-p", appPath, "-s", stackName, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
+		push := Cf("push", appName, "-m", "128M", "-p", appPath, "-s", stackName, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
 		Expect(push).To(Exit(0))
 		Expect(push).To(Say(expected_lsb_release))
 		Expect(push).To(Say(""))

--- a/apps/app_staging_environment_test.go
+++ b/apps/app_staging_environment_test.go
@@ -112,7 +112,7 @@ EOF
 	})
 
 	It("uses ruby 1.9.3-p547 for staging", func() {
-		push := Cf("push", appName, "-p", appPath, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
+		push := Cf("push", appName, "-m", "128M", "-p", appPath, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
 		Expect(push).To(Exit(0))
 		Expect(push).To(Say("RUBY_LOCATION=/usr/bin/ruby"))
 		Expect(push).To(Say("RUBY_VERSION=ruby 1.9.3p547"))

--- a/apps/buildpack_cache_test.go
+++ b/apps/buildpack_cache_test.go
@@ -115,7 +115,7 @@ EOF
 	})
 
 	It("uses the buildpack cache after first staging", func() {
-		push := Cf("push", appName, "-p", appPath, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
+		push := Cf("push", appName, "-m", "128M", "-p", appPath, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
 		Expect(push).To(Exit(0))
 
 		Eventually(func() string {

--- a/apps/buildpacks_test.go
+++ b/apps/buildpacks_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Buildpacks", func() {
 
 	Describe("node", func() {
 		It("makes the app reachable via its bound route", func() {
-			Expect(cf.Cf("push", appName, "-p", assets.NewAssets().Node, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Node, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(appName)
@@ -48,7 +48,7 @@ var _ = Describe("Buildpacks", func() {
 
 	Describe("golang", func() {
 		It("makes the app reachable via its bound route", func() {
-			Expect(cf.Cf("push", appName, "-p", assets.NewAssets().Golang, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Golang, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(appName)
@@ -58,7 +58,7 @@ var _ = Describe("Buildpacks", func() {
 
 	Describe("python", func() {
 		It("makes the app reachable via its bound route", func() {
-			Expect(cf.Cf("push", appName, "-p", assets.NewAssets().Python, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Python, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(appName)
@@ -71,7 +71,7 @@ var _ = Describe("Buildpacks", func() {
 		var phpPushTimeout = CF_PUSH_TIMEOUT + 6*time.Minute
 
 		It("makes the app reachable via its bound route", func() {
-			Expect(cf.Cf("push", appName, "-p", assets.NewAssets().Php, "-d", config.AppsDomain).Wait(phpPushTimeout)).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Php, "-d", config.AppsDomain).Wait(phpPushTimeout)).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(appName)
@@ -81,7 +81,7 @@ var _ = Describe("Buildpacks", func() {
 
 	Describe("staticfile", func() {
 		It("makes the app reachable via its bound route", func() {
-			Expect(cf.Cf("push", appName, "-p", assets.NewAssets().Staticfile, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Staticfile, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(appName)
@@ -91,7 +91,7 @@ var _ = Describe("Buildpacks", func() {
 
 	Describe("binary", func() {
 		It("makes the app reachable via its bound route", func() {
-			Expect(cf.Cf("push", appName, "-b", "binary_buildpack", "-p", assets.NewAssets().Binary, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-m", "128M", "-b", "binary_buildpack", "-p", assets.NewAssets().Binary, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(appName)

--- a/apps/changing_start_command_test.go
+++ b/apps/changing_start_command_test.go
@@ -19,6 +19,7 @@ var _ = Describe("Changing an app's start command", func() {
 
 		Expect(cf.Cf(
 			"push", appName,
+			"-m", "128M",
 			"-p", assets.NewAssets().Dora,
 			"-d", helpers.LoadConfig().AppsDomain,
 			"-c", "FOO=foo bundle exec rackup config.ru -p $PORT",

--- a/apps/delete_route_test.go
+++ b/apps/delete_route_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Delete Route", func() {
 	BeforeEach(func() {
 		appName = generator.PrefixedRandomName("CATS-APP-")
 
-		Expect(cf.Cf("push", appName, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 		Eventually(func() string {
 			return helpers.CurlAppRoot(appName)
 		}, DEFAULT_TIMEOUT).Should(ContainSubstring("Hi, I'm Dora!"))

--- a/apps/droplet_download_test.go
+++ b/apps/droplet_download_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Downloading droplets", func() {
 	BeforeEach(func() {
 		helloWorldAppName = generator.PrefixedRandomName("CATS-APP-")
 
-		Expect(cf.Cf("push", helloWorldAppName, "-p", assets.NewAssets().HelloWorld, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", helloWorldAppName, "-m", "128M", "-p", assets.NewAssets().HelloWorld, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 	})
 
 	AfterEach(func() {

--- a/apps/dynamic_info_test.go
+++ b/apps/dynamic_info_test.go
@@ -18,7 +18,7 @@ var _ = Describe("A running application", func() {
 	BeforeEach(func() {
 		appName = generator.PrefixedRandomName("CATS-APP-")
 
-		Expect(cf.Cf("push", appName, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 	})
 
 	AfterEach(func() {

--- a/apps/lifecycle_test.go
+++ b/apps/lifecycle_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Application Lifecycle", func() {
 	BeforeEach(func() {
 		appName = generator.PrefixedRandomName("CATS-APP-")
 
-		Expect(cf.Cf("push", appName, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 	})
 
 	AfterEach(func() {
@@ -70,7 +70,7 @@ var _ = Describe("Application Lifecycle", func() {
 
 			BeforeEach(func() {
 				app2 = generator.PrefixedRandomName("CATS-APP-")
-				Expect(cf.Cf("push", app2, "-p", assets.NewAssets().HelloWorld, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+				Expect(cf.Cf("push", app2, "-m", "128M", "-p", assets.NewAssets().HelloWorld, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 			})
 
 			AfterEach(func() {
@@ -178,7 +178,7 @@ var _ = Describe("Application Lifecycle", func() {
 				return helpers.CurlAppRoot(appName)
 			}, DEFAULT_TIMEOUT).Should(ContainSubstring("Hi, I'm Dora!"))
 
-			Expect(cf.Cf("push", appName, "-p", assets.NewAssets().HelloWorld, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().HelloWorld, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(appName)

--- a/apps/loggregator_test.go
+++ b/apps/loggregator_test.go
@@ -32,7 +32,7 @@ var _ = Describe("loggregator", func() {
 	BeforeEach(func() {
 		appName = generator.PrefixedRandomName("CATS-APP-")
 
-		Expect(cf.Cf("push", appName, "-p", assets.NewAssets().LoggregatorLoadGenerator, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().LoggregatorLoadGenerator, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 	})
 
 	AfterEach(func() {

--- a/apps/one_push_many_restarts_test.go
+++ b/apps/one_push_many_restarts_test.go
@@ -46,7 +46,7 @@ var _ = Describe("An application that's already been pushed", func() {
 		output := string(appQuery.Out.Contents())
 
 		if appQuery.ExitCode() == 1 && strings.Contains(output, "not found") {
-			pushCommand := cf.Cf("push", appName, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
+			pushCommand := cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
 			if pushCommand.ExitCode() != 0 {
 				Expect(cf.Cf("delete", "-f", appName).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 				Fail("persistent app failed to stage")

--- a/apps/output_volume_test.go
+++ b/apps/output_volume_test.go
@@ -19,7 +19,7 @@ var _ = Describe("An application printing a bunch of output", func() {
 	BeforeEach(func() {
 		appName = generator.PrefixedRandomName("CATS-APP-")
 
-		Expect(cf.Cf("push", appName, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 	})
 
 	AfterEach(func() {

--- a/apps/process_types_test.go
+++ b/apps/process_types_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Process Types", func() {
 
 		Describe("without a procfile", func() {
 			BeforeEach(func() {
-				Expect(cf.Cf("push", appName, "-p", assets.NewAssets().Node, "-c", "node server.js --cool-arg", "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+				Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Node, "-c", "node server.js --cool-arg", "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 			})
 
 			AfterEach(func() {
@@ -51,7 +51,7 @@ var _ = Describe("Process Types", func() {
 
 		Describe("with a procfile", func() {
 			BeforeEach(func() {
-				Expect(cf.Cf("push", appName, "-p", assets.NewAssets().NodeWithProcfile, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+				Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().NodeWithProcfile, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 			})
 
 			AfterEach(func() {

--- a/apps/staging_log_test.go
+++ b/apps/staging_log_test.go
@@ -23,7 +23,7 @@ var _ = Describe("An application being staged", func() {
 	})
 
 	It("has its staging log streamed during a push", func() {
-		push := cf.Cf("push", appName, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
+		push := cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
 
 		output := string(push.Buffer().Contents())
 		expected := []string{"Installing dependencies", "Uploading droplet", "App started"}

--- a/apps/wildcard_routes_test.go
+++ b/apps/wildcard_routes_test.go
@@ -38,10 +38,10 @@ var _ = Describe("Wildcard Routes", func() {
 		})
 
 		appNameDora = generator.PrefixedRandomName("CATS-APP-")
-		Expect(cf.Cf("push", appNameDora, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", appNameDora, "-m", "128M", "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 
 		appNameSimple = generator.PrefixedRandomName("CATS-APP-")
-		Expect(cf.Cf("push", appNameSimple, "-p", assets.NewAssets().HelloWorld, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", appNameSimple, "-m", "128M", "-p", assets.NewAssets().HelloWorld, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 	})
 
 	AfterEach(func() {

--- a/helpers/services/broker.go
+++ b/helpers/services/broker.go
@@ -102,7 +102,7 @@ func NewServiceBroker(name string, path string, context helpers.SuiteContext) Se
 }
 
 func (b ServiceBroker) Push() {
-	Expect(cf.Cf("push", b.Name, "-p", b.Path, "--no-start").Wait(BROKER_START_TIMEOUT)).To(Exit(0))
+	Expect(cf.Cf("push", b.Name, "-m", "128M", "-p", b.Path, "--no-start").Wait(BROKER_START_TIMEOUT)).To(Exit(0))
 	if helpers.LoadConfig().UseDiego {
 		appGuid := strings.TrimSpace(string(cf.Cf("app", b.Name, "--guid").Wait(DEFAULT_TIMEOUT).Out.Contents()))
 		cf.Cf("curl",

--- a/internet_dependent/git_buildpack_test.go
+++ b/internet_dependent/git_buildpack_test.go
@@ -18,7 +18,7 @@ var _ = Describe("GitBuildpack", func() {
 
 	It("uses a buildpack from a git url", func() {
 		appName = generator.PrefixedRandomName("CATS-APP-")
-		Expect(cf.Cf("push", appName, "-p", assets.NewAssets().Node, "-b", "https://github.com/cloudfoundry/nodejs-buildpack.git#v1.3.1").Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Node, "-b", "https://github.com/cloudfoundry/nodejs-buildpack.git#v1.3.1").Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 
 		Eventually(func() string {
 			return helpers.CurlAppRoot(appName)

--- a/logging/syslog_drain_test.go
+++ b/logging/syslog_drain_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Logging", func() {
 
 			appName = generator.PrefixedRandomName("CATS-APP-")
 
-			Eventually(cf.Cf("push", appName, "-p", assets.NewAssets().RubySimple, "-d", config.AppsDomain), CF_PUSH_TIMEOUT).Should(Exit(0), "Failed to push app")
+			Eventually(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().RubySimple, "-d", config.AppsDomain), CF_PUSH_TIMEOUT).Should(Exit(0), "Failed to push app")
 
 			syslogDrainURL := "syslog://" + syslogDrainAddress
 			serviceName = "service-" + generator.RandomName()

--- a/operator/environment_variables_group_test.go
+++ b/operator/environment_variables_group_test.go
@@ -85,7 +85,7 @@ exit 1
 			Expect(cf.Cf("set-running-environment-variable-group", `{"CATS_RUNNING_TEST_VAR":"running_env_value"}`).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 		})
 
-		Expect(cf.Cf("push", appName, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 
 		env := helpers.CurlApp(appName, "/env")
 
@@ -101,7 +101,7 @@ exit 1
 			Expect(cf.Cf("create-buildpack", buildpackName, buildpackZip, "999").Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 		})
 
-		Expect(cf.Cf("push", appName, "-b", buildpackName, "-p", assets.NewAssets().HelloWorld, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(1))
+		Expect(cf.Cf("push", appName, "-m", "128M", "-b", buildpackName, "-p", assets.NewAssets().HelloWorld, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(1))
 
 		Eventually(func() *Session {
 			appLogsSession := cf.Cf("logs", "--recent", appName)

--- a/operator/fuse_test.go
+++ b/operator/fuse_test.go
@@ -23,7 +23,7 @@ var _ = Describe("FUSE", func() {
 	})
 
 	It("Can mount a fuse endpoint", func() {
-		Expect(cf.Cf("push", appName, "-p", assets.NewAssets().Fuse, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Fuse, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 
 		Eventually(func() string {
 			return helpers.CurlAppRoot(appName)

--- a/routing/routing_suite_test.go
+++ b/routing/routing_suite_test.go
@@ -37,7 +37,7 @@ type StatsResponse map[string]Stat
 
 func PushApp(asset string) string {
 	app := generator.PrefixedRandomName("RATS-APP-")
-	Expect(cf.Cf("push", app, "-p", asset, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+	Expect(cf.Cf("push", app, "-m", "128M", "-p", asset, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 	return app
 }
 

--- a/security_groups/running_security_groups_test.go
+++ b/security_groups/running_security_groups_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Security Groups", func() {
 
 	BeforeEach(func() {
 		serverAppName = generator.PrefixedRandomName("CATS-APP-")
-		Expect(cf.Cf("push", serverAppName, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", serverAppName, "-m", "128M", "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 
 		// gather app url
 		var appsResponse AppsResponse
@@ -74,7 +74,7 @@ var _ = Describe("Security Groups", func() {
 	//  are discoverable via the cc api and dora's myip endpoint
 	It("allows previously-blocked ip traffic after applying a security group, and re-blocks it when the group is removed", func() {
 		clientAppName := generator.PrefixedRandomName("CATS-APP-")
-		Expect(cf.Cf("push", clientAppName, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", clientAppName, "-m", "128M", "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 		defer func() { cf.Cf("delete", clientAppName, "-f").Wait(CF_PUSH_TIMEOUT) }()
 
 		// gather container ip
@@ -149,7 +149,7 @@ var _ = Describe("Security Groups", func() {
 			})
 		}()
 
-		Expect(cf.Cf("push", testAppName, "-b", buildpack, "-p", assets.NewAssets().HelloWorld, "--no-start", "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", testAppName, "-m", "128M", "-b", buildpack, "-p", assets.NewAssets().HelloWorld, "--no-start", "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 		defer func() { cf.Cf("delete", testAppName, "-f").Wait(CF_PUSH_TIMEOUT) }()
 
 		Expect(cf.Cf("set-env", testAppName, "TESTURI", "www.google.com").Wait(DEFAULT_TIMEOUT)).To(Exit(0))

--- a/services/purge_service_offering_test.go
+++ b/services/purge_service_offering_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Purging service offerings", func() {
 			appName = generator.PrefixedRandomName("CATS-APP-")
 			instanceName = generator.RandomName()
 
-			createApp := cf.Cf("push", appName, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
+			createApp := cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
 			Expect(createApp).To(Exit(0), "failed creating app")
 
 			broker.CreateServiceInstance(instanceName)

--- a/services/recursive_delete_test.go
+++ b/services/recursive_delete_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Recursive Delete", func() {
 			target := cf.Cf("target", "-o", orgName, "-s", spaceName).Wait(CF_PUSH_TIMEOUT)
 			Expect(target).To(Exit(0), "failed targeting")
 
-			createApp := cf.Cf("push", appName, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
+			createApp := cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
 			Expect(createApp).To(Exit(0), "failed creating app")
 
 			createService := cf.Cf("create-service", broker.Service.Name, broker.SyncPlans[0].Name, instanceName).Wait(DEFAULT_TIMEOUT)

--- a/services/service_instance_lifecycle_test.go
+++ b/services/service_instance_lifecycle_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Service Instance Lifecycle", func() {
 
 			BeforeEach(func() {
 				appName = generator.PrefixedRandomName("CATS-APP-")
-				createApp := cf.Cf("push", appName, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
+				createApp := cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
 				Expect(createApp).To(Exit(0), "failed creating app")
 
 				checkForEvents(appName, []string{"audit.app.create"})
@@ -363,7 +363,7 @@ var _ = Describe("Service Instance Lifecycle", func() {
 				var appName string
 				BeforeEach(func() {
 					appName = generator.PrefixedRandomName("CATS-APP-")
-					createApp := cf.Cf("push", appName, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
+					createApp := cf.Cf("push", appName, "-m", "128M", "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
 					Expect(createApp).To(Exit(0), "failed creating app")
 				})
 				It("can bind a service instance", func() {


### PR DESCRIPTION
Signed-off-by: Jesse Alford <jalford@pivotal.io>

we did the brute force method of decorating all `cf push` with `-m 128M` unless a -m flag was already present – a condition we checked for with manual review.

CATs passes on our environment with the following skip flags set
```
-skipPackage=helpers,v3,security_groups,routing '-skip=SSO|lucid64'
```

please consider merging this in for the cf-218 release.