### PR TITLE
Change file permissions of scp/sftp test asset

### DIFF
--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -194,7 +194,7 @@ var _ = Describe(deaUnsupportedTag+"SSH", func() {
 			generatedFileName = "binary.dat"
 			generatedFile = filepath.Join(sourceDir, generatedFileName)
 
-			err = ioutil.WriteFile(generatedFile, fileContents, 0664)
+			err = ioutil.WriteFile(generatedFile, fileContents, 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			generatedFileInfo, err = os.Stat(generatedFile)
@@ -289,7 +289,7 @@ var _ = Describe(deaUnsupportedTag+"SSH", func() {
 			generatedFileName = "binary.dat"
 			generatedFile = filepath.Join(sourceDir, generatedFileName)
 
-			err = ioutil.WriteFile(generatedFile, fileContents, 0664)
+			err = ioutil.WriteFile(generatedFile, fileContents, 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			generatedFileInfo, err = os.Stat(generatedFile)


### PR DESCRIPTION
Thanks for contributing to the `cf-acceptance-tests`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

On linux the `0664` file permission will give write permission to the
current users group. When scping the file into a container, this
permission gets dropped as the group does not exist. On OSX, the group
is not given write permission to the generated file so this is not a
concern. On the errand VM, the vcap group exists in both the container
and the VM, so it is able to transfer the permissions correctly.

[#119334663]

* An explanation of the use cases your change solves

Running the cf-acceptance-tests locally on a linux workstation without the vcap user group.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have successfully run these tests against bosh-lite 

Signed-off-by: James Myers <jmyers@pivotal.io>