### PR TITLE
backend compatibility test no longer requires DEAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ You can of course combine the `-v` flag with the `-nodes=N` flag.
 Test Group Name| Compatable Backend | Description
 --- | --- | ---
 `apps`| DEA or Diego | Tests the core functionalities of Cloud Foundry: staging, running, logging, routing, buildpacks, etc.  This test group should always pass against a sound Cloud Foundry deployment.
-`backend_compatibility` | DEA and Diego are required simultaneously| Tests interoperability of droplets staged on Diego or the DEAs
+`backend_compatibility` | Diego | Tests interoperability of droplets staged on the DEAs running on Diego
 `detect` | DEA or Diego | Tests the ability of the platform to detect the correct buildpack for compiling an application if no buildpack is explicitly specified.
 `docker`| Diego |Test our ability to run docker containers on diego and that we handle docker metadata correctly.
 `internet_dependent`| DEA or Diego | This test group tests the feature of being able to specify a buildpack via a Github URL.  As such, this depends on your Cloud Foundry application containers having access to the Internet.  You should take into account the configuration of the network into which you've deployed your Cloud Foundry, as well as any security group settings applied to application containers.

--- a/backend_compatibility/backend_compatibility.go
+++ b/backend_compatibility/backend_compatibility.go
@@ -1,9 +1,14 @@
 package backend_compatibility
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
@@ -11,9 +16,8 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers"
 )
-
-const binaryHi = "Hello from a binary"
 
 var _ = BackendCompatibilityDescribe("Backend Compatibility", func() {
 	var appName string
@@ -22,12 +26,11 @@ var _ = BackendCompatibilityDescribe("Backend Compatibility", func() {
 		appName = random_name.CATSRandomName("APP")
 		Eventually(cf.Cf(
 			"push", appName,
-			"-p", assets.NewAssets().Binary,
+			"-p", assets.NewAssets().Dora,
 			"--no-start",
 			"-m", DEFAULT_MEMORY_LIMIT,
-			"-b", "binary_buildpack",
-			"-d", Config.GetAppsDomain(),
-			"-c", "./app"),
+			"-b", Config.GetRubyBuildpackName(),
+			"-d", Config.GetAppsDomain()),
 			Config.CfPushTimeoutDuration()).Should(Exit(0))
 	})
 
@@ -36,32 +39,39 @@ var _ = BackendCompatibilityDescribe("Backend Compatibility", func() {
 		Eventually(cf.Cf("delete", appName, "-f"), Config.DefaultTimeoutDuration()).Should(Exit(0))
 	})
 
-	Describe("An app staged on Diego", func() {
-		BeforeEach(func() {
-			app_helpers.EnableDiego(appName)
-
-			Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
-			Eventually(helpers.CurlingAppRoot(Config, appName), Config.DefaultTimeoutDuration()).Should(ContainSubstring(binaryHi))
-		})
-
-		It("runs on the DEAs", func() {
-			app_helpers.DisableDiego(appName)
-			Eventually(cf.Cf("restart", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
-			Eventually(helpers.CurlingAppRoot(Config, appName), Config.DefaultTimeoutDuration()).Should(ContainSubstring(binaryHi))
-		})
-	})
-
 	Describe("An app staged on the DEA", func() {
 		BeforeEach(func() {
-			app_helpers.DisableDiego(appName)
-			Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
-			Eventually(helpers.CurlingAppRoot(Config, appName), Config.DefaultTimeoutDuration()).Should(ContainSubstring(binaryHi))
+			guid := cf.Cf("app", appName, "--guid").Wait(Config.DefaultTimeoutDuration()).Out.Contents()
+			appGuid := strings.TrimSpace(string(guid))
+
+			By("Uploading a droplet staged on the DEA")
+			dropletPath := assets.NewAssets().DoraDroplet
+
+			token := v3_helpers.GetAuthToken()
+			uploadUrl := fmt.Sprintf("%s%s/v2/apps/%s/droplet/upload", Config.Protocol(), Config.GetApiEndpoint(), appGuid)
+			bits := fmt.Sprintf(`droplet=@%s`, dropletPath)
+			curl := helpers.Curl(Config, "-v", uploadUrl, "-X", "PUT", "-F", bits, "-H", fmt.Sprintf("Authorization: %s", token)).Wait(Config.DefaultTimeoutDuration())
+			Expect(curl).To(Exit(0))
+
+			var job struct {
+				Metadata struct {
+					Url string `json:"url"`
+				} `json:"metadata"`
+			}
+			bytes := curl.Out.Contents()
+			json.Unmarshal(bytes, &job)
+			pollingUrl := job.Metadata.Url
+
+			Eventually(func() *Session {
+				return cf.Cf("curl", pollingUrl).Wait(Config.DefaultTimeoutDuration())
+			}, Config.DefaultTimeoutDuration()).Should(gbytes.Say("finished"))
 		})
 
 		It("runs on Diego", func() {
-			app_helpers.EnableDiego(appName)
-			Eventually(cf.Cf("restart", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
-			Eventually(helpers.CurlingAppRoot(Config, appName), Config.DefaultTimeoutDuration()).Should(ContainSubstring(binaryHi))
+			Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
+			Eventually(func() string {
+				return helpers.CurlAppRoot(Config, appName)
+			}, Config.DefaultTimeoutDuration()).Should(ContainSubstring("Hi, I'm Dora!"))
 		})
 	})
 })

--- a/helpers/assets/assets.go
+++ b/helpers/assets/assets.go
@@ -3,6 +3,7 @@ package assets
 type Assets struct {
 	AsyncServiceBroker       string
 	Dora                     string
+	DoraDroplet              string
 	DoraZip                  string
 	DotnetCore               string
 	Fuse                     string
@@ -33,6 +34,7 @@ func NewAssets() Assets {
 	return Assets{
 		AsyncServiceBroker:       "assets/service_broker",
 		Dora:                     "assets/dora",
+		DoraDroplet:              "assets/dora-droplet.tar.gz",
 		DoraZip:                  "assets/dora.zip",
 		DotnetCore:               "assets/dotnet-core",
 		Fuse:                     "assets/fuse-mount",


### PR DESCRIPTION
* add dora-droplet.tar.gz asset which has been staged on a DEA
* remove test checking compatibility between a droplet staged on
  Diego -> DEAs
* do not use the binary asset, or a user specified start command: part
  of checking compatibility is to ensure that a start command parsed by
  staging on a DEA is usable on Diego
* update README.md

[#144070419]