### PR TITLE
Redact private_docker_registry image and username

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -8,7 +8,7 @@ if [ ! -f "${CONFIG}" ]; then
 fi
 
 echo "Printing sanitized \$CONFIG"
-grep -v password $CONFIG
+grep -v -e password -e private_docker_registry_ $CONFIG
 
 bin_dir=$(dirname "${BASH_SOURCE[0]}")
 project_go_root="${bin_dir}/../../../../../"


### PR DESCRIPTION
- current grep only removes password lines
- this grep still displays `include_private_docker_registry`

[#144962927]

Signed-off-by: Michael Xu <mxu@pivotal.io>