### PR TITLE
Add a large payload test to the Applications CATs suite

### DIFF
--- a/apps/large_payload_test.go
+++ b/apps/large_payload_test.go
@@ -1,0 +1,36 @@
+package apps
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+)
+
+var _ = Describe("Large_payload", func() {
+	var appName string
+	AfterEach(func() {
+		app_helpers.AppReport(appName, DEFAULT_TIMEOUT)
+
+		Expect(cf.Cf("delete", appName, "-f").Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+	})
+	It("should be able to curl for a large response body", func() {
+		appName = generator.PrefixedRandomName("CATS-APPS-")
+		Expect(cf.Cf("push", appName, "--no-start", "-b", config.RubyBuildpackName, "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
+		app_helpers.ConditionallyEnableDiego(appName)
+		Expect(cf.Cf("start", appName).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+
+		Eventually(func() int {
+			curlResponse := helpers.CurlApp(appName, fmt.Sprintf("/largetext/5"))
+			return len(curlResponse)
+		}, 10*time.Second, 10*time.Second).Should(Equal(5 * 1024))
+	})
+})

--- a/assets/dora/dora.rb
+++ b/assets/dora/dora.rb
@@ -93,5 +93,15 @@ class Dora < Sinatra::Base
     `ip addr show  | grep 'scope global w' | grep inet | awk '{print $2}'`
   end
 
+  get '/largetext/:kbytes' do
+    fiveMB = 5 * 1024
+    numKB = params[:kbytes].to_i
+    ktext="1" * 1024
+    text=""
+    size = numKB > fiveMB ? fiveMB : numKB
+    size.times {text+=ktext}
+    text
+  end
+
   run! if app_file == $0
 end


### PR DESCRIPTION
- Added an endpoint to the dora app, `/largetext`, that returns a response body of a specified size
- Added a test to the Applications CATs suite to test the return of a large response body from an app.