### PR TITLE
test syslog drain for matching regex

### DIFF
--- a/apps/syslog_drain.go
+++ b/apps/syslog_drain.go
@@ -76,14 +76,13 @@ var _ = AppsDescribe("Logging", func() {
 func getSyslogDrainAddress(appName string) string {
 	var address []byte
 
-	Eventually(func() []byte {
+	Eventually(func() [][]byte {
 		re, err := regexp.Compile("ADDRESS: \\|(.*)\\|")
 		Expect(err).NotTo(HaveOccurred())
 
 		logs := cf.Cf("logs", appName, "--recent").Wait(Config.DefaultTimeoutDuration())
-		address = re.FindSubmatch(logs.Out.Contents())[1]
-		return address
-	}, Config.DefaultTimeoutDuration()).Should(Not(BeNil()))
+		return re.FindSubmatch(logs.Out.Contents())
+	}, Config.DefaultTimeoutDuration()).Should(HaveLen(2))
 
 	return string(address)
 }


### PR DESCRIPTION
The test would always blow up if the first `cf logs --recent` did not match the regex. This ensures that `Eventually` will continue and fail gracefully.

Signed off by: Eno Compton <ecompton@pivotal.io>