### PR TITLE
Do not pass quotes around filename for curl

### DIFF
--- a/helpers/v3_helpers/v3.go
+++ b/helpers/v3_helpers/v3.go
@@ -101,7 +101,7 @@ func GetAuthToken() string {
 }
 
 func UploadPackage(uploadUrl, packageZipPath, token string) {
-	bits := fmt.Sprintf(`bits=@"%s"`, packageZipPath)
+	bits := fmt.Sprintf(`bits=@%s`, packageZipPath)
 	_, err := exec.Command("curl", "-v", "-s", uploadUrl, "-F", bits, "-H", fmt.Sprintf("Authorization: %s", token)).CombinedOutput()
 	Expect(err).NotTo(HaveOccurred())
 }


### PR DESCRIPTION
Passing quotes to the form data parameter `-F` of curl, is only
supported from version 7.26 of curl (see
https://github.com/curl/curl/commit/2698520aef593cbd746a64f79021a4c8d7c83d65)

The latest stemcells include version 7.35, so the tests work fine in
a errand based on such stemcells, but if you run the test in a system
with an older version of curl (e.g. Debian stable with 7.26) the test
will fail.

This commit simply removes such quotes to allow run the test on older
versions or curl.