### PR TITLE
Pin dotnet version.

### DIFF
--- a/assets/dotnet-core/project.json
+++ b/assets/dotnet-core/project.json
@@ -7,7 +7,7 @@
     "Microsoft.AspNetCore.Server.Kestrel": "*",
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "*"
+      "version": "1.0.0"
     },
     "Microsoft.Extensions.Configuration.CommandLine": "*"
   },


### PR DESCRIPTION
Based on discussion in https://github.com/cloudfoundry/dotnet-core-buildpack/issues/116, it sounds like dotnet apps need to pin a version to deploy correctly.