### PR TITLE
Add DEFAULT_TIMEOUT to Eventually assertions in docker tests

### DIFF
--- a/docker/docker_lifecycle_test.go
+++ b/docker/docker_lifecycle_test.go
@@ -107,12 +107,12 @@ var _ = Describe(deaUnsupportedTag+"Docker Application Lifecycle", func() {
 				Eventually(cf.Cf(
 					"set-env", appName,
 					"HOME", "/tmp/fakehome"),
-				).Should(Exit(0))
+					DEFAULT_TIMEOUT).Should(Exit(0))
 
 				Eventually(cf.Cf(
 					"set-env", appName,
 					"TMPDIR", "/tmp/dir"),
-				).Should(Exit(0))
+					DEFAULT_TIMEOUT).Should(Exit(0))
 			})
 
 			It("prefers the env vars from cf set-env over those in the Dockerfile", func() {


### PR DESCRIPTION
In the recent PR where I added these tests, I forgot to specify DEFAULT_TIMEOUT in the Eventually assertions. This caused tests to time out too quickly in the Diego CI environment.
