### PR TITLE
Remove Evenutally in favor of Expect

### DIFF
--- a/routing/zipkin_tracing.go
+++ b/routing/zipkin_tracing.go
@@ -66,7 +66,7 @@ var _ = ZipkinDescribe("Zipkin Tracing", func() {
 
 				appLogsSession = cf.Cf("logs", "--recent", hostname)
 
-				Eventually(appLogsSession.Out).Should(gbytes.Say("x_b3_traceid:\"fee1f7ba6aeec41c"))
+				Expect(appLogsSession.Out).Should(gbytes.Say("x_b3_traceid:\"fee1f7ba6aeec41c"))
 				_, appLogSpanId, _ := grabIDs(string(appLogsSession.Out.Contents()), traceId)
 
 				Expect(curlOutput).To(ContainSubstring(traceId))


### PR DESCRIPTION
- this test has been extremely flakey due to
  gbytes say not showing up in the requisite amount
  of time.
- no reason to actually use an eventually as all of
  the logs have already been fetched on the line above
  and we are not waiting for them to "Eventually" come
  in.

Signed-off-by: Zachary Gershman <zgershman@pivotal.io>