### PR TITLE
Increase large payload test from 5kB to 200kB

### DIFF
--- a/apps/large_payload.go
+++ b/apps/large_payload.go
@@ -18,6 +18,7 @@ import (
 )
 
 var _ = AppsDescribe("Large_payload", func() {
+	const payloadSize = 200
 	var appName string
 	AfterEach(func() {
 		app_helpers.AppReport(appName, Config.DefaultTimeoutDuration())
@@ -31,8 +32,8 @@ var _ = AppsDescribe("Large_payload", func() {
 		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 		Eventually(func() int {
-			curlResponse := helpers.CurlApp(Config, appName, fmt.Sprintf("/largetext/5"))
+			curlResponse := helpers.CurlApp(Config, appName, fmt.Sprintf("/largetext/%d", payloadSize))
 			return len(curlResponse)
-		}, 10*time.Second, 10*time.Second).Should(Equal(5 * 1024))
+		}, 10*time.Second, 10*time.Second).Should(Equal(payloadSize * 1024))
 	})
 })


### PR DESCRIPTION
I can no longer see the referenced story, but from 34d1c48 it looks like the
original intention of this test was highlight problems delivering large
responses from CF applications caused by MTU misconfiguration.

We recently experienced a problem like this which has been described in
cloudfoundry/guardian#77. This test passed because the response size of 5kB
was smaller than the MTU size of 9kB on some AWS instance types:

- http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/network_mtu.html#jumbo_frame_instances

Increasing this to a larger value will make the test more effective. I've
chosen a value of 200kB because it's larger than standard MTUs and
indicative of the response from an average website.