### PR TITLE
add integration tests for starting multiple app instances

### DIFF
--- a/apps/lifecycle_test.go
+++ b/apps/lifecycle_test.go
@@ -53,6 +53,9 @@ var _ = Describe("Application Lifecycle", func() {
 
 		Expect(cf.Cf("push", appName, "--no-start", "-b", config.RubyBuildpackName, "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Dora, "-d", config.AppsDomain).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 		app_helpers.SetBackend(appName)
+	})
+
+	JustBeforeEach(func() {
 		Expect(cf.Cf("start", appName).Wait(CF_PUSH_TIMEOUT)).To(Exit(0))
 	})
 
@@ -73,7 +76,7 @@ var _ = Describe("Application Lifecycle", func() {
 			var app2 string
 			var path = "/imposter_dora"
 
-			BeforeEach(func() {
+			JustBeforeEach(func() {
 				app2 = generator.PrefixedRandomName("CATS-APP-")
 				Expect(cf.Cf("push", app2, "--no-start", "-b", config.RubyBuildpackName, "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().HelloWorld, "-d", config.AppsDomain).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 				app_helpers.SetBackend(app2)
@@ -124,6 +127,19 @@ var _ = Describe("Application Lifecycle", func() {
 			})
 		})
 
+		Context("multiple instances", func() {
+			BeforeEach(func() {
+				Expect(cf.Cf("scale", appName, "-i", "2").Wait(DEFAULT_TIMEOUT)).To(Exit(0))
+			})
+
+			It("is able to start all instances", func() {
+				app := cf.Cf("app", appName).Wait(DEFAULT_TIMEOUT)
+				Expect(app).To(Exit(0))
+				Expect(app).To(Say("#0   running"))
+				Expect(app).To(Say("#1   running"))
+			})
+		})
+
 		It("makes system environment variables available", func() {
 			var envOutput string
 			Eventually(func() string {
@@ -151,7 +167,7 @@ var _ = Describe("Application Lifecycle", func() {
 	})
 
 	Describe("stopping", func() {
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			Expect(cf.Cf("stop", appName).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 		})
 
@@ -167,7 +183,7 @@ var _ = Describe("Application Lifecycle", func() {
 		})
 
 		Describe("and then starting", func() {
-			BeforeEach(func() {
+			JustBeforeEach(func() {
 				Expect(cf.Cf("start", appName).Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 			})
 
@@ -196,7 +212,7 @@ var _ = Describe("Application Lifecycle", func() {
 	})
 
 	Describe("deleting", func() {
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			Expect(cf.Cf("delete", appName, "-f", "-r").Wait(DEFAULT_TIMEOUT)).To(Exit(0))
 		})
 


### PR DESCRIPTION
Thanks for contributing to the `cf-acceptance-tests`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Add a CAT to apps suite to cover pushing an app and starting multiple instances

* An explanation of the use cases your change solves
Tests multiple instances started when being pushed.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have successfully run these tests against bosh-lite 

[#118940535]

Signed-off-by: Sandy Cash <scarlet.tanager@gmail.com>