### PR TITLE
Allow firehose test to fail when it times out

### DIFF
--- a/apps/loggregator_test.go
+++ b/apps/loggregator_test.go
@@ -99,7 +99,7 @@ var _ = Describe("loggregator", func() {
 				return helpers.CurlApp(appName, fmt.Sprintf("/log/sleep/%d", hundredthOfOneSecond))
 			}, DEFAULT_TIMEOUT).Should(ContainSubstring("Muahaha"))
 
-			Eventually(msgChan, 5).Should(Receive(EnvelopeContainingMessageLike("Muahaha")), "To enable the logging & metrics firehose feature, please ask your CF administrator to add the 'doppler.firehose' scope to your CF admin user.")
+			Eventually(msgChan, 5*time.Second).Should(Receive(EnvelopeContainingMessageLike("Muahaha")), "To enable the logging & metrics firehose feature, please ask your CF administrator to add the 'doppler.firehose' scope to your CF admin user.")
 		})
 	})
 


### PR DESCRIPTION
* A short explanation of the proposed change:

Firehose test was not failing when timeout was hit. It does fail now.

* An explanation of the use cases your change solves:

It properly fails now when timeout occurs, which is useful. This closes #94.

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `master` branch
* [x] I have successfully run these tests against bosh-lite 