### PR TITLE
remove id token usage

### DIFF
--- a/services/sso.go
+++ b/services/sso.go
@@ -64,7 +64,7 @@ func AuthenticateUser(authorizationEndpoint string, username string, password st
 func RequestScopes(cookie string, config OAuthConfig) (authCode string, httpCode string) {
 	authCode = `initialized`
 
-	requestScopesUri := fmt.Sprintf("%v/oauth/authorize?client_id=%v&response_type=code+id_token&redirect_uri=%v&scope=%v",
+	requestScopesUri := fmt.Sprintf("%v/oauth/authorize?client_id=%v&response_type=code&redirect_uri=%v&scope=%v",
 		config.AuthorizationEndpoint,
 		url.QueryEscape(config.ClientId),
 		config.RedirectUri,


### PR DESCRIPTION
API change in the UAA now supports the id_token parameter. CATS doesn't. 

CATS doesn't need the parameter nor use it.