### PR TITLE
Add protocol to uploadUrl of v3 tests

### DIFF
--- a/v3/app_lifecycle_test.go
+++ b/v3/app_lifecycle_test.go
@@ -32,7 +32,7 @@ var _ = Describe("v3 buildpack app lifecycle", func() {
 		appGuid = CreateApp(appName, spaceGuid, `{"foo":"bar"}`)
 		packageGuid = CreatePackage(appGuid)
 		token = GetAuthToken()
-		uploadUrl = fmt.Sprintf("%s/v3/packages/%s/upload", config.ApiEndpoint, packageGuid)
+		uploadUrl = fmt.Sprintf("%s%s/v3/packages/%s/upload", config.Protocol(), config.ApiEndpoint, packageGuid)
 	})
 
 	AfterEach(func() {

--- a/v3/buildpacks_test.go
+++ b/v3/buildpacks_test.go
@@ -34,7 +34,7 @@ var _ = Describe("buildpack", func() {
 		appGuid = CreateApp(appName, spaceGuid, "{}")
 		packageGuid = CreatePackage(appGuid)
 		token = GetAuthToken()
-		uploadUrl := fmt.Sprintf("%s/v3/packages/%s/upload", config.ApiEndpoint, packageGuid)
+		uploadUrl := fmt.Sprintf("%s%s/v3/packages/%s/upload", config.Protocol(), config.ApiEndpoint, packageGuid)
 		UploadPackage(uploadUrl, assets.NewAssets().DoraZip, token)
 		WaitForPackageToBeReady(packageGuid)
 

--- a/v3/package_test.go
+++ b/v3/package_test.go
@@ -36,7 +36,7 @@ var _ = Describe("package features", func() {
 		appGuid = CreateApp(appName, spaceGuid, "{}")
 		packageGuid = CreatePackage(appGuid)
 		token = GetAuthToken()
-		uploadUrl = fmt.Sprintf("%s/v3/packages/%s/upload", config.ApiEndpoint, packageGuid)
+		uploadUrl = fmt.Sprintf("%s%s/v3/packages/%s/upload", config.Protocol(), config.ApiEndpoint, packageGuid)
 	})
 
 	AfterEach(func() {

--- a/v3/process_test.go
+++ b/v3/process_test.go
@@ -35,7 +35,7 @@ var _ = Describe("process", func() {
 		appGuid = CreateApp(appName, spaceGuid, `{"foo":"bar"}`)
 		packageGuid = CreatePackage(appGuid)
 		token := GetAuthToken()
-		uploadUrl := fmt.Sprintf("%s/v3/packages/%s/upload", config.ApiEndpoint, packageGuid)
+		uploadUrl := fmt.Sprintf("%s%s/v3/packages/%s/upload", config.Protocol(), config.ApiEndpoint, packageGuid)
 		UploadPackage(uploadUrl, assets.NewAssets().DoraZip, token)
 		WaitForPackageToBeReady(packageGuid)
 	})

--- a/v3/service_bindings_test.go
+++ b/v3/service_bindings_test.go
@@ -39,7 +39,7 @@ var _ = Describe("service bindings", func() {
 		appGuid = CreateApp(appName, spaceGuid, "{}")
 		packageGuid = CreatePackage(appGuid)
 		token = GetAuthToken()
-		uploadUrl := fmt.Sprintf("%s/v3/packages/%s/upload", config.ApiEndpoint, packageGuid)
+		uploadUrl := fmt.Sprintf("%s%s/v3/packages/%s/upload", config.Protocol(), config.ApiEndpoint, packageGuid)
 		UploadPackage(uploadUrl, assets.NewAssets().DoraZip, token)
 		WaitForPackageToBeReady(packageGuid)
 		Expect(cf.Cf("create-user-provided-service", upsName, "-p", "{\"username\":\"admin\",\"password\":\"my-service\"}").Wait(DEFAULT_TIMEOUT)).To(Exit(0))

--- a/v3/task_test.go
+++ b/v3/task_test.go
@@ -44,7 +44,7 @@ var _ = Describe("v3 tasks", func() {
 		appGuid = CreateApp(appName, spaceGuid, `{"foo":"bar"}`)
 		packageGuid = CreatePackage(appGuid)
 		token = GetAuthToken()
-		uploadUrl := fmt.Sprintf("%s/v3/packages/%s/upload", config.ApiEndpoint, packageGuid)
+		uploadUrl := fmt.Sprintf("%s%s/v3/packages/%s/upload", config.Protocol(), config.ApiEndpoint, packageGuid)
 		UploadPackage(uploadUrl, assets.NewAssets().DoraZip, token)
 		WaitForPackageToBeReady(packageGuid)
 		dropletGuid := StageBuildpackPackage(packageGuid, "ruby_buildpack")


### PR DESCRIPTION
Add protocol to uploadUrl in all of the v3 tests.

Tests fail without this if your deployment is operating on https instead of http. This is because without protocol specified the tests will try to connect using default protocol and port, which http on port 80.