### PR TITLE
Refactor isolation segment test helpers

### DIFF
--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -44,10 +44,6 @@ func IsolationSegmentsDescribe(description string, callback func()) bool {
 			if !Config.GetIncludeIsolationSegments() {
 				Skip(`Skipping this test because Config.IncludeIsolationSegments is set to 'false'.`)
 			}
-
-			if Config.GetIsolationSegmentName() == "" {
-				Skip(`Skipping this test because Config.IsolationSegmentName is not set.`)
-			}
 		})
 		callback()
 	})

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -219,6 +219,11 @@ func validateConfig(config *config) Errors {
 		errs.Add(err)
 	}
 
+	err = validateIsolationSegments(config)
+	if err != nil {
+		errs.Add(err)
+	}
+
 	if config.UseHttp == nil {
 		errs.Add(fmt.Errorf("* 'use_http' must not be null"))
 	}
@@ -488,6 +493,24 @@ func validatePrivateDockerRegistry(config *config) error {
 		return fmt.Errorf("* Invalid configuration: 'private_docker_registry_password' must be provided if 'include_private_docker_registry' is true")
 	}
 
+	return nil
+}
+
+func validateIsolationSegments(config *config) error {
+	if config.IncludeIsolationSegments == nil {
+		return fmt.Errorf("* 'include_isolation_segments' must not be null")
+	}
+	if config.IsolationSegmentName == nil {
+		return fmt.Errorf("* 'isolation_segment_name' must not be null")
+	}
+
+	if !config.GetIncludeIsolationSegments() {
+		return nil
+	}
+
+	if config.GetIsolationSegmentName() == "" {
+		return fmt.Errorf("* Invalid configuration: 'isolation_segment_name' must be provided if 'include_isolation_segments' is true")
+	}
 	return nil
 }
 

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -50,6 +50,9 @@ type testConfig struct {
 	PrivateDockerRegistryImage    *string `json:"private_docker_registry_image,omitempty"`
 	PrivateDockerRegistryUsername *string `json:"private_docker_registry_username,omitempty"`
 	PrivateDockerRegistryPassword *string `json:"private_docker_registry_password,omitempty"`
+
+	IncludeIsolationSegments *bool   `json:"include_isolation_segments,omitempty"`
+	IsolationSegmentName     *string `json:"isolation_segment_name,omitempty"`
 }
 
 type allConfig struct {
@@ -404,6 +407,25 @@ var _ = Describe("Config", func() {
 				config, err := cfg.NewCatsConfig(tmpFilePath)
 				Expect(config).To(BeNil())
 				Expect(err).To(MatchError("* Invalid configuration: 'private_docker_registry_password' must be provided if 'include_private_docker_registry' is true"))
+			})
+		})
+	})
+
+	Context("when including isolation segment tests", func() {
+		BeforeEach(func() {
+			testCfg.IncludeIsolationSegments = ptrToBool(true)
+			testCfg.IsolationSegmentName = ptrToString("value")
+		})
+
+		Context("when image is an empty string", func() {
+			BeforeEach(func() {
+				testCfg.IsolationSegmentName = ptrToString("")
+			})
+
+			It("returns an error", func() {
+				config, err := cfg.NewCatsConfig(tmpFilePath)
+				Expect(config).To(BeNil())
+				Expect(err).To(MatchError("* Invalid configuration: 'isolation_segment_name' must be provided if 'include_isolation_segments' is true"))
 			})
 		})
 	})

--- a/helpers/v3_helpers/v3.go
+++ b/helpers/v3_helpers/v3.go
@@ -3,6 +3,7 @@ package v3_helpers
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
@@ -10,6 +11,7 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/config"
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
@@ -20,14 +22,46 @@ const (
 	V3_JAVA_MEMORY_LIMIT    = "512"
 )
 
