### PR TITLE
[#143441987] Add configurable cleanup of persistent app org

### DIFF
--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/cloudfoundry/cf-acceptance-tests/tasks"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/v3"
 
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
 	. "github.com/cloudfoundry/cf-acceptance-tests/helpers/buildpacks"
@@ -85,6 +86,11 @@ func TestCATS(t *testing.T) {
 	AfterSuite(func() {
 		if TestSetup != nil {
 			TestSetup.Teardown()
+		}
+		if Config.GetCleanupPersistentAppOrg() {
+			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+				cf.Cf("delete-org", Config.GetPersistentAppOrg(), "-f").Wait(Config.DefaultTimeoutDuration())
+			})
 		}
 	})
 

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -47,6 +47,7 @@ type CatsConfig interface {
 	GetPersistentAppOrg() string
 	GetPersistentAppQuotaName() string
 	GetPersistentAppSpace() string
+	GetCleanupPersistentAppOrg() bool
 	GetRubyBuildpackName() string
 	Protocol() string
 

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -30,10 +30,11 @@ type config struct {
 
 	ConfigurableTestPassword *string `json:"test_password"`
 
-	PersistentAppHost      *string `json:"persistent_app_host"`
-	PersistentAppOrg       *string `json:"persistent_app_org"`
-	PersistentAppQuotaName *string `json:"persistent_app_quota_name"`
-	PersistentAppSpace     *string `json:"persistent_app_space"`
+	PersistentAppHost       *string `json:"persistent_app_host"`
+	PersistentAppOrg        *string `json:"persistent_app_org"`
+	PersistentAppQuotaName  *string `json:"persistent_app_quota_name"`
+	PersistentAppSpace      *string `json:"persistent_app_space"`
+	CleanupPersistentAppOrg *bool   `json:"cleanup_persistent_app_org"`
 
 	IsolationSegmentName *string `json:"isolation_segment_name"`
 
@@ -107,6 +108,7 @@ func getDefaults() config {
 	defaults.PersistentAppOrg = ptrToString("CATS-persistent-org")
 	defaults.PersistentAppQuotaName = ptrToString("CATS-persistent-quota")
 	defaults.PersistentAppSpace = ptrToString("CATS-persistent-space")
+	defaults.CleanupPersistentAppOrg = ptrToBool(false)
 
 	defaults.IsolationSegmentName = ptrToString("")
 
@@ -518,11 +520,16 @@ func (c *config) GetArtifactsDirectory() string {
 func (c *config) GetPersistentAppSpace() string {
 	return *c.PersistentAppSpace
 }
+
 func (c *config) GetPersistentAppOrg() string {
 	return *c.PersistentAppOrg
 }
+
 func (c *config) GetPersistentAppQuotaName() string {
 	return *c.PersistentAppQuotaName
+}
+func (c *config) GetCleanupPersistentAppOrg() bool {
+	return *c.CleanupPersistentAppOrg
 }
 
 func (c *config) GetIsolationSegmentName() string {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -43,7 +43,8 @@ type testConfig struct {
 	SleepTimeout                 *int `json:"sleep_timeout,omitempty"`
 
 	// optional
-	Backend *string `json:"backend,omitempty"`
+	Backend                 *string `json:"backend,omitempty"`
+	CleanupPersistentAppOrg *bool   `json:"cleanup_persistent_app_org"`
 }
 
 type allConfig struct {
@@ -186,6 +187,7 @@ var _ = Describe("Config", func() {
 		Expect(config.GetPersistentAppOrg()).To(Equal("CATS-persistent-org"))
 		Expect(config.GetPersistentAppQuotaName()).To(Equal("CATS-persistent-quota"))
 		Expect(config.GetPersistentAppSpace()).To(Equal("CATS-persistent-space"))
+		Expect(config.GetCleanupPersistentAppOrg()).To(Equal(false))
 
 		Expect(config.GetIsolationSegmentName()).To(Equal(""))
 
@@ -318,6 +320,7 @@ var _ = Describe("Config", func() {
 			testCfg.AsyncServiceOperationTimeout = ptrToInt(90)
 			testCfg.DetectTimeout = ptrToInt(100)
 			testCfg.SleepTimeout = ptrToInt(101)
+			testCfg.CleanupPersistentAppOrg = ptrToBool(true)
 		})
 
 		It("respects the overriden values", func() {
@@ -331,6 +334,7 @@ var _ = Describe("Config", func() {
 			Expect(config.AsyncServiceOperationTimeoutDuration()).To(Equal(90 * time.Minute))
 			Expect(config.DetectTimeoutDuration()).To(Equal(100 * time.Minute))
 			Expect(config.SleepTimeoutDuration()).To(Equal(101 * time.Second))
+			Expect(config.GetCleanupPersistentAppOrg()).To(Equal(true))
 		})
 	})
 


### PR DESCRIPTION
I'm proposing the following configuration flag to enable cleanup of persistent app org at the end of CATs runs for [this story](https://www.pivotaltracker.com/story/show/143441987).  