### PR TITLE
Add JSON-formatted environment endpoint to Dora

### DIFF
--- a/assets/dora/README.md
+++ b/assets/dora/README.md
@@ -15,7 +15,9 @@
 1. `GET /logspew/:bytes` Spews out n bytes to the logs
 1. `GET /loglines/:linecount` Writes n lines to stdout, each line contains a timestamp with nanoseconds
 1. `GET /echo/:destination/:output` Echos out the output to the destination
-1. `GET /env/:name` Prints out the env variable
+1. `GET /env/:name` Prints out the environment variable `:name`
+1. `GET /env` Prints out the entire environment as a serialized Ruby hash
+1. `GET /env.json` Prints out the entire environment as a JSON object
 1. `GET /largetext/:kbytes` Returns a dummy response of size `:kbytes`. For testing large payloads.
 
 ## Sticky Sessions

--- a/assets/dora/dora.rb
+++ b/assets/dora/dora.rb
@@ -89,6 +89,10 @@ class Dora < Sinatra::Base
     ENV.to_hash.to_s
   end
 
+  get '/env.json' do
+    ENV.to_hash.to_json
+  end
+
   get '/myip' do
     `ip route get 1 | awk '{print $NF;exit}'`
   end


### PR DESCRIPTION
The current `/env` endpoint returns a serialized Ruby hash. For this
response to be manipulated programmatically, it must be interpreted
back into a hash with a Ruby `eval`, which requires a Ruby interpreter
and is demonstrably insecure. A variant on this endpoint that returns
the environment as a JSON object is much safer and is language-agnostic.

There are no doubt some CATs that could improve the robustness of
their assertions by manipulating this JSON-formatted response.

No tests, but the Dora README is updated.