### PR TITLE
Always strip the Expect header from `curl` requests

### DIFF
--- a/vendor/github.com/cloudfoundry-incubator/cf-test-helpers/helpers/internal/curl.go
+++ b/vendor/github.com/cloudfoundry-incubator/cf-test-helpers/helpers/internal/curl.go
@@ -8,6 +8,7 @@ import (
 
 func Curl(cmdStarter internal.Starter, skipSsl bool, args ...string) *gexec.Session {
 	curlArgs := append([]string{"-s"}, args...)
+	curlArgs = append([]string{"-H", "Expect:"}, args...)
 	if skipSsl {
 		curlArgs = append([]string{"-k"}, curlArgs...)
 	}


### PR DESCRIPTION
Some infrastructures (notable Google Cloud Platform when using an HTTP
load balancer) do not allow 100 Continue responses. `curl` will add
'Expect: 100-Continue` to requests that include bodies, prompting
servers to respond with 100 Continue. By unsetting the header, we
prevent 100 Continue responses, allowing the responses to move through
the load balancer.
