### PR TITLE
removed reference to loggregator endpoint in cf config

### DIFF
--- a/apps/loggregator.go
+++ b/apps/loggregator.go
@@ -140,8 +140,8 @@ var _ = AppsDescribe("loggregator", func() {
 })
 
 type cfHomeConfig struct {
-	AccessToken         string
-	LoggregatorEndpoint string
+	AccessToken     string
+	DopplerEndPoint string
 }
 
 func getCfHomeConfig() *cfHomeConfig {
@@ -170,5 +170,5 @@ func getAdminUserAccessToken() string {
 }
 
 func getDopplerEndpoint() string {
-	return strings.Replace(getCfHomeConfig().LoggregatorEndpoint, "loggregator", "doppler", -1)
+	return getCfHomeConfig().DopplerEndPoint
 }


### PR DESCRIPTION
- CF CLI has deprecated this endpoint in the config
- Tests in loggregator.go were failing because they depend on the config.

Signed-off-by: Alex Melnik <aleksandr.s.melnik@hpe.com>