### PR TITLE
Remove v3 helpers from task suite

### DIFF
--- a/helpers/app_helpers/app_usage_events.go
+++ b/helpers/app_helpers/app_usage_events.go
@@ -1,4 +1,4 @@
-package v3_helpers
+package app_helpers
 
 import (
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"

--- a/isolation_segments/isolation_segments.go
+++ b/isolation_segments/isolation_segments.go
@@ -18,8 +18,6 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/config"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
-	//	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
-	//	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 )
 
 const (

--- a/v3/app_lifecycle.go
+++ b/v3/app_lifecycle.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
+	. "github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"


### PR DESCRIPTION
- V3 helpers are still experimental, but tasks are not.
Backwards-incompatable Changes to the v3 helpers could break users
running the tasks suite.

Signed-off-by: Michael Xu <mxu@pivotal.io>