### PR TITLE
remove `ruby` directives from Gemfile

### DIFF
--- a/assets/dora/Gemfile
+++ b/assets/dora/Gemfile
@@ -1,7 +1,5 @@
 source "http://rubygems.org"
 
-ruby "2.0.0"
-
 gem "sinatra"
 gem "json"
 

--- a/assets/fuse-mount/Gemfile
+++ b/assets/fuse-mount/Gemfile
@@ -1,5 +1,3 @@
 source 'http://rubygems.org'
 
-ruby '2.0.0'
-
 gem 'sinatra'

--- a/assets/service_broker/Gemfile
+++ b/assets/service_broker/Gemfile
@@ -1,7 +1,5 @@
 source 'http://rubygems.org'
 
-ruby '2.1.6'
-
 gem 'sinatra'
 gem 'json'
 gem 'colorize'


### PR DESCRIPTION
When Ruby versions get deprecated CATs start failing for the wrong reasons.

[#110323846]

Signed-off-by: Brandon Shroyer <bshroyer@pivotal.io>