### PR TITLE
Fail fast when response does not include GUID

### DIFF
--- a/helpers/v3_helpers/v3.go
+++ b/helpers/v3_helpers/v3.go
@@ -122,6 +122,7 @@ func StageBuildpackPackage(packageGuid, buildpack string) string {
 	var droplet struct {
 		Guid string `json:"guid"`
 	}
+	Expect(droplet.Guid).NotTo(BeEmpty())
 	json.Unmarshal(bytes, &droplet)
 	return droplet.Guid
 }


### PR DESCRIPTION
When the droplet upload for a package fails, the helper currently succeeds even though there is no GUID in the response. This fix checks for the existence of the GUID and fails fast when it's not there.

The same change could probably be made at many different places, but we weren't sure if that is appropriate and thus fixed only the one place were it hurt us so far.

/cc @suhlig 
