### PR TITLE
Buildpack names are taken from config instead of hard-coded

### DIFF
--- a/v3/app_lifecycle_test.go
+++ b/v3/app_lifecycle_test.go
@@ -47,7 +47,7 @@ var _ = Describe("v3 buildpack app lifecycle", func() {
 		})
 
 		It("can run apps with processes from the Procfile", func() {
-			dropletGuid := StageBuildpackPackage(packageGuid, "ruby_buildpack")
+			dropletGuid := StageBuildpackPackage(packageGuid, config.RubyBuildpackName)
 			WaitForDropletToStage(dropletGuid)
 
 			AssignDropletToApp(appGuid, dropletGuid)
@@ -105,7 +105,7 @@ var _ = Describe("v3 buildpack app lifecycle", func() {
 		})
 
 		It("can run spring apps", func() {
-			dropletGuid := StageBuildpackPackage(packageGuid, "java_buildpack")
+			dropletGuid := StageBuildpackPackage(packageGuid, config.JavaBuildpackName)
 			WaitForDropletToStage(dropletGuid)
 
 			AssignDropletToApp(appGuid, dropletGuid)

--- a/v3/package_test.go
+++ b/v3/package_test.go
@@ -93,7 +93,7 @@ var _ = Describe("package features", func() {
 		})
 
 		It("can still stage the package", func() {
-			dropletGuid := StageBuildpackPackage(packageGuid, "java_buildpack")
+			dropletGuid := StageBuildpackPackage(packageGuid, config.JavaBuildpackName)
 			dropletPath := fmt.Sprintf("/v3/droplets/%s", dropletGuid)
 
 			Eventually(func() *Session {


### PR DESCRIPTION
Hello,

We are running CATs with a java buildpack that isn't named "java_buildpack", and noticed some v3 failures due to tests hardcoding that name. We've changed 2 instances of "java_buildpack" and 1 of "ruby_buildpack" being hardcoded to pull their values from the config JSON instead.

This will help anyone who is using a custom buildpack name vet their deployment using the v3 CATs.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have successfully run these tests against a CF deployment 

Thanks,

Raina
PCF Release Engineering

