### PR TITLE
Increase timeoutes for firehose data tests

### DIFF
--- a/apps/loggregator_test.go
+++ b/apps/loggregator_test.go
@@ -99,7 +99,7 @@ var _ = Describe("loggregator", func() {
 				return helpers.CurlApp(appName, fmt.Sprintf("/log/sleep/%d", hundredthOfOneSecond))
 			}, DEFAULT_TIMEOUT).Should(ContainSubstring("Muahaha"))
 
-			Eventually(msgChan, 5*time.Second).Should(Receive(EnvelopeContainingMessageLike("Muahaha")), "To enable the logging & metrics firehose feature, please ask your CF administrator to add the 'doppler.firehose' scope to your CF admin user.")
+			Eventually(msgChan, 10*time.Second).Should(Receive(EnvelopeContainingMessageLike("Muahaha")), "To enable the logging & metrics firehose feature, please ask your CF administrator to add the 'doppler.firehose' scope to your CF admin user.")
 		})
 
 		It("shows container metrics", func() {
@@ -128,7 +128,7 @@ var _ = Describe("loggregator", func() {
 						return false
 					}
 				}
-			}, DEFAULT_TIMEOUT).Should(BeTrue())
+			}, 2*DEFAULT_TIMEOUT).Should(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
Thanks for contributing to the `cf-acceptance-tests`. To speed up the process of reviewing your pull request please provide us with:

We've been experiencing failures that look to be caused by the time to execute the tests are close to the timeouts. We were able to get consistent failures when we dropped the timeout to 15s which leads us to believe that most of the time, the tests are completing at close to the default timeout time span.

We ran this spec against an AWS deployment with the `ginkgo -untilItFails=true` twenty times without failure.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have successfully run these tests against ~~bosh-lite~~ an AWS deployed cf installation 
