### PR TITLE
use go1.5 instead of go1.4

### DIFF
--- a/assets/golang/Godeps/Godeps.json
+++ b/assets/golang/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
 	"ImportPath": "go-online",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.5",
 	"Deps": []
 }

--- a/assets/worker-app/Godeps/Godeps.json
+++ b/assets/worker-app/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
 	"ImportPath": "go-online",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.5",
 	"Deps": []
 }


### PR DESCRIPTION
Thanks for contributing to the `cf-acceptance-tests`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

bump the version of go used by the app.

* An explanation of the use cases your change solves

go buildpack has recently deprecated go1.4. this is causing CATS to fail on CF with the latest buildpack. this change fix CATS

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have successfully run these tests against bosh-lite 