### PR TITLE
If the logs don't contain a match for `ADDRESS: ` regex, it panics

### DIFF
--- a/apps/syslog_drain.go
+++ b/apps/syslog_drain.go
@@ -1,6 +1,7 @@
 package apps
 
 import (
+	"fmt"
 	"regexp"
 	"time"
 
@@ -81,7 +82,9 @@ func getSyslogDrainAddress(appName string) string {
 		Expect(err).NotTo(HaveOccurred())
 
 		logs := cf.Cf("logs", appName, "--recent").Wait(Config.DefaultTimeoutDuration())
-		address = re.FindSubmatch(logs.Out.Contents())[1]
+		addressMatch := re.FindSubmatch(logs.Out.Contents())
+		Expect(addressMatch).ToNot(BeNil(), fmt.Sprintf("Expected logs to contain the syslog drain address matching pattern '%s' but it did not", re.String()))
+		address = addressMatch[1]
 		return address
 	}, Config.DefaultTimeoutDuration()).Should(Not(BeNil()))
 


### PR DESCRIPTION
Fixes error:
```
[apps] Logging
/go/src/github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers/cats_suite_helpers.go:38
  Syslog drains
  /go/src/github.com/cloudfoundry/cf-acceptance-tests/apps/syslog_drain.go:73
    forwards app messages to registered syslog drains [It]
    /go/src/github.com/cloudfoundry/cf-acceptance-tests/apps/syslog_drain.go:72

    Test Panicked
    runtime error: index out of range
    /usr/local/go/src/runtime/panic.go:458

    Full Stack Trace
      /usr/local/go/src/runtime/panic.go:458 +0x243
    github.com/cloudfoundry/cf-acceptance-tests/apps.getSyslogDrainAddress.func1(0x0, 0x0, 0x0)
      /go/src/github.com/cloudfoundry/cf-acceptance-tests/apps/syslog_drain.go:84 +0x311
```

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>