### PR TITLE
Respect cf-test-helpers' SkipSSHHostValidation option

### DIFF
--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -63,7 +63,7 @@ var _ = Describe(deaUnsupportedTag+"SSH", func() {
 
 	Describe("ssh", func() {
 		It("can execute a remote command in the container", func() {
-			envCmd := cf.Cf("ssh", "-i", "1", appName, "-c", "/usr/bin/env")
+			envCmd := cf.Cf("ssh", skipHostValidationFlag(), "-i", "1", appName, "-c", "/usr/bin/env")
 			Expect(envCmd.Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 
 			output := string(envCmd.Buffer().Contents())
@@ -76,7 +76,7 @@ var _ = Describe(deaUnsupportedTag+"SSH", func() {
 		})
 
 		It("runs an interactive session when no command is provided", func() {
-			envCmd := exec.Command("cf", "ssh", "-i", "1", appName)
+			envCmd := exec.Command("cf", "ssh", skipHostValidationFlag(), "-i", "1", appName)
 
 			stdin, err := envCmd.StdinPipe()
 			Expect(err).NotTo(HaveOccurred())
@@ -107,7 +107,7 @@ var _ = Describe(deaUnsupportedTag+"SSH", func() {
 		})
 
 		It("allows local port forwarding", func() {
-			listenCmd := exec.Command("cf", "ssh", "-i", "1", "-L", "127.0.0.1:37001:localhost:8080", appName)
+			listenCmd := exec.Command("cf", "ssh", skipHostValidationFlag(), "-i", "1", "-L", "127.0.0.1:37001:localhost:8080", appName)
 
 			stdin, err := listenCmd.StdinPipe()
 			Expect(err).NotTo(HaveOccurred())
@@ -483,4 +483,12 @@ func compareFile(actualFile, expectedFile string) {
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(actualContents).To(Equal(expectedContents))
+}
+
+func skipHostValidationFlag() string {
+	if helpers.LoadConfig().SkipSSHHostValidation {
+		return "-k"
+	} else {
+		return ""
+	}
 }


### PR DESCRIPTION
MicroPCF needs to be able to disable SSH host key validation.

Second part of https://github.com/cloudfoundry-incubator/cf-test-helpers/pull/17

CF test helpers was bumped by fac7c726d90cc3e2d063bb60515c5f818cd406a8

- @sclevine and @mdelillo