### PR TITLE
Include protocol in SSO URLs.

### DIFF
--- a/services/sso_lifecycle.go
+++ b/services/sso_lifecycle.go
@@ -40,7 +40,7 @@ var _ = ServicesDescribe("SSO Lifecycle", func() {
 		oauthConfig.RedirectUri = redirectUri
 		oauthConfig.RequestedScopes = `openid,cloud_controller_service_permissions.read`
 
-		apiEndpoint = Config.GetApiEndpoint()
+		apiEndpoint = Config.Protocol() + Config.GetApiEndpoint()
 		SetOauthEndpoints(apiEndpoint, &oauthConfig, Config)
 
 		broker.Create()


### PR DESCRIPTION
Our api server is behind a proxy that redirects http to https, so making a request to the url without a protocol returns a 301 with an empty body, which panics the sso tests. This patch prepends the protocol to the api url--wdyt?