### PR TITLE
Fix ordering problem in afterEach

### DIFF
--- a/services/recursive_delete.go
+++ b/services/recursive_delete.go
@@ -76,8 +76,8 @@ var _ = ServicesDescribe("Recursive Delete", func() {
 					Expect(cf.Cf("delete-service", instanceName, "-f").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 					Expect(cf.Cf("delete-space", spaceName, "-f").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 				}
-				Expect(cf.Cf("delete-quota", "-f", quotaName).Wait(TestSetup.ShortTimeout())).To(Exit(0))
 				Expect(cf.Cf("delete-org", orgName, "-f").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+				Expect(cf.Cf("delete-quota", "-f", quotaName).Wait(TestSetup.ShortTimeout())).To(Exit(0))
 			}
 		})
 	})


### PR DESCRIPTION
Before, if the `cf delete-org` in the spec failed, then the afterEach
would fail to delete the quota.

Signed-off-by: Tim Downey <tdowney@pivotal.io>

```
cf delete-quota -f CATS-1-QUOTA-5baada7e-b579-45c2-7 
Deleting quota CATS-1-QUOTA-5baada7e-b579-45c2-7 as admin...
FAILED
Please delete the organization associations for your quota definition.
```