### PR TITLE
Remove empty app name message when running tests.

### DIFF
--- a/helpers/app_helpers/app_helpers.go
+++ b/helpers/app_helpers/app_helpers.go
@@ -1,7 +1,6 @@
 package app_helpers
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -50,7 +49,6 @@ func DisableDiegoAndCheckResponse(appName, expectedSubstring string) {
 
 func AppReport(appName string, timeout time.Duration) {
 	if appName == "" {
-		fmt.Println("App name was set to \"\"; skipping app report.")
 		return
 	}
 	Eventually(cf.Cf("app", appName, "--guid"), timeout).Should(Exit())


### PR DESCRIPTION
It makes the test output extremely verbose when running with the --succinct ginkgo flag. For example, when running just the v3 test group, the output currently looks like this:
```
+ ginkgo --failFast --succinct --nodes=4
[1482431888] CATS - 133/135 specs - 4 nodes 
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

SSSS
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

SS
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

SSSSSSSSSS
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

SS
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
• [SLOW TEST:20.974 seconds]
[v3] package features with a valid package can copy package bits to another app and download the package 
/tmp/build/f9b4e60d/go/src/github.com/cloudfoundry/cf-acceptance-tests/v3/package.go:88
------------------------------
• [SLOW TEST:27.008 seconds]
[v3] buildpack Stages with a user specified admin buildpack 
/tmp/build/f9b4e60d/go/src/github.com/cloudfoundry/cf-acceptance-tests/v3/buildpacks.go:67
------------------------------
• [SLOW TEST:30.331 seconds]
[v3] route_mapping Route mapping lifecycle creates a route mapping on a specified port 
/tmp/build/f9b4e60d/go/src/github.com/cloudfoundry/cf-acceptance-tests/v3/route_mapping.go:95
------------------------------
App name was set to ""; skipping app report.

SS
------------------------------
• [SLOW TEST:33.881 seconds]
[v3] package features when the package contains files in unwriteable directories can still stage the package 
/tmp/build/f9b4e60d/go/src/github.com/cloudfoundry/cf-acceptance-tests/v3/package.go:104
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

SSS
------------------------------
• [SLOW TEST:46.645 seconds]
[v3] process terminating an instance /v3/apps/:guid/processes/:type/instances/:index restarts the instance 
/tmp/build/f9b4e60d/go/src/github.com/cloudfoundry/cf-acceptance-tests/v3/process.go:105
------------------------------
• [SLOW TEST:29.991 seconds]
[v3] v3 tasks tasks lifecycle can successfully create and run a task 
/tmp/build/f9b4e60d/go/src/github.com/cloudfoundry/cf-acceptance-tests/v3/task.go:97
------------------------------
• [SLOW TEST:61.837 seconds]
[v3] buildpack uses buildpack cache for staging 
/tmp/build/f9b4e60d/go/src/github.com/cloudfoundry/cf-acceptance-tests/v3/buildpacks.go:108
------------------------------
• [SLOW TEST:15.684 seconds]
[v3] v3 tasks When canceling a task should show task is in FAILED state 
/tmp/build/f9b4e60d/go/src/github.com/cloudfoundry/cf-acceptance-tests/v3/task.go:131
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

SSSSSSSS
------------------------------
• [SLOW TEST:29.948 seconds]
[v3] droplet features copying a droplet can copy a droplet 
/tmp/build/f9b4e60d/go/src/github.com/cloudfoundry/cf-acceptance-tests/v3/droplet.go:85
------------------------------
• [SLOW TEST:61.395 seconds]
[v3] process terminating an instance /v3/processes/:guid/instances/:index restarts the instance 
/tmp/build/f9b4e60d/go/src/github.com/cloudfoundry/cf-acceptance-tests/v3/process.go:136
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

SSSPPS
------------------------------
• [SLOW TEST:19.424 seconds]
[v3] droplet features copying a droplet creates an audit.app.droplet.create event for the copied droplet 
/tmp/build/f9b4e60d/go/src/github.com/cloudfoundry/cf-acceptance-tests/v3/droplet.go:148
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

SS
------------------------------
App name was set to ""; skipping app report.

S
------------------------------
• [SLOW TEST:30.606 seconds]
[v3] v3 buildpack app lifecycle with a ruby_buildpack can run apps with processes from the Procfile 
/tmp/build/f9b4e60d/go/src/github.com/cloudfoundry/cf-acceptance-tests/v3/app_lifecycle.go:100
------------------------------
• [SLOW TEST:34.237 seconds]
[v3] v3 buildpack app lifecycle with a java_buildpack can run spring apps 
/tmp/build/f9b4e60d/go/src/github.com/cloudfoundry/cf-acceptance-tests/v3/app_lifecycle.go:146
------------------------------
App name was set to ""; skipping app report.
App name was set to ""; skipping app report.

S
------------------------------
App name was set to ""; skipping app report.

SSSSSSSSSSSSSSSSSSSS SUCCESS! 4m28.556438498s 

Ginkgo ran 1 suite in 4m54.037483978s
Test Suite Passed
```