### PR TITLE
Improve assertions against app usage events

### DIFF
--- a/helpers/app_helpers/app_usage_events.go
+++ b/helpers/app_helpers/app_usage_events.go
@@ -16,12 +16,19 @@ type Entity struct {
 	ProcessType   string `json:"process_type"`
 	TaskGuid      string `json:"task_guid"`
 }
+
+type Metadata struct {
+	Guid string `json:"guid"`
+}
+
 type AppUsageEvent struct {
-	Entity `json:"entity"`
+	Entity   `json:"entity"`
+	Metadata `json:"metadata"`
 }
 
 type AppUsageEvents struct {
 	Resources []AppUsageEvent `struct:"resources"`
+	NextUrl   string          `json:"next_url"`
 }
 
 func UsageEventsInclude(events []AppUsageEvent, event AppUsageEvent) bool {
@@ -40,12 +47,37 @@ func UsageEventsInclude(events []AppUsageEvent, event AppUsageEvent) bool {
 	return found
 }
 
-func LastPageUsageEvents(TestSetup *workflowhelpers.ReproducibleTestSuiteSetup) []AppUsageEvent {
+func LastAppUsageEventGuid(testSetup *workflowhelpers.ReproducibleTestSuiteSetup) string {
 	var response AppUsageEvents
 
 	workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
-		workflowhelpers.ApiRequest("GET", "/v2/app_usage_events?results-per-page=150&order-direction=desc&page=1", &response, Config.DefaultTimeoutDuration())
+		workflowhelpers.ApiRequest("GET", "/v2/app_usage_events?results-per-page=1&order-direction=desc&page=1", &response, Config.DefaultTimeoutDuration())
 	})
 
-	return response.Resources
+	return response.Resources[0].Metadata.Guid
+}
+
+// Returns all app usage events that occured since the given app usage event guid
+func UsageEventsAfterGuid(testSetup *workflowhelpers.ReproducibleTestSuiteSetup, guid string) []AppUsageEvent {
+	resources := make([]AppUsageEvent, 0)
+
+	workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+		firstPageUrl := "/v2/app_usage_events?results-per-page=150&order-direction=desc&page=1&after_guid=" + guid
+		url := firstPageUrl
+
+		for {
+			var response AppUsageEvents
+			workflowhelpers.ApiRequest("GET", url, &response, Config.DefaultTimeoutDuration())
+
+			resources = append(resources, response.Resources...)
+
+			if len(response.Resources) == 0 || response.NextUrl == "" {
+				break
+			}
+
+			url = response.NextUrl
+		}
+	})
+
+	return resources
 }

