### PR TITLE
Check for errors while slurping

### DIFF
--- a/apps/loggregator_test.go
+++ b/apps/loggregator_test.go
@@ -112,33 +112,35 @@ var _ = Describe("loggregator", func() {
 
 			Expect(messages).To(ContainElement(EnvelopeContainingMessageLike("Muahaha")), "To enable the logging & metrics firehose feature, please ask your CF administrator to add the 'doppler.firehose' scope to your CF admin user.")
 		})
-	})
 
-	It("shows container metrics", func() {
-		config := helpers.LoadConfig()
-		appGuid := strings.TrimSpace(string(cf.Cf("app", appName, "--guid").Wait(DEFAULT_TIMEOUT).Out.Contents()))
+		It("shows container metrics", func() {
+			config := helpers.LoadConfig()
+			appGuid := strings.TrimSpace(string(cf.Cf("app", appName, "--guid").Wait(DEFAULT_TIMEOUT).Out.Contents()))
 
-		noaaConnection := noaa.NewConsumer(getDopplerEndpoint(), &tls.Config{InsecureSkipVerify: config.SkipSSLValidation}, nil)
-		msgChan := make(chan *events.Envelope, 100000)
-		errorChan := make(chan error)
-		stopchan := make(chan struct{})
-		go noaaConnection.Firehose(generator.RandomName(), getAdminUserAccessToken(), msgChan, errorChan, stopchan)
-		defer close(stopchan)
+			noaaConnection := noaa.NewConsumer(getDopplerEndpoint(), &tls.Config{InsecureSkipVerify: config.SkipSSLValidation}, nil)
+			msgChan := make(chan *events.Envelope, 100000)
+			errorChan := make(chan error)
+			stopchan := make(chan struct{})
+			go noaaConnection.Firehose(generator.RandomName(), getAdminUserAccessToken(), msgChan, errorChan, stopchan)
+			defer close(stopchan)
 
-		Eventually(func() bool {
-			for {
-				select {
-				case msg := <-msgChan:
-					if cm := msg.GetContainerMetric(); cm != nil {
-						if cm.GetApplicationId() == appGuid && cm.GetInstanceIndex() == 0 {
-							return true
+			Eventually(func() bool {
+				for {
+					select {
+					case msg := <-msgChan:
+						if cm := msg.GetContainerMetric(); cm != nil {
+							if cm.GetApplicationId() == appGuid && cm.GetInstanceIndex() == 0 {
+								return true
+							}
 						}
+					case e := <-errorChan:
+						Expect(e).ToNot(HaveOccurred())
+					default:
+						return false
 					}
-				default:
-					return false
 				}
-			}
-		}, DEFAULT_TIMEOUT).Should(BeTrue())
+			}, DEFAULT_TIMEOUT).Should(BeTrue())
+		})
 	})
 })
 


### PR DESCRIPTION
The reformat was due to moving the test under the correct context.
Check for errors from the firehose.

[##116437533]