### PR TITLE
update "can delete the key" service test in service_instance_lifecycle.go

### DIFF
--- a/services/service_instance_lifecycle.go
+++ b/services/service_instance_lifecycle.go
@@ -212,10 +212,7 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 							Expect(deleteServiceKey).To(Exit(0), "failed deleting service key")
 
 							keyInfo := cf.Cf("service-key", instanceName, keyName).Wait(Config.DefaultTimeoutDuration())
-							Expect(keyInfo).To(Exit(), "failed key info")
-
-							errorMessage := fmt.Sprintf("No service key %s found for service instance %s", keyName, instanceName)
-							Expect(keyInfo).To(Say(errorMessage))
+							Expect(keyInfo).To(Say(fmt.Sprintf("No service key %s found for service instance %s", keyName, instanceName)))
 						})
 					})
 				})

--- a/services/service_instance_lifecycle.go
+++ b/services/service_instance_lifecycle.go
@@ -212,7 +212,7 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 							Expect(deleteServiceKey).To(Exit(0), "failed deleting service key")
 
 							keyInfo := cf.Cf("service-key", instanceName, keyName).Wait(Config.DefaultTimeoutDuration())
-							Expect(keyInfo).To(Exit(0), "failed key info")
+							Expect(keyInfo).To(Exit(), "failed key info")
 
 							errorMessage := fmt.Sprintf("No service key %s found for service instance %s", keyName, instanceName)
 							Expect(keyInfo).To(Say(errorMessage))


### PR DESCRIPTION
This test recently broke because of a change in behavior to the "service-key" command - as a result of a bug fix in the CLI (tracker story #134271615).

In short, when running the "service-key" command, it used to exit 0 when the key is not found. It now exits 1. This PR updates a test assumption accordingly.