### PR TITLE
Fixes panic in apps/syslog_drain.go when address not yet in logs

### DIFF
--- a/apps/syslog_drain.go
+++ b/apps/syslog_drain.go
@@ -81,7 +81,11 @@ func getSyslogDrainAddress(appName string) string {
 		Expect(err).NotTo(HaveOccurred())
 
 		logs := cf.Cf("logs", appName, "--recent").Wait(Config.DefaultTimeoutDuration())
-		address = re.FindSubmatch(logs.Out.Contents())[1]
+		matched := re.FindSubmatch(logs.Out.Contents())
+		if len(matched) < 2 {
+			return nil
+		}
+		address = matched[1]
 		return address
 	}, Config.DefaultTimeoutDuration()).Should(Not(BeNil()))
 


### PR DESCRIPTION
If the address is not yet in the log output, the test would have previously panicked on an "Index out of range" error.

This change ensures the address is present before continuing the test.