### PR TITLE
Add routing isolation segment tests to CATS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tags
 results
 .idea
 .DS_Store
+logs

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ export CONFIG=$PWD/integration_config.json
 * `test_password`: Used to set the password for the test user. This may be needed if your CF installation has password policies.
 * `timeout_scale`: Used primarily to scale default timeouts for test setup and teardown actions (e.g. creating an org) as opposed to main test actions (e.g. pushing an app).
 * `isolation_segment_name`: Name of the isolation segment to use for the isolation segments test.
+* `isolation_segment_domain`: Domain that will route to the isolated router in the isolation segments test.
 * `private_docker_registry_image`: Name of the private docker image to use when testing private docker registries. [See below](#private-docker)
 * `private_docker_registry_username`: Username to access the private docker repository. [See below](#private-docker)
 * `private_docker_registry_password`: Password to access the private docker repository. [See below](#private-docker)
@@ -274,7 +275,7 @@ You can of course combine the `-v` flag with the `-nodes=N` flag.
 
 ## Explanation of Test Groups
 
-Test Group Name| Compatable Backend | Description
+Test Group Name| Compatible Backend | Description
 --- | --- | ---
 `apps`| DEA or Diego | Tests the core functionalities of Cloud Foundry: staging, running, logging, routing, buildpacks, etc.  This test group should always pass against a sound Cloud Foundry deployment.
 `backend_compatibility` | Diego | Tests interoperability of droplets staged on the DEAs running on Diego
@@ -287,7 +288,7 @@ Test Group Name| Compatable Backend | Description
 `services`| DEA or Diego | This test group tests various features related to services, e.g. registering a service broker via the service broker API.  Some of these tests exercise special integrations, such as Single Sign-On authentication; you may wish to run some tests in this package but selectively skip others if you haven't configured the required integrations.
 `ssh`| Diego |This test group tests our ability to communicate with Diego apps via ssh, scp, and sftp.
 `v3`| Diego| This test group contains tests for the next-generation v3 Cloud Controller API.  As of this writing, the v3 API is not officially supported.
-`isolation_segments` | Diego | This test group requires that Diego be deployed with a minimum of 2 cells. One of those cells must have been deployed with a `placement_tag`. Finally, the `isolation_segment_name` must be set in the CATs properties to match this placement tag.
+`isolation_segments` | Diego | This test group requires that Diego be deployed with a minimum of 2 cells. One of those cells must have been deployed with a `placement_tag`. Additionally, a minimum of two Gorouter instances must be deployed. One instance must be configured with the property `routing_table_sharding_mode: shared-and-segments`. The other instance must have the properties `routing_table_sharding_mode: segments` and `isolation_segments: [YOUR_PLACEMENT_TAG_HERE]`. The `isolation_segment_name` in the CATs properties must match the `placement_tag` and `isolation_segment`. Finally, the `isolation_segment_domain` must be set and traffic to that domain should go to the isolation router.
 
 ## Contributing
 

--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -48,6 +48,9 @@ func IsolationSegmentsDescribe(description string, callback func()) bool {
 			if Config.GetIsolationSegmentName() == "" {
 				Skip(`Skipping this test because Config.IsolationSegmentName is not set.`)
 			}
+			if Config.GetIsolationSegmentDomain() == "" {
+				Skip(`Skipping this test because Config.IsolationSegmentDomain is not set.`)
+			}
 		})
 		callback()
 	})

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -42,6 +42,7 @@ type CatsConfig interface {
 	GetExistingUserPassword() string
 	GetGoBuildpackName() string
 	GetIsolationSegmentName() string
+	GetIsolationSegmentDomain() string
 	GetJavaBuildpackName() string
 	GetNamePrefix() string
 	GetNodejsBuildpackName() string

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -35,7 +35,8 @@ type config struct {
 	PersistentAppQuotaName *string `json:"persistent_app_quota_name"`
 	PersistentAppSpace     *string `json:"persistent_app_space"`
 
-	IsolationSegmentName *string `json:"isolation_segment_name"`
+	IsolationSegmentName   *string `json:"isolation_segment_name"`
+	IsolationSegmentDomain *string `json:"isolation_segment_domain"`
 
 	Backend           *string `json:"backend"`
 	SkipSSLValidation *bool   `json:"skip_ssl_validation"`
@@ -115,6 +116,7 @@ func getDefaults() config {
 	defaults.PersistentAppSpace = ptrToString("CATS-persistent-space")
 
 	defaults.IsolationSegmentName = ptrToString("")
+	defaults.IsolationSegmentDomain = ptrToString("")
 
 	defaults.BinaryBuildpackName = ptrToString("binary_buildpack")
 	defaults.GoBuildpackName = ptrToString("go_buildpack")
@@ -590,6 +592,10 @@ func (c *config) GetPersistentAppQuotaName() string {
 
 func (c *config) GetIsolationSegmentName() string {
 	return *c.IsolationSegmentName
+}
+
+func (c *config) GetIsolationSegmentDomain() string {
+	return *c.IsolationSegmentDomain
 }
 
 func (c *config) GetNamePrefix() string {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -118,6 +118,7 @@ type allConfig struct {
 	IncludeV3                         *bool `json:"include_v3"`
 	IncludeZipkin                     *bool `json:"include_zipkin"`
 	IncludeIsolationSegments          *bool `json:"include_isolation_segments"`
+	IncludeRoutingIsolationSegments   *bool `json:"include_routing_isolation_segments"`
 
 	PrivateDockerRegistryImage    *string `json:"private_docker_registry_image"`
 	PrivateDockerRegistryUsername *string `json:"private_docker_registry_username"`
@@ -199,6 +200,7 @@ var _ = Describe("Config", func() {
 		Expect(config.GetPersistentAppSpace()).To(Equal("CATS-persistent-space"))
 
 		Expect(config.GetIsolationSegmentName()).To(Equal(""))
+		Expect(config.GetIsolationSegmentDomain()).To(Equal(""))
 
 		Expect(config.GetIncludeApps()).To(BeTrue())
 		Expect(config.GetIncludeDetect()).To(BeTrue())


### PR DESCRIPTION
See routing story https://www.pivotaltracker.com/story/show/143996443

- Add Routing Isolation Segment tests to existing Capi isolation segment
tests
- Cleaned up leaking tests (org entitlements, defaultIsoSegs)
- Add isolation_segment_domain config property
- Update Readme

Signed-off-by: Charles Hansen <chansen@pivotal.io>
Signed-off-by: Belinda Liu <bliu@pivotal.io>
Signed-off-by: Edwin Xie <exie@pivotal.io>