-func StartApp(appGuid string) {
-	startURL := fmt.Sprintf("/v3/apps/%s/start", appGuid)
-	Expect(cf.Cf("curl", startURL, "-X", "PUT").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+func AssignDropletToApp(appGuid, dropletGuid string) {
+	appUpdatePath := fmt.Sprintf("/v3/apps/%s/relationships/current_droplet", appGuid)
+	appUpdateBody := fmt.Sprintf(`{"data": {"guid":"%s"}}`, dropletGuid)
+	Expect(cf.Cf("curl", appUpdatePath, "-X", "PATCH", "-d", appUpdateBody).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+
+	for _, process := range GetProcesses(appGuid, "") {
+		ScaleProcess(appGuid, process.Type, V3_DEFAULT_MEMORY_LIMIT)
+	}
 }
 
-func StopApp(appGuid string) {
-	stopURL := fmt.Sprintf("/v3/apps/%s/stop", appGuid)
-	Expect(cf.Cf("curl", stopURL, "-X", "PUT").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+func AssignIsolationSegmentToSpace(spaceGuid, isoSegGuid string) {
+	Eventually(cf.Cf("curl", fmt.Sprintf("/v3/spaces/%s/relationships/isolation_segment", spaceGuid),
+		"-X",
+		"PATCH",
+		"-d",
+		fmt.Sprintf(`{"data":{"guid":"%s"}}`, isoSegGuid)),
+		Config.DefaultTimeoutDuration()).Should(Exit(0))
+}
+
+func CreateAndMapRoute(appGuid, space, domain, host string) {
+	CreateRoute(space, domain, host)
+	getRoutePath := fmt.Sprintf("/v2/routes?q=host:%s", host)
+	routeBody := cf.Cf("curl", getRoutePath).Wait(Config.DefaultTimeoutDuration()).Out.Contents()
+	routeJSON := struct {
+		Resources []struct {
+			Metadata struct {
+				Guid string `json:"guid"`
+			} `json:"metadata"`
+		} `json:"resources"`
+	}{}
+	json.Unmarshal([]byte(routeBody), &routeJSON)
+	routeGuid := routeJSON.Resources[0].Metadata.Guid
+	addRouteBody := fmt.Sprintf(`
+	{
+		"relationships": {
+			"app":   {"guid": "%s"},
+			"route": {"guid": "%s"}
+		}
+	}`, appGuid, routeGuid)
+	Expect(cf.Cf("curl", "/v3/route_mappings", "-X", "POST", "-d", addRouteBody).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 }
 
 func CreateApp(appName, spaceGuid, environmentVariables string) string {
@@ -50,37 +84,96 @@ func CreateDockerApp(appName, spaceGuid, environmentVariables string) string {
 	return app.Guid
 }
 
+func CreateDockerPackage(appGuid, imagePath string) string {
+	packageCreateUrl := fmt.Sprintf("/v3/packages")
+	session := cf.Cf("curl", packageCreateUrl, "-X", "POST", "-d", fmt.Sprintf(`{"relationships":{"app":{"data":{"guid":"%s"}}},"type":"docker", "data": {"image": "%s"}}`, appGuid, imagePath))
+	bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
+	var pac struct {
+		Guid string `json:"guid"`
+	}
+	json.Unmarshal(bytes, &pac)
+	return pac.Guid
+}
+
+func CreateIsolationSegment(name string) string {
+	session := cf.Cf("curl", "/v3/isolation_segments", "-X", "POST", "-d", fmt.Sprintf(`{"name":"%s"}`, name))
+	bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
+
+	var isolation_segment struct {
+		Guid string `json:"guid"`
+	}
+	err := json.Unmarshal(bytes, &isolation_segment)
+	Expect(err).ToNot(HaveOccurred())
+
+	return isolation_segment.Guid
+}
+
+func CreateOrGetIsolationSegment(name string) (string, bool) {
+	var isoSegGuid string
+	var created bool
+	if IsolationSegmentExists(name) {
+		isoSegGuid = GetIsolationSegmentGuid(name)
+		created = true
+	} else {
+		isoSegGuid = CreateIsolationSegment(name)
+		created = false
+	}
+	return isoSegGuid, created
+}
+
+func CreatePackage(appGuid string) string {
+	packageCreateUrl := fmt.Sprintf("/v3/packages")
+	session := cf.Cf("curl", packageCreateUrl, "-X", "POST", "-d", fmt.Sprintf(`{"relationships":{"app":{"data":{"guid":"%s"}}},"type":"bits"}`, appGuid))
+	bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
+	var pac struct {
+		Guid string `json:"guid"`
+	}
+	json.Unmarshal(bytes, &pac)
+	return pac.Guid
+}
+
+func CreateRoute(space, domain, host string) {
+	Expect(cf.Cf("create-route", space, domain, "-n", host).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+}
+
 func DeleteApp(appGuid string) {
 	session := cf.Cf("curl", fmt.Sprintf("/v3/apps/%s", appGuid), "-X", "DELETE", "-v")
 	bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
 	Expect(bytes).To(ContainSubstring("204 No Content"))
 }
 
-func WaitForPackageToBeReady(packageGuid string) {
-	pkgUrl := fmt.Sprintf("/v3/packages/%s", packageGuid)
-	Eventually(func() *Session {
-		session := cf.Cf("curl", pkgUrl)
-		Expect(session.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		return session
-	}, Config.LongCurlTimeoutDuration()).Should(Say("READY"))
+func DeleteIsolationSegment(guid string) {
+	Eventually(cf.Cf("curl", fmt.Sprintf("/v3/isolation_segments/%s", guid), "-X", "DELETE"), Config.DefaultTimeoutDuration()).Should(Exit(0))
 }
 
-func WaitForDropletToCopy(dropletGuid string) {
-	dropletPath := fmt.Sprintf("/v3/droplets/%s", dropletGuid)
-	Eventually(func() *Session {
-		session := cf.Cf("curl", dropletPath).Wait(Config.DefaultTimeoutDuration())
-		Expect(session).NotTo(Say("FAILED"))
-		return session
-	}, Config.CfPushTimeoutDuration()).Should(Say("STAGED"))
+func EntitleOrgToIsolationSegment(orgGuid, isoSegGuid string) {
+	Eventually(cf.Cf("curl",
+		fmt.Sprintf("/v3/isolation_segments/%s/relationships/organizations", isoSegGuid),
+		"-X",
+		"POST",
+		"-d",
+		fmt.Sprintf(`{"data":[{ "guid":"%s" }]}`, orgGuid)),
+		Config.DefaultTimeoutDuration()).Should(Exit(0))
 }
 
-func WaitForBuildToStage(buildGuid string) {
-	buildPath := fmt.Sprintf("/v3/builds/%s", buildGuid)
-	Eventually(func() *Session {
-		session := cf.Cf("curl", buildPath).Wait(Config.DefaultTimeoutDuration())
-		Expect(session).NotTo(Say("FAILED"))
-		return session
-	}, Config.CfPushTimeoutDuration()).Should(Say("STAGED"))
+func FetchRecentLogs(appGuid, oauthToken string, config config.CatsConfig) *Session {
+	loggregatorEndpoint := getHttpLoggregatorEndpoint()
+	logUrl := fmt.Sprintf("%s/apps/%s/recentlogs", loggregatorEndpoint, appGuid)
+	session := helpers.Curl(Config, logUrl, "-H", fmt.Sprintf("Authorization: %s", oauthToken))
+	Expect(session.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+	return session
+}
+
+func GetAuthToken() string {
+	session := cf.Cf("oauth-token")
+	bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
+	return strings.TrimSpace(string(bytes))
+}
+
+func GetDefaultIsolationSegment(orgGuid string) string {
+	session := cf.Cf("curl", fmt.Sprintf("/v3/organizations/%s/relationships/default_isolation_segment", orgGuid))
+	bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
+	return GetIsolationSegmentGuidFromResponse(bytes)
 }
 
 func GetDropletFromBuild(buildGuid string) string {
@@ -96,26 +189,46 @@ func GetDropletFromBuild(buildGuid string) string {
 	return build.Droplet.Guid
 }
 
-func CreatePackage(appGuid string) string {
-	packageCreateUrl := fmt.Sprintf("/v3/packages")
-	session := cf.Cf("curl", packageCreateUrl, "-X", "POST", "-d", fmt.Sprintf(`{"relationships":{"app":{"data":{"guid":"%s"}}},"type":"bits"}`, appGuid))
-	bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
-	var pac struct {
+func GetGuidFromResponse(response []byte) string {
+	type resource struct {
 		Guid string `json:"guid"`
 	}
-	json.Unmarshal(bytes, &pac)
-	return pac.Guid
+	var GetResponse struct {
+		Resources []resource `json:"resources"`
+	}
+
+	err := json.Unmarshal(response, &GetResponse)
+	Expect(err).ToNot(HaveOccurred())
+
+	if len(GetResponse.Resources) == 0 {
+		Fail("No guid found for response")
+	}
+
+	return GetResponse.Resources[0].Guid
 }
 
-func CreateDockerPackage(appGuid, imagePath string) string {
-	packageCreateUrl := fmt.Sprintf("/v3/packages")
-	session := cf.Cf("curl", packageCreateUrl, "-X", "POST", "-d", fmt.Sprintf(`{"relationships":{"app":{"data":{"guid":"%s"}}},"type":"docker", "data": {"image": "%s"}}`, appGuid, imagePath))
+func GetIsolationSegmentGuid(name string) string {
+	session := cf.Cf("curl", fmt.Sprintf("/v3/isolation_segments?names=%s", name))
 	bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
-	var pac struct {
+	return GetGuidFromResponse(bytes)
+}
+
+func GetIsolationSegmentGuidFromResponse(response []byte) string {
+	type data struct {
 		Guid string `json:"guid"`
 	}
-	json.Unmarshal(bytes, &pac)
-	return pac.Guid
+	var GetResponse struct {
+		Data data `json:"data"`
+	}
+
+	err := json.Unmarshal(response, &GetResponse)
+	Expect(err).ToNot(HaveOccurred())
+
+	if (data{}) == GetResponse.Data {
+		return ""
+	}
+
+	return GetResponse.Data.Guid
 }
 
 func GetSpaceGuidFromName(spaceName string) string {
@@ -124,16 +237,68 @@ func GetSpaceGuidFromName(spaceName string) string {
 	return strings.TrimSpace(string(bytes))
 }
 
-func GetAuthToken() string {
-	session := cf.Cf("oauth-token")
+func IsolationSegmentExists(name string) bool {
+	session := cf.Cf("curl", fmt.Sprintf("/v3/isolation_segments?names=%s", name))
 	bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
-	return strings.TrimSpace(string(bytes))
+	type resource struct {
+		Guid string `json:"guid"`
+	}
+	var GetResponse struct {
+		Resources []resource `json:"resources"`
+	}
+
+	err := json.Unmarshal(bytes, &GetResponse)
+	Expect(err).ToNot(HaveOccurred())
+	return len(GetResponse.Resources) > 0
 }
 
-func UploadPackage(uploadUrl, packageZipPath, token string) {
-	bits := fmt.Sprintf(`bits=@%s`, packageZipPath)
-	curl := helpers.Curl(Config, "-v", "-s", uploadUrl, "-F", bits, "-H", fmt.Sprintf("Authorization: %s", token)).Wait(Config.DefaultTimeoutDuration())
-	Expect(curl).To(Exit(0))
+func OrgEntitledToIsolationSegment(orgGuid string, isoSegName string) bool {
+	session := cf.Cf("curl", fmt.Sprintf("/v3/isolation_segments?names=%s&organization_guids=%s", isoSegName, orgGuid))
+	bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
+
+	type resource struct {
+		Guid string `json:"guid"`
+	}
+	var GetResponse struct {
+		Resources []resource `json:"resources"`
+	}
+
+	err := json.Unmarshal(bytes, &GetResponse)
+	Expect(err).ToNot(HaveOccurred())
+	return len(GetResponse.Resources) > 0
+}
+
+func RevokeOrgEntitlementForIsolationSegment(orgGuid, isoSegGuid string) {
+	Eventually(cf.Cf("curl",
+		fmt.Sprintf("/v3/isolation_segments/%s/relationships/organizations/%s", isoSegGuid, orgGuid),
+		"-X",
+		"DELETE",
+	), Config.DefaultTimeoutDuration()).Should(Exit(0))
+}
+
+func ScaleProcess(appGuid, processType, memoryInMb string) {
+	scalePath := fmt.Sprintf("/v3/apps/%s/processes/%s/scale", appGuid, processType)
+	scaleBody := fmt.Sprintf(`{"memory_in_mb":"%s"}`, memoryInMb)
+	Expect(cf.Cf("curl", scalePath, "-X", "PUT", "-d", scaleBody).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+}
+
+func SendRequestWithSpoofedHeader(host, domain string) *http.Response {
+	req, _ := http.NewRequest("GET", fmt.Sprintf("http://wildcard-path.%s", domain), nil)
+	req.Host = host
+
+	resp, err := http.DefaultClient.Do(req)
+	Expect(err).NotTo(HaveOccurred())
+	return resp
+}
+
+func SetDefaultIsolationSegment(orgGuid, isoSegGuid string) {
+	Eventually(cf.Cf("curl",
+		fmt.Sprintf("/v3/organizations/%s/relationships/default_isolation_segment", orgGuid),
+		"-X",
+		"PATCH",
+		"-d",
+		fmt.Sprintf(`{"data":{"guid":"%s"}}`, isoSegGuid)),
+		Config.DefaultTimeoutDuration()).Should(Exit(0))
 }
 
 func StageBuildpackPackage(packageGuid, buildpack string) string {
@@ -161,56 +326,50 @@ func StageDockerPackage(packageGuid string) string {
 	return build.Guid
 }
 
-func CreateAndMapRoute(appGuid, space, domain, host string) {
-	CreateRoute(space, domain, host)
-	getRoutePath := fmt.Sprintf("/v2/routes?q=host:%s", host)
-	routeBody := cf.Cf("curl", getRoutePath).Wait(Config.DefaultTimeoutDuration()).Out.Contents()
-	routeJSON := struct {
-		Resources []struct {
-			Metadata struct {
-				Guid string `json:"guid"`
-			} `json:"metadata"`
-		} `json:"resources"`
-	}{}
-	json.Unmarshal([]byte(routeBody), &routeJSON)
-	routeGuid := routeJSON.Resources[0].Metadata.Guid
-	addRouteBody := fmt.Sprintf(`
-	{
-		"relationships": {
-			"app":   {"guid": "%s"},
-			"route": {"guid": "%s"}
-		}
-	}`, appGuid, routeGuid)
-	Expect(cf.Cf("curl", "/v3/route_mappings", "-X", "POST", "-d", addRouteBody).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+func StartApp(appGuid string) {
+	startURL := fmt.Sprintf("/v3/apps/%s/start", appGuid)
+	Expect(cf.Cf("curl", startURL, "-X", "PUT").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 }
 
-func AssignDropletToApp(appGuid, dropletGuid string) {
-	appUpdatePath := fmt.Sprintf("/v3/apps/%s/relationships/current_droplet", appGuid)
-	appUpdateBody := fmt.Sprintf(`{"data": {"guid":"%s"}}`, dropletGuid)
-	Expect(cf.Cf("curl", appUpdatePath, "-X", "PATCH", "-d", appUpdateBody).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-
-	for _, process := range GetProcesses(appGuid, "") {
-		ScaleProcess(appGuid, process.Type, V3_DEFAULT_MEMORY_LIMIT)
-	}
+func StopApp(appGuid string) {
+	stopURL := fmt.Sprintf("/v3/apps/%s/stop", appGuid)
+	Expect(cf.Cf("curl", stopURL, "-X", "PUT").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 }
 
-func FetchRecentLogs(appGuid, oauthToken string, config config.CatsConfig) *Session {
-	loggregatorEndpoint := getHttpLoggregatorEndpoint()
-	logUrl := fmt.Sprintf("%s/apps/%s/recentlogs", loggregatorEndpoint, appGuid)
-	session := helpers.Curl(Config, logUrl, "-H", fmt.Sprintf("Authorization: %s", oauthToken))
-	Expect(session.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-	return session
+func UploadPackage(uploadUrl, packageZipPath, token string) {
+	bits := fmt.Sprintf(`bits=@%s`, packageZipPath)
+	curl := helpers.Curl(Config, "-v", "-s", uploadUrl, "-F", bits, "-H", fmt.Sprintf("Authorization: %s", token)).Wait(Config.DefaultTimeoutDuration())
+	Expect(curl).To(Exit(0))
 }
 
-func ScaleProcess(appGuid, processType, memoryInMb string) {
-	scalePath := fmt.Sprintf("/v3/apps/%s/processes/%s/scale", appGuid, processType)
-	scaleBody := fmt.Sprintf(`{"memory_in_mb":"%s"}`, memoryInMb)
-	Expect(cf.Cf("curl", scalePath, "-X", "PUT", "-d", scaleBody).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+func WaitForBuildToStage(buildGuid string) {
+	buildPath := fmt.Sprintf("/v3/builds/%s", buildGuid)
+	Eventually(func() *Session {
+		session := cf.Cf("curl", buildPath).Wait(Config.DefaultTimeoutDuration())
+		Expect(session).NotTo(Say("FAILED"))
+		return session
+	}, Config.CfPushTimeoutDuration()).Should(Say("STAGED"))
 }
 
-func CreateRoute(space, domain, host string) {
-	Expect(cf.Cf("create-route", space, domain, "-n", host).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+func WaitForDropletToCopy(dropletGuid string) {
+	dropletPath := fmt.Sprintf("/v3/droplets/%s", dropletGuid)
+	Eventually(func() *Session {
+		session := cf.Cf("curl", dropletPath).Wait(Config.DefaultTimeoutDuration())
+		Expect(session).NotTo(Say("FAILED"))
+		return session
+	}, Config.CfPushTimeoutDuration()).Should(Say("STAGED"))
 }
+
+func WaitForPackageToBeReady(packageGuid string) {
+	pkgUrl := fmt.Sprintf("/v3/packages/%s", packageGuid)
+	Eventually(func() *Session {
+		session := cf.Cf("curl", pkgUrl)
+		Expect(session.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+		return session
+	}, Config.LongCurlTimeoutDuration()).Should(Say("READY"))
+}
+
+//private
 
 func getHttpLoggregatorEndpoint() string {
 	infoCommand := cf.Cf("curl", "/v2/info")


### PR DESCRIPTION
This commit includes a refactor to make the isolation segment-related functions public. Additionally, we fixed some test cleanup that had the side effect of leaving an isolation segment set as a default for an org.

This is in preparation for a future PR to implement a test suite for routing isolation segments.

Signed-off-by: Belinda Liu <bliu@pivotal.io>
Signed-off-by: Jonathan Berkhahn <jaberkha@us.ibm.com>