### PR TITLE
Clean up quota in recursive-delete services test

### DIFF
--- a/services/recursive_delete_test.go
+++ b/services/recursive_delete_test.go
@@ -61,7 +61,9 @@ var _ = Describe("Recursive Delete", func() {
 		app_helpers.AppReport(broker.Name, DEFAULT_TIMEOUT)
 
 		broker.Destroy()
-		runner.NewCmdRunner(cf.Cf("delete-quota", quotaName), context.ShortTimeout()).Run()
+		cf.AsUser(context.AdminUserContext(), DEFAULT_TIMEOUT, func() {
+			runner.NewCmdRunner(cf.Cf("delete-quota", "-f", quotaName), context.ShortTimeout()).Run()
+		})
 	})
 
 	It("deletes all apps and services in all spaces in an org", func() {


### PR DESCRIPTION
The original `delete-quota` command here always fails because it is expecting interactive input to confirm the deletion. This commit supplies it with the `-f` flag to avoid the confirmation as well as the admin context authorizing it to perform the delete.