### PR TITLE
Update security groups test for compatibility with container networking

### DIFF
--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -7,6 +7,7 @@ import (
 type CatsConfig interface {
 	GetIncludeApps() bool
 	GetIncludeBackendCompatiblity() bool
+	GetIncludeContainerNetworking() bool
 	GetIncludeDetect() bool
 	GetIncludeDocker() bool
 	GetIncludeInternetDependent() bool

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -58,6 +58,7 @@ type config struct {
 
 	IncludeApps                       *bool `json:"include_apps"`
 	IncludeBackendCompatiblity        *bool `json:"include_backend_compatibility"`
+	IncludeContainerNetworking        *bool `json:"include_container_networking"`
 	IncludeDetect                     *bool `json:"include_detect"`
 	IncludeDocker                     *bool `json:"include_docker"`
 	IncludeInternetDependent          *bool `json:"include_internet_dependent"`
@@ -115,6 +116,7 @@ func getDefaults() config {
 	defaults.IncludeRouting = ptrToBool(true)
 
 	defaults.IncludeBackendCompatiblity = ptrToBool(false)
+	defaults.IncludeContainerNetworking = ptrToBool(false)
 	defaults.IncludeDocker = ptrToBool(false)
 	defaults.IncludeInternetDependent = ptrToBool(false)
 	defaults.IncludeRouteServices = ptrToBool(false)
@@ -264,6 +266,9 @@ func load(path string, config *config) Errors {
 	}
 	if config.IncludeBackendCompatiblity == nil {
 		errs.Add(fmt.Errorf("* 'include_backend_compatibility' must not be null"))
+	}
+	if config.IncludeContainerNetworking == nil {
+		errs.Add(fmt.Errorf("* 'include_container_networking' must not be null"))
 	}
 	if config.IncludeDetect == nil {
 		errs.Add(fmt.Errorf("* 'include_detect' must not be null"))
@@ -487,6 +492,10 @@ func (c *config) GetIncludeApps() bool {
 
 func (c *config) GetIncludeBackendCompatiblity() bool {
 	return *c.IncludeBackendCompatiblity
+}
+
+func (c *config) GetIncludeContainerNetworking() bool {
+	return *c.IncludeContainerNetworking
 }
 
 func (c *config) GetIncludeDetect() bool {


### PR DESCRIPTION
This updates the existing security-group tests in CATS for running applications to work with container networking.

It requires a new config option,`include_container_networking` which defaults to `false`

When false, the existing test is run using security groups.  When true, it instead uses the cf cli network policy plugin to create/remove policies.

To work with container networking, this will also require PR https://github.com/cloudfoundry/cf-acceptance-tests/pull/144 be merged.
- Initial work done here for context: [#132951677](https://www.pivotaltracker.com/story/show/132951677)
- Tracking story for this PR: [#133349151](https://www.pivotaltracker.com/story/show/133349151)

/cc @markstgodard 
