### PR TITLE
Don't delete the app file during test [#105779022]

### DIFF
--- a/apps/admin_buildpack_lifecycle_test.go
+++ b/apps/admin_buildpack_lifecycle_test.go
@@ -30,7 +30,23 @@ var _ = Describe("Admin Buildpacks", func() {
 		return fmt.Sprintf("simple-buildpack-please-match-%s", appName)
 	}
 
-	setupBuildpack := func() {
+	type AppConfig struct {
+		Empty bool
+	}
+
+	appWithContent := func() AppConfig {
+		return AppConfig{
+			Empty: false,
+		}
+	}
+
+	emptyApp := func() AppConfig {
+		return AppConfig{
+			Empty: true,
+		}
+	}
+
+	setupBuildpack := func(appConfig AppConfig) {
 		AsUser(context.AdminUserContext(), DEFAULT_TIMEOUT, func() {
 			BuildpackName = RandomName()
 			appName = PrefixedRandomName("CATS-APP-")
@@ -86,8 +102,10 @@ EOF
 				},
 			})
 
-			_, err = os.Create(path.Join(appPath, matchingFilename(appName)))
-			Expect(err).ToNot(HaveOccurred())
+			if !appConfig.Empty {
+				_, err = os.Create(path.Join(appPath, matchingFilename(appName)))
+				Expect(err).ToNot(HaveOccurred())
+			}
 
 			_, err = os.Create(path.Join(appPath, "some-file"))
 			Expect(err).ToNot(HaveOccurred())
@@ -114,9 +132,6 @@ EOF
 	}
 
 	itDoesNotDetectForEmptyApp := func() {
-		err := os.Remove(path.Join(appPath, matchingFilename(appName)))
-		Expect(err).ToNot(HaveOccurred())
-
 		push := Cf("push", appName, "-m", "128M", "-p", appPath, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)
 		Expect(push).To(Exit(1))
 		Expect(push).To(Say("NoAppDetectedError"))
@@ -160,19 +175,20 @@ EOF
 			// Tests that rely on buildpack detection must be run in serial,
 			// but ginkgo doesn't allow specific blocks to be marked as serial-only
 			// so we manually mimic setup/teardown pattern here
-			setupBuildpack()
+
+			setupBuildpack(appWithContent())
 			itIsUsedForTheApp()
 			deleteBuildpack()
 
-			setupBuildpack()
+			setupBuildpack(emptyApp())
 			itDoesNotDetectForEmptyApp()
 			deleteBuildpack()
 
-			setupBuildpack()
+			setupBuildpack(appWithContent())
 			itDoesNotDetectWhenBuildpackDisabled()
 			deleteBuildpack()
 
-			setupBuildpack()
+			setupBuildpack(appWithContent())
 			itDoesNotDetectWhenBuildpackDeleted()
 			deleteBuildpack()
 		})


### PR DESCRIPTION
* Instead of deleting, don't create the file
* Stops windows having problems with open file handles
* Uses a struct-as-context 'AppConfig' to make the params in setupBuildpack calls meaningful.