### PR TITLE
Update go fixture apps to use default go version

### DIFF
--- a/apps/healthcheck.go
+++ b/apps/healthcheck.go
@@ -10,6 +10,8 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
 
+	"path/filepath"
+
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
@@ -37,6 +39,7 @@ var _ = AppsDescribe("Healthcheck", func() {
 			Eventually(cf.Cf(
 				"push", appName,
 				"-p", assets.NewAssets().WorkerApp,
+				"-f", filepath.Join(assets.NewAssets().WorkerApp, "manifest.yml"),
 				"--no-start",
 				"-b", "go_buildpack",
 				"-m", DEFAULT_MEMORY_LIMIT,

--- a/apps/routing_transparency.go
+++ b/apps/routing_transparency.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
+	"path/filepath"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
@@ -23,6 +24,7 @@ var _ = AppsDescribe("Routing Transparency", func() {
 			"--no-start",
 			"-b", Config.GetGoBuildpackName(),
 			"-p", assets.NewAssets().Golang,
+			"-f", filepath.Join(assets.NewAssets().Golang, "manifest.yml"),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		app_helpers.SetBackend(appName)

--- a/assets/golang/Godeps/Godeps.json
+++ b/assets/golang/Godeps/Godeps.json
@@ -1,5 +1,0 @@
-{
-	"ImportPath": "go-online",
-	"GoVersion": "go1.7",
-	"Deps": []
-}

--- a/assets/golang/Procfile
+++ b/assets/golang/Procfile
@@ -1,1 +1,0 @@
-web: go-online

--- a/assets/golang/manifest.yml
+++ b/assets/golang/manifest.yml
@@ -1,0 +1,4 @@
+---
+applications:
+- env:
+    GOPACKAGENAME: go-online

--- a/assets/multi-port-app/Godeps/Godeps.json
+++ b/assets/multi-port-app/Godeps/Godeps.json
@@ -1,5 +1,0 @@
-{
-	"ImportPath": "go-online",
-	"GoVersion": "go1.7",
-	"Deps": []
-}

--- a/assets/multi-port-app/Procfile
+++ b/assets/multi-port-app/Procfile
@@ -1,1 +1,0 @@
-web: go-online

--- a/assets/multi-port-app/manifest.yml
+++ b/assets/multi-port-app/manifest.yml
@@ -1,0 +1,4 @@
+---
+applications:
+- env:
+    GOPACKAGENAME: go-online

--- a/assets/syslog-drain-listener/manifest.yml
+++ b/assets/syslog-drain-listener/manifest.yml
@@ -2,5 +2,4 @@
 applications:
 - name: syslog-drain-listener
   env:
-    GOVERSION: go1.6
     GOPACKAGENAME: main

--- a/assets/worker-app/Godeps/Godeps.json
+++ b/assets/worker-app/Godeps/Godeps.json
@@ -1,5 +1,0 @@
-{
-	"ImportPath": "go-online",
-	"GoVersion": "go1.7",
-	"Deps": []
-}

--- a/assets/worker-app/Procfile
+++ b/assets/worker-app/Procfile
@@ -1,1 +1,0 @@
-web: go-online

--- a/assets/worker-app/manifest.yml
+++ b/assets/worker-app/manifest.yml
@@ -1,0 +1,4 @@
+---
+applications:
+- env:
+    GOPACKAGENAME: go-online

--- a/detect/buildpacks.go
+++ b/detect/buildpacks.go
@@ -1,6 +1,7 @@
 package detect
 
 import (
+	"path/filepath"
 	"time"
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
@@ -68,7 +69,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 
 	Describe("golang", func() {
 		It("makes the app reachable via its bound route", func() {
-			Expect(cf.Cf("push", appName, "--no-start", "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Golang, "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+			Expect(cf.Cf("push", appName, "--no-start", "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Golang, "-f", filepath.Join(assets.NewAssets().Golang, "manifest.yml"), "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 			app_helpers.SetBackend(appName)
 			Expect(cf.Cf("start", appName).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
 

--- a/route_services/route_services.go
+++ b/route_services/route_services.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"path/filepath"
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 
@@ -50,11 +51,13 @@ var _ = RouteServicesDescribe("Route Services", func() {
 				createServiceBroker(brokerName, brokerAppName, serviceName)
 				createServiceInstance(serviceInstanceName, serviceName)
 
-				PushAppNoStart(appName, golangAsset, Config.GetGoBuildpackName(), Config.GetAppsDomain(), Config.CfPushTimeoutDuration(), DEFAULT_MEMORY_LIMIT)
+				PushAppNoStart(appName, golangAsset, Config.GetGoBuildpackName(), Config.GetAppsDomain(), Config.CfPushTimeoutDuration(), DEFAULT_MEMORY_LIMIT, "-f", filepath.Join(golangAsset, "manifest.yml"))
 				EnableDiego(appName, Config.DefaultTimeoutDuration())
 				StartApp(appName, Config.CfPushTimeoutDuration())
 
-				PushApp(routeServiceName, loggingRouteServiceAsset, Config.GetGoBuildpackName(), Config.GetAppsDomain(), Config.CfPushTimeoutDuration(), DEFAULT_MEMORY_LIMIT)
+				PushAppNoStart(routeServiceName, loggingRouteServiceAsset, Config.GetGoBuildpackName(), Config.GetAppsDomain(), Config.CfPushTimeoutDuration(), DEFAULT_MEMORY_LIMIT, "-f", filepath.Join(loggingRouteServiceAsset, "manifest.yml"))
+				SetBackend(routeServiceName, Config.CfPushTimeoutDuration())
+				StartApp(routeServiceName, Config.CfPushTimeoutDuration())
 				configureBroker(brokerAppName, routeServiceName)
 
 				bindRouteToService(appName, serviceInstanceName)
@@ -100,7 +103,7 @@ var _ = RouteServicesDescribe("Route Services", func() {
 				createServiceBroker(brokerName, brokerAppName, serviceName)
 				createServiceInstance(serviceInstanceName, serviceName)
 
-				PushAppNoStart(appName, golangAsset, Config.GetGoBuildpackName(), Config.GetAppsDomain(), Config.CfPushTimeoutDuration(), DEFAULT_MEMORY_LIMIT)
+				PushAppNoStart(appName, golangAsset, Config.GetGoBuildpackName(), Config.GetAppsDomain(), Config.CfPushTimeoutDuration(), DEFAULT_MEMORY_LIMIT, "-f", filepath.Join(golangAsset, "manifest.yml"))
 				EnableDiego(appName, Config.DefaultTimeoutDuration())
 				StartApp(appName, Config.CfPushTimeoutDuration())
 

--- a/routing/multiple_app_ports.go
+++ b/routing/multiple_app_ports.go
@@ -5,6 +5,8 @@ import (
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 
+	"path/filepath"
+
 	. "code.cloudfoundry.org/cf-routing-test-helpers/helpers"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
@@ -28,7 +30,7 @@ var _ = RoutingDescribe("Multiple App Ports", func() {
 		app = random_name.CATSRandomName("APP")
 		cmd := fmt.Sprintf("go-online --ports=7777,8888,8080")
 
-		PushAppNoStart(app, multiPortAppAsset, Config.GetGoBuildpackName(), Config.GetAppsDomain(), Config.CfPushTimeoutDuration(), DEFAULT_MEMORY_LIMIT, "-c", cmd)
+		PushAppNoStart(app, multiPortAppAsset, Config.GetGoBuildpackName(), Config.GetAppsDomain(), Config.CfPushTimeoutDuration(), DEFAULT_MEMORY_LIMIT, "-c", cmd, "-f", filepath.Join(multiPortAppAsset, "manifest.yml"))
 		EnableDiego(app, Config.DefaultTimeoutDuration())
 		StartApp(app, APP_START_TIMEOUT)
 	})


### PR DESCRIPTION
- by using go native vendoring and not specifying GOVERSION, the go
buildpack will use the default version of Go. This should future-proof
these fixtures against versions of Go being removed from the buildpack

[#142416247]

Signed-off-by: Anna Thornton <athornton@pivotal.io>
Signed-off-by: Nikita Rathi <nrathi@pivotal.io>