### PR TITLE
Tests assertions are now compatible with different CF CLI versions

### DIFF
--- a/apps/loggregator.go
+++ b/apps/loggregator.go
@@ -68,7 +68,7 @@ var _ = AppsDescribe("loggregator", func() {
 		})
 
 		It("exercises basic loggregator behavior", func() {
-			Eventually(logs, (Config.DefaultTimeoutDuration() + time.Minute)).Should(Say("Connected, tailing logs for app"))
+			Eventually(logs, (Config.DefaultTimeoutDuration() + time.Minute)).Should(Say("(Connected, tailing|Retrieving) logs for app"))
 
 			Eventually(func() string {
 				return helpers.CurlApp(Config, appName, fmt.Sprintf("/log/sleep/%d", hundredthOfOneSecond))

--- a/isolation_segments/isolation_segments.go
+++ b/isolation_segments/isolation_segments.go
@@ -245,7 +245,7 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 					"-d",
 					fmt.Sprintf(`{"data":{"guid":"%s"}}`, isoSegGuid)).Wait(Config.DefaultTimeoutDuration())
 				Expect(session).To(Exit(0))
-				Expect(session).To(Say("Ensure it has been entitled to this organization"))
+				Expect(session).To(Say("Ensure it has been entitled to the|this organization"))
 			})
 		})
 	})


### PR DESCRIPTION
The CLI Team recently introduced a regression in the CATs tests. This PR updates the assertions such that they are backwards compatible with different cf cli versions.