### PR TITLE
Modifies app to return container ip with ip route

### DIFF
--- a/assets/dora/dora.rb
+++ b/assets/dora/dora.rb
@@ -90,7 +90,7 @@ class Dora < Sinatra::Base
   end
 
   get '/myip' do
-    `ip addr show  | grep 'scope global w' | grep inet | awk '{print $2}'`
+    `ip route get 1 | awk '{print $NF;exit}'`
   end
 
   get '/largetext/:kbytes' do


### PR DESCRIPTION
Currently dora's method for discovering the container IP is particular to garden. The container networking team would like to change this to be more generic.

https://www.pivotaltracker.com/story/show/132339657

cc @jaydunk
