### PR TITLE
Update app_bits_copy_test.go

### DIFF
--- a/apps/app_bits_copy_test.go
+++ b/apps/app_bits_copy_test.go
@@ -20,8 +20,8 @@ var _ = Describe("Copy app bits", func() {
 		golangAppName = generator.PrefixedRandomName("CATS-APP-")
 		helloWorldAppName = generator.PrefixedRandomName("CATS-APP-")
 
-		Expect(cf.Cf("push", golangAppName, "--no-start", "-b", config.RubyBuildpackName, "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Golang, "-d", config.AppsDomain).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
-		Expect(cf.Cf("push", helloWorldAppName, "--no-start", "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().HelloWorld, "-d", config.AppsDomain).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", golangAppName, "--no-start", "-b", config.RubyBuildpackName, "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Golang, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
+		Expect(cf.Cf("push", helloWorldAppName, "--no-start", "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().HelloWorld, "-d", config.AppsDomain).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
This test fails seldom in case of a slow push (> 30s). 

I assume the DEFAULT_TIMEOUT (30s) shouldn't be used for push. I have changed it to CF_PUSH_TIMEOUT (2 minutes).