### PR TITLE
Make sure request only gets one event

### DIFF
--- a/v3/droplet_test.go
+++ b/v3/droplet_test.go
@@ -99,8 +99,8 @@ var _ = Describe("droplet features", func() {
 			DeleteApp(appGuid) // to prove that the new app does not depend on the old app
 
 			AssignDropletToApp(destinationAppGuid, copiedDropletGuid)
-
-			session = cf.Cf("curl", "v2/events?results-per-page=100", "-X", "GET")
+			eventsQuery := fmt.Sprintf("v2/events?q=type:audit.app.droplet.create&q=actee:%s", destinationAppGuid)
+			session = cf.Cf("curl", eventsQuery, "-X", "GET")
 			bytes = session.Wait(DEFAULT_TIMEOUT).Out.Contents()
 
 			type request struct {


### PR DESCRIPTION
Thanks for contributing to the `cf-acceptance-tests`. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

The original events query returned multiple pages but we weren't iterating over all the pages. If your event ended up on the second page the test would fail.

* An explanation of the use cases your change solves

Makes test less likely to fail by looking for the particular event the test specifies and the actee GUID. There should only be one event.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have successfully run these tests against a full-scale CF deploy

[#126327439]

Signed-off-by: Ryan Moran <rmoran@pivotal.io>