### PR TITLE
Update CATS to include context route path

### DIFF
--- a/cli_compatibility_test.go
+++ b/cli_compatibility_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const minCliVersion = "6.11.3"
+const minCliVersion = "6.15"
 
 var _ = Describe("cf CLI version", func() {
 	It("meets the minimum required CLI version for the CATs", func() {

--- a/routing/context_paths_test.go
+++ b/routing/context_paths_test.go
@@ -17,18 +17,20 @@ var _ = Describe("Context Paths", func() {
 		app2Path = "/app2"
 		app3     string
 		app3Path = "/app3/long/sub/path"
-		domain   string
+		hostname string
 	)
 
 	BeforeEach(func() {
+		domain := config.AppsDomain
+
 		app1 = PushApp(helloRoutingAsset, config.RubyBuildpackName)
 		app2 = PushApp(helloRoutingAsset, config.RubyBuildpackName)
 		app3 = PushApp(helloRoutingAsset, config.RubyBuildpackName)
 
-		domain = app1
+		hostname = app1
 
-		MapRouteToApp(domain, app2Path, app2)
-		MapRouteToApp(domain, app3Path, app3)
+		MapRouteToApp(app2, domain, hostname, app2Path)
+		MapRouteToApp(app3, domain, hostname, app3Path)
 	})
 
 	AfterEach(func() {
@@ -44,15 +46,15 @@ var _ = Describe("Context Paths", func() {
 	Context("when another app has a route with a context path", func() {
 		It("routes to app with context path", func() {
 			Eventually(func() string {
-				return helpers.CurlAppRoot(domain)
+				return helpers.CurlAppRoot(hostname)
 			}, DEFAULT_TIMEOUT).Should(ContainSubstring(app1))
 
 			Eventually(func() string {
-				return helpers.CurlApp(domain, app2Path)
+				return helpers.CurlApp(hostname, app2Path)
 			}, DEFAULT_TIMEOUT).Should(ContainSubstring(app2))
 
 			Eventually(func() string {
-				return helpers.CurlApp(domain, app3Path)
+				return helpers.CurlApp(hostname, app3Path)
 			}, DEFAULT_TIMEOUT).Should(ContainSubstring(app3))
 		})
 	})

--- a/routing/route_services_test.go
+++ b/routing/route_services_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Route Services", func() {
 					serviceInstanceName = createServiceInstance(serviceName)
 
 					appName = PushAppNoStart(golangAsset, config.GoBuildpackName)
-					EnableDiego(appName)
+					app_helpers.EnableDiego(appName)
 					StartApp(appName)
 
 					routeServiceName = PushApp(loggingRouteServiceAsset, config.GoBuildpackName)
@@ -81,7 +81,7 @@ var _ = Describe("Route Services", func() {
 					brokerName, brokerAppName, serviceName = createServiceBroker()
 					serviceInstanceName = createServiceInstance(serviceName)
 					appName = PushAppNoStart(golangAsset, config.GoBuildpackName)
-					EnableDiego(appName)
+					app_helpers.EnableDiego(appName)
 					StartApp(appName)
 
 					configureBroker(brokerAppName, "")
@@ -123,7 +123,7 @@ var _ = Describe("Route Services", func() {
 					brokerName, brokerAppName, serviceName = createServiceBroker()
 					serviceInstanceName = createServiceInstance(serviceName)
 
-					CreateRoute(hostname, "", spacename, domain)
+					createRoute(hostname, "", spacename, domain)
 
 					configureBroker(brokerAppName, "")
 				})
@@ -156,7 +156,7 @@ func (c customMap) key(key string) customMap {
 }
 
 func bindRouteToService(hostname, serviceInstanceName string) {
-	routeGuid := GetRouteGuid(hostname, "")
+	routeGuid := getRouteGuid(hostname, "")
 	serviceInstanceGuid := getServiceInstanceGuid(serviceInstanceName)
 	cf.Cf("curl", fmt.Sprintf("/v2/service_instances/%s/routes/%s", serviceInstanceGuid, routeGuid), "-X", "PUT")
 
@@ -170,7 +170,7 @@ func bindRouteToService(hostname, serviceInstanceName string) {
 }
 
 func bindRouteToServiceWithParams(hostname, serviceInstanceName string, params string) {
-	routeGuid := GetRouteGuid(hostname, "")
+	routeGuid := getRouteGuid(hostname, "")
 	serviceInstanceGuid := getServiceInstanceGuid(serviceInstanceName)
 	cf.Cf("curl", fmt.Sprintf("/v2/service_instances/%s/routes/%s", serviceInstanceGuid, routeGuid), "-X", "PUT",
 		"-d", fmt.Sprintf("{\"parameters\": %s}", params))
@@ -205,7 +205,7 @@ func deleteServiceInstance(serviceInstanceName string) {
 }
 
 func unbindRouteFromService(hostname, serviceInstanceName string) {
-	routeGuid := GetRouteGuid(hostname, "")
+	routeGuid := getRouteGuid(hostname, "")
 	guid := getServiceInstanceGuid(serviceInstanceName)
 	cf.Cf("curl", fmt.Sprintf("/v2/service_instances/%s/routes/%s", guid, routeGuid), "-X", "DELETE")
 

--- a/routing/route_services_test.go
+++ b/routing/route_services_test.go
@@ -18,8 +18,9 @@ import (
 	. "github.com/onsi/gomega/gexec"
 )
 
-var _ = Describe("Route Services", func() {
+var _ = Describe(deaUnsupportedTag+"Route Services", func() {
 	config := helpers.LoadConfig()
+
 	if config.IncludeRouteServices {
 		Context("when a route binds to a service", func() {
 			Context("when service broker returns a route service url", func() {

--- a/routing/route_services_test.go
+++ b/routing/route_services_test.go
@@ -110,26 +110,33 @@ var _ = Describe("Route Services", func() {
 					brokerName          string
 					brokerAppName       string
 					serviceInstanceName string
-					routeGuid           string
+					domain              string
+					hostname            string
 				)
 
 				BeforeEach(func() {
 					var serviceName string
+					domain = config.AppsDomain
+					spacename := context.RegularUserContext().Space
+					hostname = generator.PrefixedRandomName("RATS-HOSTNAME-")
+
 					brokerName, brokerAppName, serviceName = createServiceBroker()
 					serviceInstanceName = createServiceInstance(serviceName)
-					routeGuid = CreateRoute("panda", "", targetedSpaceGuid(), sharedDomainGuid())
+
+					CreateRoute(hostname, "", spacename, domain)
 
 					configureBroker(brokerAppName, "")
 				})
 
 				AfterEach(func() {
-					unbindRouteFromService("panda", serviceInstanceName)
+					unbindRouteFromService(hostname, serviceInstanceName)
 					deleteServiceInstance(serviceInstanceName)
 					deleteServiceBroker(brokerName)
+					DeleteRoute(hostname, "", domain)
 				})
 
 				It("passes them to the service broker", func() {
-					bindRouteToServiceWithParams("panda", serviceInstanceName, "{\"key1\":[\"value1\",\"irynaparam\"],\"key2\":\"value3\"}")
+					bindRouteToServiceWithParams(hostname, serviceInstanceName, "{\"key1\":[\"value1\",\"irynaparam\"],\"key2\":\"value3\"}")
 
 					Eventually(func() *Session {
 						logs := cf.Cf("logs", "--recent", brokerAppName)
@@ -148,8 +155,8 @@ func (c customMap) key(key string) customMap {
 	return c[key].(map[string]interface{})
 }
 
-func bindRouteToService(routeName, serviceInstanceName string) {
-	routeGuid := getRouteGuid(routeName)
+func bindRouteToService(hostname, serviceInstanceName string) {
+	routeGuid := GetRouteGuid(hostname, "")
 	serviceInstanceGuid := getServiceInstanceGuid(serviceInstanceName)
 	cf.Cf("curl", fmt.Sprintf("/v2/service_instances/%s/routes/%s", serviceInstanceGuid, routeGuid), "-X", "PUT")
 
@@ -162,11 +169,11 @@ func bindRouteToService(routeName, serviceInstanceName string) {
 	}, DEFAULT_TIMEOUT, "1s").ShouldNot(ContainSubstring(`"service_instance_guid": null`))
 }
 
-func bindRouteToServiceWithParams(routeName, serviceInstanceName string, params string) {
-	routeGuid := getRouteGuid(routeName)
+func bindRouteToServiceWithParams(hostname, serviceInstanceName string, params string) {
+	routeGuid := GetRouteGuid(hostname, "")
 	serviceInstanceGuid := getServiceInstanceGuid(serviceInstanceName)
-	cf.Cf("curl", fmt.Sprintf("/v2/service_instances/%s/routes/%s", serviceInstanceGuid, routeGuid), "-X", "PUT", 
-							  "-d", fmt.Sprintf("{\"parameters\": %s}", params))
+	cf.Cf("curl", fmt.Sprintf("/v2/service_instances/%s/routes/%s", serviceInstanceGuid, routeGuid), "-X", "PUT",
+		"-d", fmt.Sprintf("{\"parameters\": %s}", params))
 
 	Eventually(func() string {
 		response := cf.Cf("curl", fmt.Sprintf("/v2/routes/%s", routeGuid))
@@ -197,31 +204,18 @@ func deleteServiceInstance(serviceInstanceName string) {
 	}, DEFAULT_TIMEOUT, "1s").Should(ContainSubstring("CF-ServiceInstanceNotFound"))
 }
 
-func unbindRouteFromService(routeName, serviceInstanceName string) {
-	route_guid := getRouteGuid(routeName)
+func unbindRouteFromService(hostname, serviceInstanceName string) {
+	routeGuid := GetRouteGuid(hostname, "")
 	guid := getServiceInstanceGuid(serviceInstanceName)
-	cf.Cf("curl", fmt.Sprintf("/v2/service_instances/%s/routes/%s", guid, route_guid), "-X", "DELETE")
+	cf.Cf("curl", fmt.Sprintf("/v2/service_instances/%s/routes/%s", guid, routeGuid), "-X", "DELETE")
 
 	Eventually(func() string {
-		response := cf.Cf("curl", fmt.Sprintf("/v2/routes/%s", route_guid))
+		response := cf.Cf("curl", fmt.Sprintf("/v2/routes/%s", routeGuid))
 		Expect(response.Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 
 		contents := response.Out.Contents()
 		return string(contents)
 	}, DEFAULT_TIMEOUT, "1s").Should(ContainSubstring(`"service_instance_guid": null`))
-}
-
-func getRouteGuid(hostname string) string {
-	responseBuffer := cf.Cf("curl", fmt.Sprintf("/v2/routes?q=host:%s", hostname))
-	Expect(responseBuffer.Wait(DEFAULT_TIMEOUT)).To(Exit(0))
-	routeBytes := responseBuffer.Out.Contents()
-
-	var routeMap response
-
-	err := json.Unmarshal(routeBytes, &routeMap)
-	Expect(err).NotTo(HaveOccurred())
-
-	return routeMap.Resources[0].Metadata.Guid
 }
 
 type metadata struct {

--- a/routing/routing_suite_test.go
+++ b/routing/routing_suite_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
@@ -59,11 +58,6 @@ type Stat struct {
 }
 type StatsResponse map[string]Stat
 
-func EnableDiego(appName string) {
-	appGuid := GetAppGuid(appName)
-	Expect(cf.Cf("curl", fmt.Sprintf("/v2/apps/%s", appGuid), "-d", `{"diego": true}`, "-X", "PUT").Wait(DEFAULT_TIMEOUT)).To(Exit(0))
-}
-
 func RestartApp(app string) {
 	Expect(cf.Cf("restart", app).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 }
@@ -97,13 +91,6 @@ func DeleteApp(appName string) {
 	Expect(cf.Cf("delete", appName, "-f", "-r").Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 }
 
-func GetAppGuid(appName string) string {
-	session := cf.Cf("app", appName, "--guid").Wait(DEFAULT_TIMEOUT)
-	Expect(session).To(Exit(0))
-	appGuid := session.Out.Contents()
-	return strings.TrimSpace(string(appGuid))
-}
-
 func MapRouteToApp(app, domain, host, path string) {
 	Expect(cf.Cf("map-route", app, domain, "--hostname", host, "--path", path).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 }
@@ -116,14 +103,14 @@ func DeleteRoute(hostname, contextPath, domain string) {
 	).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 }
 
-func CreateRoute(hostname, contextPath, space, domain string) {
+func createRoute(hostname, contextPath, space, domain string) {
 	Expect(cf.Cf("create-route", space, domain,
 		"--hostname", hostname,
 		"--path", contextPath,
 	).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 }
 
-func GetRouteGuid(hostname, path string) string {
+func getRouteGuid(hostname, path string) string {
 	responseBuffer := cf.Cf("curl", fmt.Sprintf("/v2/routes?q=host:%s&q=path:%s", hostname, path))
 	Expect(responseBuffer.Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 	routeBytes := responseBuffer.Out.Contents()

--- a/routing/routing_suite_test.go
+++ b/routing/routing_suite_test.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	DEFAULT_MEMORY_LIMIT = "256M"
+	deaUnsupportedTag    = "{NO_DEA_SUPPORT} "
 )
 
 var (

--- a/routing/routing_suite_test.go
+++ b/routing/routing_suite_test.go
@@ -116,13 +116,11 @@ func DeleteRoute(hostname, contextPath, domain string) {
 	).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 }
 
-func CreateRoute(hostname, contextPath, space, domain string) string {
+func CreateRoute(hostname, contextPath, space, domain string) {
 	Expect(cf.Cf("create-route", space, domain,
 		"--hostname", hostname,
 		"--path", contextPath,
 	).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
-
-	return GetRouteGuid(hostname, contextPath)
 }
 
 func GetRouteGuid(hostname, path string) string {

--- a/routing/session_affinity_test.go
+++ b/routing/session_affinity_test.go
@@ -123,6 +123,8 @@ var _ = Describe("Session Affinity", func() {
 		)
 
 		BeforeEach(func() {
+			domain := config.AppsDomain
+
 			app1 = PushApp(stickyAsset, config.RubyBuildpackName)
 			app2 = PushApp(stickyAsset, config.RubyBuildpackName)
 
@@ -130,8 +132,8 @@ var _ = Describe("Session Affinity", func() {
 			ScaleAppInstances(app2, 2)
 			hostname = generator.PrefixedRandomName("RATS-HOSTNAME-")
 
-			MapRouteToApp(hostname, app1Path, app1)
-			MapRouteToApp(hostname, app2Path, app2)
+			MapRouteToApp(app1, domain, hostname, app1Path)
+			MapRouteToApp(app2, domain, hostname, app2Path)
 
 			cookieStore, err := ioutil.TempFile("", "cats-sticky-session")
 			Expect(err).ToNot(HaveOccurred())
@@ -188,6 +190,8 @@ var _ = Describe("Session Affinity", func() {
 		)
 
 		BeforeEach(func() {
+			domain := config.AppsDomain
+
 			app1 = PushApp(stickyAsset, config.RubyBuildpackName)
 			app2 = PushApp(stickyAsset, config.RubyBuildpackName)
 
@@ -195,7 +199,7 @@ var _ = Describe("Session Affinity", func() {
 			ScaleAppInstances(app2, 2)
 			hostname = app1
 
-			MapRouteToApp(hostname, app2Path, app2)
+			MapRouteToApp(app2, domain, hostname, app2Path)
 
 			cookieStore, err := ioutil.TempFile("", "cats-sticky-session")
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION

This PR updates CATS to use CF CLI for testing context route path.

Pivotal tracker story: https://www.pivotaltracker.com/story/show/106693894

Shash & Chris
Routing Team
Cloudfoundry