--- a/tasks/task.go
+++ b/tasks/task.go
@@ -94,6 +94,7 @@ var _ = TasksDescribe("v3 tasks", func() {
 			By("creating the task")
 			taskName := "mreow"
 			command := "ls"
+			lastUsageEventGuid := app_helpers.LastAppUsageEventGuid(TestSetup)
 			createCommand := cf.Cf("run-task", appName, command, "--name", taskName).Wait(Config.DefaultTimeoutDuration())
 			Expect(createCommand).To(Exit(0))
 
@@ -110,8 +111,8 @@ var _ = TasksDescribe("v3 tasks", func() {
 			taskGuid := getGuid(appGuid, sequenceId)
 
 			By("TASK_STARTED AppUsageEvent")
-			usageEvents := app_helpers.LastPageUsageEvents(TestSetup)
-			start_event := app_helpers.AppUsageEvent{app_helpers.Entity{State: "TASK_STARTED", ParentAppGuid: appGuid, ParentAppName: appName, TaskGuid: taskGuid}}
+			usageEvents := app_helpers.UsageEventsAfterGuid(TestSetup, lastUsageEventGuid)
+			start_event := app_helpers.AppUsageEvent{Entity: app_helpers.Entity{State: "TASK_STARTED", ParentAppGuid: appGuid, ParentAppName: appName, TaskGuid: taskGuid}}
 			Expect(app_helpers.UsageEventsInclude(usageEvents, start_event)).To(BeTrue())
 
 			By("successfully running")
@@ -126,8 +127,8 @@ var _ = TasksDescribe("v3 tasks", func() {
 			Expect(outputName).To(Equal(taskName))
 
 			By("TASK_STOPPED AppUsageEvent")
-			usageEvents = app_helpers.LastPageUsageEvents(TestSetup)
-			stop_event := app_helpers.AppUsageEvent{app_helpers.Entity{State: "TASK_STOPPED", ParentAppGuid: appGuid, ParentAppName: appName, TaskGuid: taskGuid}}
+			usageEvents = app_helpers.UsageEventsAfterGuid(TestSetup, lastUsageEventGuid)
+			stop_event := app_helpers.AppUsageEvent{Entity: app_helpers.Entity{State: "TASK_STOPPED", ParentAppGuid: appGuid, ParentAppName: appName, TaskGuid: taskGuid}}
 			Expect(app_helpers.UsageEventsInclude(usageEvents, stop_event)).To(BeTrue())
 		})
 	})

--- a/v3/app_lifecycle.go
+++ b/v3/app_lifecycle.go
@@ -69,6 +69,8 @@ var _ = V3Describe("v3 buildpack app lifecycle", func() {
 
 			CreateAndMapRoute(appGuid, TestSetup.RegularUserContext().Space, Config.GetAppsDomain(), webProcess.Name)
 
+			lastUsageEventGuid := LastAppUsageEventGuid(TestSetup)
+
 			StartApp(appGuid)
 
 			Eventually(func() string {
@@ -82,10 +84,10 @@ var _ = V3Describe("v3 buildpack app lifecycle", func() {
 			Expect(string(cf.Cf("apps").Wait(Config.DefaultTimeoutDuration()).Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(started)", webProcess.Name)))
 			Expect(string(cf.Cf("apps").Wait(Config.DefaultTimeoutDuration()).Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(started)", workerProcess.Name)))
 
-			usageEvents := LastPageUsageEvents(TestSetup)
+			usageEvents := UsageEventsAfterGuid(TestSetup, lastUsageEventGuid)
 
-			event1 := AppUsageEvent{Entity{ProcessType: webProcess.Type, AppGuid: webProcess.Guid, State: "STARTED", ParentAppGuid: appGuid, ParentAppName: appName}}
-			event2 := AppUsageEvent{Entity{ProcessType: workerProcess.Type, AppGuid: workerProcess.Guid, State: "STARTED", ParentAppGuid: appGuid, ParentAppName: appName}}
+			event1 := AppUsageEvent{Entity: Entity{ProcessType: webProcess.Type, AppGuid: webProcess.Guid, State: "STARTED", ParentAppGuid: appGuid, ParentAppName: appName}}
+			event2 := AppUsageEvent{Entity: Entity{ProcessType: workerProcess.Type, AppGuid: workerProcess.Guid, State: "STARTED", ParentAppGuid: appGuid, ParentAppName: appName}}
 			Expect(UsageEventsInclude(usageEvents, event1)).To(BeTrue())
 			Expect(UsageEventsInclude(usageEvents, event2)).To(BeTrue())
 
@@ -94,9 +96,9 @@ var _ = V3Describe("v3 buildpack app lifecycle", func() {
 			Expect(string(cf.Cf("apps").Wait(Config.DefaultTimeoutDuration()).Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(stopped)", webProcess.Name)))
 			Expect(string(cf.Cf("apps").Wait(Config.DefaultTimeoutDuration()).Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(stopped)", workerProcess.Name)))
 
-			usageEvents = LastPageUsageEvents(TestSetup)
-			event1 = AppUsageEvent{Entity{ProcessType: webProcess.Type, AppGuid: webProcess.Guid, State: "STOPPED", ParentAppGuid: appGuid, ParentAppName: appName}}
-			event2 = AppUsageEvent{Entity{ProcessType: workerProcess.Type, AppGuid: workerProcess.Guid, State: "STOPPED", ParentAppGuid: appGuid, ParentAppName: appName}}
+			usageEvents = UsageEventsAfterGuid(TestSetup, lastUsageEventGuid)
+			event1 = AppUsageEvent{Entity: Entity{ProcessType: webProcess.Type, AppGuid: webProcess.Guid, State: "STOPPED", ParentAppGuid: appGuid, ParentAppName: appName}}
+			event2 = AppUsageEvent{Entity: Entity{ProcessType: workerProcess.Type, AppGuid: workerProcess.Guid, State: "STOPPED", ParentAppGuid: appGuid, ParentAppName: appName}}
 			Expect(UsageEventsInclude(usageEvents, event1)).To(BeTrue())
 			Expect(UsageEventsInclude(usageEvents, event2)).To(BeTrue())
 
@@ -126,6 +128,7 @@ var _ = V3Describe("v3 buildpack app lifecycle", func() {
 
 			CreateAndMapRoute(appGuid, TestSetup.RegularUserContext().Space, Config.GetAppsDomain(), webProcess.Name)
 
+			lastUsageEventGuid := LastAppUsageEventGuid(TestSetup)
 			StartApp(appGuid)
 
 			Eventually(func() string {
@@ -134,17 +137,17 @@ var _ = V3Describe("v3 buildpack app lifecycle", func() {
 
 			Expect(string(cf.Cf("apps").Wait(Config.DefaultTimeoutDuration()).Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(started)", webProcess.Name)))
 
-			usageEvents := LastPageUsageEvents(TestSetup)
+			usageEvents := UsageEventsAfterGuid(TestSetup, lastUsageEventGuid)
 
-			event1 := AppUsageEvent{Entity{ProcessType: webProcess.Type, AppGuid: webProcess.Guid, State: "STARTED", ParentAppGuid: appGuid, ParentAppName: appName}}
+			event1 := AppUsageEvent{Entity: Entity{ProcessType: webProcess.Type, AppGuid: webProcess.Guid, State: "STARTED", ParentAppGuid: appGuid, ParentAppName: appName}}
 			Expect(UsageEventsInclude(usageEvents, event1)).To(BeTrue())
 
 			StopApp(appGuid)
 
 			Expect(string(cf.Cf("apps").Wait(Config.DefaultTimeoutDuration()).Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(stopped)", webProcess.Name)))
 
-			usageEvents = LastPageUsageEvents(TestSetup)
-			event1 = AppUsageEvent{Entity{ProcessType: webProcess.Type, AppGuid: webProcess.Guid, State: "STOPPED", ParentAppGuid: appGuid, ParentAppName: appName}}
+			usageEvents = UsageEventsAfterGuid(TestSetup, lastUsageEventGuid)
+			event1 = AppUsageEvent{Entity: Entity{ProcessType: webProcess.Type, AppGuid: webProcess.Guid, State: "STOPPED", ParentAppGuid: appGuid, ParentAppName: appName}}
 			Expect(UsageEventsInclude(usageEvents, event1)).To(BeTrue())
 
 			Eventually(func() string {
@@ -199,6 +202,7 @@ var _ = V3Describe("v3 docker app lifecycle", func() {
 
 		CreateAndMapRoute(appGuid, TestSetup.RegularUserContext().Space, Config.GetAppsDomain(), webProcess.Name)
 
+		lastUsageEventGuid := LastAppUsageEventGuid(TestSetup)
 		StartApp(appGuid)
 
 		Eventually(func() string {
@@ -210,17 +214,17 @@ var _ = V3Describe("v3 docker app lifecycle", func() {
 		Expect(output).To(ContainSubstring(appCreationEnvironmentVariables))
 
 		Expect(string(cf.Cf("apps").Wait(Config.DefaultTimeoutDuration()).Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(started)", webProcess.Name)))
-		usageEvents := LastPageUsageEvents(TestSetup)
+		usageEvents := UsageEventsAfterGuid(TestSetup, lastUsageEventGuid)
 
-		event := AppUsageEvent{Entity{ProcessType: webProcess.Type, AppGuid: webProcess.Guid, State: "STARTED", ParentAppGuid: appGuid, ParentAppName: appName}}
+		event := AppUsageEvent{Entity: Entity{ProcessType: webProcess.Type, AppGuid: webProcess.Guid, State: "STARTED", ParentAppGuid: appGuid, ParentAppName: appName}}
 		Expect(UsageEventsInclude(usageEvents, event)).To(BeTrue())
 
 		StopApp(appGuid)
 
 		Expect(string(cf.Cf("apps").Wait(Config.DefaultTimeoutDuration()).Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(stopped)", webProcess.Name)))
 
-		usageEvents = LastPageUsageEvents(TestSetup)
-		event = AppUsageEvent{Entity{ProcessType: webProcess.Type, AppGuid: webProcess.Guid, State: "STOPPED", ParentAppGuid: appGuid, ParentAppName: appName}}
+		usageEvents = UsageEventsAfterGuid(TestSetup, lastUsageEventGuid)
+		event = AppUsageEvent{Entity: Entity{ProcessType: webProcess.Type, AppGuid: webProcess.Guid, State: "STOPPED", ParentAppGuid: appGuid, ParentAppName: appName}}
 		Expect(UsageEventsInclude(usageEvents, event)).To(BeTrue())
 
 		Eventually(func() string {


### PR DESCRIPTION
When querying for recent app usage events, follow pages so that we
won't miss an event due to high activity.

[#139323913](https://www.pivotaltracker.com/story/show/139323913)

Addresses issue #184 and pr #175

Signed-off-by: Aakash Shah <ashah@pivotal.io>