### PR TITLE
Use SleepTimeout instead of DefaultTimeout when sleeping

### DIFF
--- a/apps/buildpack_cache_test.go
+++ b/apps/buildpack_cache_test.go
@@ -136,7 +136,7 @@ EOF
 			return helpers.CurlAppRoot(appName)
 		}, DEFAULT_TIMEOUT).Should(ContainSubstring("custom buildpack contents - cache not found"))
 
-		time.Sleep(DEFAULT_TIMEOUT)
+		time.Sleep(SLEEP_TIMEOUT)
 
 		restage := cf.Cf("restage", appName).Wait(CF_PUSH_TIMEOUT)
 		Expect(restage).To(Exit(0))

--- a/apps/init_test.go
+++ b/apps/init_test.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	DEFAULT_TIMEOUT      = 30 * time.Second
+	SLEEP_TIMEOUT        = 30 * time.Second
 	CF_PUSH_TIMEOUT      = 2 * time.Minute
 	LONG_CURL_TIMEOUT    = 2 * time.Minute
 	CF_JAVA_TIMEOUT      = 10 * time.Minute
@@ -33,6 +34,10 @@ func TestApplications(t *testing.T) {
 
 	if config.DefaultTimeout > 0 {
 		DEFAULT_TIMEOUT = config.DefaultTimeout * time.Second
+	}
+
+	if config.SleepTimeout > 0 {
+		SLEEP_TIMEOUT = config.SleepTimeout * time.Second
 	}
 
 	if config.CfPushTimeout > 0 {

--- a/helpers/v3_helpers/globals.go
+++ b/helpers/v3_helpers/globals.go
@@ -3,8 +3,9 @@ package v3_helpers
 import "time"
 
 var (
-	DEFAULT_TIMEOUT   = 30 * time.Second
-	CF_PUSH_TIMEOUT   = 2 * time.Minute
-	LONG_CURL_TIMEOUT = 2 * time.Minute
+	DEFAULT_TIMEOUT      = 30 * time.Second
+	SLEEP_TIMEOUT        = 30 * time.Second
+	CF_PUSH_TIMEOUT      = 2 * time.Minute
+	LONG_CURL_TIMEOUT    = 2 * time.Minute
 	DEFAULT_MEMORY_LIMIT = "256"
 )

--- a/v3/buildpacks_test.go
+++ b/v3/buildpacks_test.go
@@ -82,7 +82,7 @@ var _ = Describe("buildpack", func() {
 		}, CF_PUSH_TIMEOUT).Should(Say("custom buildpack contents - cache not found"))
 
 		// Wait for buildpack cache to be uploaded to blobstore.
-		time.Sleep(DEFAULT_TIMEOUT)
+		time.Sleep(SLEEP_TIMEOUT)
 
 		secondDropletGuid := StageBuildpackPackage(packageGuid, buildpackName)
 		dropletPath = fmt.Sprintf("/v3/droplets/%s", secondDropletGuid)

--- a/v3/init_test.go
+++ b/v3/init_test.go
@@ -24,6 +24,10 @@ func TestApplications(t *testing.T) {
 		DEFAULT_TIMEOUT = config.DefaultTimeout * time.Second
 	}
 
+	if config.SleepTimeout > 0 {
+		SLEEP_TIMEOUT = config.SleepTimeout * time.Second
+	}
+
 	if config.CfPushTimeout > 0 {
 		CF_PUSH_TIMEOUT = config.CfPushTimeout * time.Second
 	}


### PR DESCRIPTION
This PR changes `time.Sleep` to use `SleepTimeout` instead of `DefaultTimeout`. The CATS suite runs slow for us, so we need to use a high `DefaultTimeout`. Using `SleepTimeout` instead of `DefaultTimeout` lets us have the higher `DefaultTimeout` without sleeping for an unnecessary amount of time.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have successfully run these tests against ~~bosh-lite~~ PCF Dev