### PR TITLE
Add tests for apps and tasks based on private docker registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ cat > integration_config.json <<EOF
   "include_detect": true,
   "include_docker": false,
   "include_internet_dependent": false,
+  "include_private_docker_registry": false,
   "include_privileged_container_support": false,
   "include_route_services": false,
   "include_routing": true,
@@ -120,6 +121,7 @@ export CONFIG=$PWD/integration_config.json
 * `include_detect`: Flag to include tests in the detect group.
 * `include_docker`: Flag to include tests related to running Docker apps on Diego. Diego must be deployed and the CC API docker_diego feature flag must be enabled for these tests to pass.
 * `include_internet_dependent`: Flag to include tests that require the deployment to have internet access.
+* `include_private_docker_registry`: Flag to run tests that rely on a private docker image. [See below](#private-docker).
 * `include_persistent_app`: Flag to run tests in `one_push_many_restarts_test.go`.
 * `include_privileged_container_support`: Flag to include privileged container tests. Requires capi.nsync.diego_privileged_containers and capi.stager.diego_privileged_containers to be enabled for tests to pass.
 * `include_route_services`: Flag to include the route services tests. Diego must be deployed for these tests to pass.
@@ -153,6 +155,10 @@ export CONFIG=$PWD/integration_config.json
 * `test_password`: Used to set the password for the test user. This may be needed if your CF installation has password policies.
 * `timeout_scale`: Used primarily to scale default timeouts for test setup and teardown actions (e.g. creating an org) as opposed to main test actions (e.g. pushing an app).
 * `isolation_segment_name`: Name of the isolation segment to use for the isolation segments test.
+* `private_docker_registry_image`: Name of the private docker image to use when testing private docker registries. [See below](#private-docker)
+* `private_docker_registry_username`: Username to access the private docker repository. [See below](#private-docker)
+* `private_docker_registry_password`: Password to access the private docker repository. [See below](#private-docker)
+
 * `staticfile_buildpack_name` [See below](#buildpack-names).
 * `java_buildpack_name` [See below](#buildpack-names).
 * `ruby_buildpack_name` [See below](#buildpack-names).
@@ -194,6 +200,23 @@ properties:
           destination: IP_OF_YOUR_LOAD_BALANCER # (e.g. 10.244.0.34 for a standard deployment of Cloud Foundry on BOSH-Lite)
     default_running_security_groups: ["load_balancer"]
 ```
+
+#### Private Docker
+To run tests that exercise the use of credentials to access a private docker registry, the `include_private_docker_registry` flag must be true, and the following config values must be provided:
+
+* `private_docker_registry_image`
+* `private_docker_registry_username`
+* `private_docker_registry_password`
+
+These tests assume that the specified private docker image is a private version of the cloudfoundry/diego-docker-app-custom:latest. To upload a private version to your DockerHub account, first create a private repository on DockerHub and log in to docker on the command line. Then run the following commands:
+
+```bash
+docker pull cloudfoundry/diego-docker-app-custom:latest
+docker tag cloudfoundry/diego-docker-app-custom:latest <your-private-repo>:<some-tag>
+docker push <your-private-repo>:<some-tag>
+```
+
+The value for the `private_docker_registry_image` config value in this case would be "<your-private-repo>:<some-tag>".
 
 #### Capturing Test Output
 When a test fails, look for the test group name (`[services]` in the example below) in the test output:

--- a/docker/private_docker_lifecycle.go
+++ b/docker/private_docker_lifecycle.go
@@ -1,0 +1,136 @@
+// +build !noInternet,!noDocker
+
+package docker
+
+import (
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/commandreporter"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = DockerDescribe("Private Docker Registry Application Lifecycle", func() {
+	var (
+		appName  string
+		username string
+		password string
+	)
+
+	type dockerCreds struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+
+	type createAppRequest struct {
+		Name              string      `json:"name"`
+		SpaceGuid         string      `json:"space_guid"`
+		DockerImage       string      `json:"docker_image"`
+		DockerCredentials dockerCreds `json:"docker_credentials"`
+	}
+
+	BeforeEach(func() {
+		if Config.GetBackend() != "diego" {
+			Skip(skip_messages.SkipDiegoMessage)
+		}
+
+		if !Config.GetIncludePrivateDockerRegistry() {
+			Skip(skip_messages.SkipPrivateDockerRegistryMessage)
+		}
+	})
+
+	JustBeforeEach(func() {
+		spaceName := TestSetup.RegularUserContext().Space
+		session := cf.Cf("space", spaceName, "--guid")
+		Eventually(session, Config.DefaultTimeoutDuration()).Should(Exit(0))
+		spaceGuid := string(session.Out.Contents())
+		spaceGuid = strings.TrimSpace(spaceGuid)
+		appName = random_name.CATSRandomName("APP")
+
+		newAppRequest, err := json.Marshal(createAppRequest{
+			Name:        appName,
+			SpaceGuid:   spaceGuid,
+			DockerImage: Config.GetPrivateDockerRegistryImage(),
+			DockerCredentials: dockerCreds{
+				Username: username,
+				Password: password,
+			}})
+
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd := exec.Command("cf", "curl", "-X", "POST", "/v2/apps", "-d", string(newAppRequest))
+		cfCurlSession, err := Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Redact the docker password from the test logs
+		cmd.Args[6] = strings.Replace(cmd.Args[6], `"password":"`+password+`"`, `"password":"***"`, 1)
+		reporter := commandreporter.NewCommandReporter()
+		reporter.Report(time.Now(), cmd)
+
+		Eventually(cfCurlSession).Should(Exit(0))
+	})
+
+	AfterEach(func() {
+		app_helpers.AppReport(appName, Config.DefaultTimeoutDuration())
+		Eventually(cf.Cf("delete", appName, "-f"), Config.DefaultTimeoutDuration()).Should(Exit(0))
+	})
+
+	Context("when the correct username and password are given", func() {
+		BeforeEach(func() {
+			username = Config.GetPrivateDockerRegistryUsername()
+			password = Config.GetPrivateDockerRegistryPassword()
+		})
+
+		It("starts the docker app successfully", func() {
+			Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
+			Eventually(cf.Cf("map-route", appName, Config.GetAppsDomain(), "--hostname", appName), Config.DefaultTimeoutDuration()).Should(Exit(0))
+			Eventually(func() string {
+				return helpers.CurlApp(Config, appName, "/env/INSTANCE_INDEX")
+			}, Config.DefaultTimeoutDuration()).Should(Equal("0"))
+		})
+
+		It("can run a task", func() {
+			Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
+			taskName := appName + "-task"
+			createCommand := cf.Cf("run-task", appName, "exit 0", "--name", taskName).Wait(Config.DefaultTimeoutDuration())
+			Expect(createCommand).To(Exit(0))
+			Eventually(func() string {
+				listCommand := cf.Cf("tasks", appName).Wait(Config.DefaultTimeoutDuration())
+				Expect(listCommand).To(Exit(0))
+				listOutput := string(listCommand.Out.Contents())
+				lines := strings.Split(listOutput, "\n")
+				if len(lines) != 6 {
+					return ""
+				}
+
+				fields := strings.Fields(lines[4])
+				Expect(fields[1]).To(Equal(taskName))
+				return fields[2]
+			}, Config.DefaultTimeoutDuration(), 2*time.Second).Should(Equal("SUCCEEDED"))
+		})
+	})
+
+	Context("when the correct username and password are not given", func() {
+		BeforeEach(func() {
+			username = Config.GetPrivateDockerRegistryUsername() + "wrong"
+			password = Config.GetPrivateDockerRegistryPassword() + "wrong"
+		})
+
+		It("does not start the docker app successfully", func() {
+			session := cf.Cf("start", appName)
+			Eventually(session, Config.CfPushTimeoutDuration()).Should(Exit(1))
+			Expect(session).To(gbytes.Say("401 Unauthorized"))
+		})
+	})
+})

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -11,6 +11,7 @@ type CatsConfig interface {
 	GetIncludeDetect() bool
 	GetIncludeDocker() bool
 	GetIncludeInternetDependent() bool
+	GetIncludePrivateDockerRegistry() bool
 	GetIncludePersistentApp() bool
 	GetIncludePrivilegedContainerSupport() bool
 	GetIncludeRouteServices() bool
@@ -44,6 +45,9 @@ type CatsConfig interface {
 	GetJavaBuildpackName() string
 	GetNamePrefix() string
 	GetNodejsBuildpackName() string
+	GetPrivateDockerRegistryImage() string
+	GetPrivateDockerRegistryUsername() string
+	GetPrivateDockerRegistryPassword() string
 	GetPersistentAppHost() string
 	GetPersistentAppOrg() string
 	GetPersistentAppQuotaName() string

--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -13,6 +13,9 @@ const SkipDockerMessage string = `Skipping this test because config.IncludeDocke
 NOTE: Ensure Docker containers are enabled on your platform before enabling this test.`
 const SkipInternetDependentMessage string = `Skipping this test because config.IncludeInternetDependent is set to 'false'.
 NOTE: Ensure that your platform has access to the internet before running this test.`
+const SkipPrivateDockerRegistryMessage string = `Skipping this test because config.IncludePrivateDockerRegistry is set to 'false'.
+NOTE: Ensure that you've provided values for config.PrivateDockerRegistryImage, config.PrivateDockerRegistryUsername,
+and config.PrivateDockerRegistryPassword before running this test.`
 const SkipPersistentAppMessage string = `Skipping this test because config.IncludePersistentApp is set to 'false'.`
 const SkipPrivilegedContainerSupportMessage string = `Skipping this test because Config.IncludePrivilegedContainerSupport is set to 'false'.
 NOTE: Ensure privileged containers are allowed on your platform before enabling this test.`


### PR DESCRIPTION
- Values for the image, username, and password must be provided
in the integration config to run these new tests.

[#144962927](https://www.pivotaltracker.com/story/show/144962927)

@jenspinney and @tcdowney