### PR TITLE
Add test suite for routing isolation segments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tags
 results
 .idea
 .DS_Store
+logs

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ export CONFIG=$PWD/integration_config.json
 * `include_v3`: Flag to include tests for the the v3 API.
 * `include_zipkin`: Flag to include tests for Zipkin tracing. `include_routing` must also be set for tests to run. CF must be deployed with `router.tracing.enable_zipkin` set for tests to pass.
 * `include_isolation_segments`: Flag to include isolation segment tests.
+* `includ_routing_isolation_segments`: Flag to include routing isolation segments. [See below](#routing-isolation-segments)
 * `backend`: App tests push their apps using the backend specified. Incompatible tests will be skipped based on which backend is chosen. If left unspecified the default backend will be used where none is specified; all tests that specify a particular backend will be skipped.
 * `use_http`: Set to true if you would like CF Acceptance Tests to use HTTP when making api and application requests. (default is HTTPS)
 * `use_existing_organization`: Set to true when you need to specify an existing organization to use rather than creating a new organization.
@@ -155,6 +156,7 @@ export CONFIG=$PWD/integration_config.json
 * `test_password`: Used to set the password for the test user. This may be needed if your CF installation has password policies.
 * `timeout_scale`: Used primarily to scale default timeouts for test setup and teardown actions (e.g. creating an org) as opposed to main test actions (e.g. pushing an app).
 * `isolation_segment_name`: Name of the isolation segment to use for the isolation segments test.
+* `isolation_segment_domain`: Domain that will route to the isolated router in the isolation segments and routing isolation segments tests. [See below](#routing-isolation-segments)
 * `private_docker_registry_image`: Name of the private docker image to use when testing private docker registries. [See below](#private-docker)
 * `private_docker_registry_username`: Username to access the private docker repository. [See below](#private-docker)
 * `private_docker_registry_password`: Password to access the private docker repository. [See below](#private-docker)
@@ -218,6 +220,13 @@ docker push <your-private-repo>:<some-tag>
 
 The value for the `private_docker_registry_image` config value in this case would be "<your-private-repo>:<some-tag>".
 
+#### Routing Isolation Segments
+To run tests that involve routing isolation segments, the following config values must be provided:
+* `isolation_segment_name`
+* `isolation_segment_domain`
+
+This suite also requires `cc.diego.temporary_local_apps` be set to true in your cf configuration, as well as additional setup. Read the documentation [here](http://docs.cloudfoundry.org/adminguide/routing-is.html) for further setup details.
+
 #### Capturing Test Output
 When a test fails, look for the test group name (`[services]` in the example below) in the test output:
 
@@ -274,7 +283,7 @@ You can of course combine the `-v` flag with the `-nodes=N` flag.
 
 ## Explanation of Test Groups
 
-Test Group Name| Compatable Backend | Description
+Test Group Name| Compatible Backend | Description
 --- | --- | ---
 `apps`| DEA or Diego | Tests the core functionalities of Cloud Foundry: staging, running, logging, routing, buildpacks, etc.  This test group should always pass against a sound Cloud Foundry deployment.
 `backend_compatibility` | Diego | Tests interoperability of droplets staged on the DEAs running on Diego
@@ -287,7 +296,8 @@ Test Group Name| Compatable Backend | Description
 `services`| DEA or Diego | This test group tests various features related to services, e.g. registering a service broker via the service broker API.  Some of these tests exercise special integrations, such as Single Sign-On authentication; you may wish to run some tests in this package but selectively skip others if you haven't configured the required integrations.
 `ssh`| Diego |This test group tests our ability to communicate with Diego apps via ssh, scp, and sftp.
 `v3`| Diego| This test group contains tests for the next-generation v3 Cloud Controller API.  As of this writing, the v3 API is not officially supported.
-`isolation_segments` | Diego | This test group requires that Diego be deployed with a minimum of 2 cells. One of those cells must have been deployed with a `placement_tag`. Finally, the `isolation_segment_name` must be set in the CATs properties to match this placement tag.
+`isolation_segments` | Diego | This test group requires that Diego be deployed with a minimum of 2 cells. One of those cells must have been deployed with a `placement_tag`. Additionally, a minimum of two Gorouter instances must be deployed. One instance must be configured with the property `routing_table_sharding_mode: shared-and-segments`. The other instance must have the properties `routing_table_sharding_mode: segments` and `isolation_segments: [YOUR_PLACEMENT_TAG_HERE]`. The `isolation_segment_name` in the CATs properties must match the `placement_tag` and `isolation_segment`. Finally, the `isolation_segment_domain` must be set and traffic to that domain should go to the isolation router.
+`routing_isolation_segments` | Diego | This group tests that requests to isolated apps are only routed through isolated routers, and vice versa.
 
 ## Contributing
 

--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -124,6 +124,17 @@ func RoutingDescribe(description string, callback func()) bool {
 	})
 }
 
+func RoutingIsolationSegmentsDescribe(description string, callback func()) bool {
+	return Describe("[routing_isolation_segments] "+description, func() {
+		BeforeEach(func() {
+			if !Config.GetIncludeRoutingIsolationSegments() {
+				Skip(`Skipping this test because Config.IncludeRoutingIsolationSegments is set to 'false'.`)
+			}
+		})
+		callback()
+	})
+}
+
 func ZipkinDescribe(description string, callback func()) bool {
 	return Describe("[routing] "+description, func() {
 		BeforeEach(func() {

--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/cloudfoundry/cf-acceptance-tests/isolation_segments"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/route_services"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/routing"
+	_ "github.com/cloudfoundry/cf-acceptance-tests/routing_isolation_segments"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/security_groups"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/services"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/ssh"

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -24,6 +24,7 @@ type CatsConfig interface {
 	GetIncludeTasks() bool
 	GetIncludeV3() bool
 	GetIncludeIsolationSegments() bool
+	GetIncludeRoutingIsolationSegments() bool
 	GetShouldKeepUser() bool
 	GetSkipSSLValidation() bool
 	GetUseExistingUser() bool
@@ -42,6 +43,7 @@ type CatsConfig interface {
 	GetExistingUserPassword() string
 	GetGoBuildpackName() string
 	GetIsolationSegmentName() string
+	GetIsolationSegmentDomain() string
 	GetJavaBuildpackName() string
 	GetNamePrefix() string
 	GetNodejsBuildpackName() string

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -35,7 +35,8 @@ type config struct {
 	PersistentAppQuotaName *string `json:"persistent_app_quota_name"`
 	PersistentAppSpace     *string `json:"persistent_app_space"`
 
-	IsolationSegmentName *string `json:"isolation_segment_name"`
+	IsolationSegmentName   *string `json:"isolation_segment_name"`
+	IsolationSegmentDomain *string `json:"isolation_segment_domain"`
 
 	Backend           *string `json:"backend"`
 	SkipSSLValidation *bool   `json:"skip_ssl_validation"`
@@ -80,6 +81,7 @@ type config struct {
 	IncludeV3                         *bool `json:"include_v3"`
 	IncludeZipkin                     *bool `json:"include_zipkin"`
 	IncludeIsolationSegments          *bool `json:"include_isolation_segments"`
+	IncludeRoutingIsolationSegments   *bool `json:"include_routing_isolation_segments"`
 
 	PrivateDockerRegistryImage    *string `json:"private_docker_registry_image"`
 	PrivateDockerRegistryUsername *string `json:"private_docker_registry_username"`
@@ -115,6 +117,7 @@ func getDefaults() config {
 	defaults.PersistentAppSpace = ptrToString("CATS-persistent-space")
 
 	defaults.IsolationSegmentName = ptrToString("")
+	defaults.IsolationSegmentDomain = ptrToString("")
 
 	defaults.BinaryBuildpackName = ptrToString("binary_buildpack")
 	defaults.GoBuildpackName = ptrToString("go_buildpack")
@@ -145,6 +148,7 @@ func getDefaults() config {
 	defaults.IncludeTasks = ptrToBool(false)
 	defaults.IncludeV3 = ptrToBool(false)
 	defaults.IncludeZipkin = ptrToBool(false)
+	defaults.IncludeRoutingIsolationSegments = ptrToBool(false)
 
 	defaults.UseHttp = ptrToBool(false)
 	defaults.UseExistingUser = ptrToBool(false)
@@ -224,6 +228,11 @@ func validateConfig(config *config) Errors {
 		errs.Add(err)
 	}
 
+	err = validateRoutingIsolationSegments(config)
+	if err != nil {
+		errs.Add(err)
+	}
+
 	if config.UseHttp == nil {
 		errs.Add(fmt.Errorf("* 'use_http' must not be null"))
 	}
@@ -250,6 +259,9 @@ func validateConfig(config *config) Errors {
 	}
 	if config.IsolationSegmentName == nil {
 		errs.Add(fmt.Errorf("* 'isolation_segment_name' must not be null"))
+	}
+	if config.IsolationSegmentDomain == nil {
+		errs.Add(fmt.Errorf("* 'isolation_segment_domain' must not be null"))
 	}
 	if config.SkipSSLValidation == nil {
 		errs.Add(fmt.Errorf("* 'skip_ssl_validation' must not be null"))
@@ -514,6 +526,30 @@ func validateIsolationSegments(config *config) error {
 	return nil
 }
 
+func validateRoutingIsolationSegments(config *config) error {
+	if config.IncludeRoutingIsolationSegments == nil {
+		return fmt.Errorf("* 'include_routing_isolation_segments' must not be null")
+	}
+	if config.IsolationSegmentName == nil {
+		return fmt.Errorf("* 'isolation_segment_name' must not be null")
+	}
+	if config.IsolationSegmentDomain == nil {
+		return fmt.Errorf("* 'isolation_segment_domain' must not be null")
+	}
+
+	if !config.GetIncludeRoutingIsolationSegments() {
+		return nil
+	}
+
+	if config.GetIsolationSegmentName() == "" {
+		return fmt.Errorf("* Invalid configuration: 'isolation_segment_name' must be provided if 'include_routing_isolation_segments' is true")
+	}
+	if config.GetIsolationSegmentDomain() == "" {
+		return fmt.Errorf("* Invalid configuration: 'isolation_segment_domain' must be provided if 'include_routing_isolation_segments' is true")
+	}
+	return nil
+}
+
 func load(path string, config *config) Errors {
 	errs := Errors{}
 	err := loadConfigFromPath(path, config)
@@ -613,6 +649,10 @@ func (c *config) GetPersistentAppQuotaName() string {
 
 func (c *config) GetIsolationSegmentName() string {
 	return *c.IsolationSegmentName
+}
+
+func (c *config) GetIsolationSegmentDomain() string {
+	return *c.IsolationSegmentDomain
 }
 
 func (c *config) GetNamePrefix() string {
@@ -733,6 +773,10 @@ func (c *config) GetIncludeV3() bool {
 
 func (c *config) GetIncludeIsolationSegments() bool {
 	return *c.IncludeIsolationSegments
+}
+
+func (c *config) GetIncludeRoutingIsolationSegments() bool {
+	return *c.IncludeRoutingIsolationSegments
 }
 
 func (c *config) GetRubyBuildpackName() string {

--- a/helpers/v3_helpers/v3.go
+++ b/helpers/v3_helpers/v3.go
@@ -336,6 +336,15 @@ func StopApp(appGuid string) {
 	Expect(cf.Cf("curl", stopURL, "-X", "PUT").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 }
 
+func UnassignIsolationSegmentFromSpace(spaceGuid string) {
+	Eventually(cf.Cf("curl", fmt.Sprintf("/v3/spaces/%s/relationships/isolation_segment", spaceGuid),
+		"-X",
+		"PATCH",
+		"-d",
+		`{"data":{"guid":null}}`),
+		Config.DefaultTimeoutDuration()).Should(Exit(0))
+}
+
 func UploadPackage(uploadUrl, packageZipPath, token string) {
 	bits := fmt.Sprintf(`bits=@%s`, packageZipPath)
 	curl := helpers.Curl(Config, "-v", "-s", uploadUrl, "-F", bits, "-H", fmt.Sprintf("Authorization: %s", token)).Wait(Config.DefaultTimeoutDuration())

--- a/routing_isolation_segments/routing_isolation_segments.go
+++ b/routing_isolation_segments/routing_isolation_segments.go
@@ -1,0 +1,164 @@
+package routing_isolation_segments
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/config"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers"
+)
+
+const (
+	SHARED_ISOLATION_SEGMENT_GUID = "933b4c58-120b-499a-b85d-4b6fc9e2903b"
+	binaryHi                      = "Hello from a binary"
+	SHARED_ISOLATION_SEGMENT_NAME = "shared"
+)
+
+var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
+	var appsDomain string
+	var orgGuid, orgName string
+	var spaceGuid, spaceName string
+	var isoSegGuid, isoSegName, isoSegDomain string
+	var testSetup *workflowhelpers.ReproducibleTestSuiteSetup
+	var created bool
+	var originallyEntitledToShared bool
+
+	BeforeEach(func() {
+		// New up a organization since we will be assigning isolation segments.
+		// This has a potential to cause other tests to fail if running in parallel mode.
+		cfg, _ := config.NewCatsConfig(os.Getenv("CONFIG"))
+		testSetup = workflowhelpers.NewTestSuiteSetup(cfg)
+		testSetup.Setup()
+
+		appsDomain = Config.GetAppsDomain()
+		orgName = testSetup.RegularUserContext().Org
+		spaceName = testSetup.RegularUserContext().Space
+		spaceGuid = v3_helpers.GetSpaceGuidFromName(spaceName)
+		isoSegName = Config.GetIsolationSegmentName()
+		isoSegDomain = Config.GetIsolationSegmentDomain()
+
+		session := cf.Cf("curl", fmt.Sprintf("/v3/organizations?names=%s", orgName))
+		bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
+		orgGuid = v3_helpers.GetGuidFromResponse(bytes)
+		workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
+			originallyEntitledToShared = v3_helpers.OrgEntitledToIsolationSegment(orgGuid, SHARED_ISOLATION_SEGMENT_NAME)
+		})
+	})
+
+	AfterEach(func() {
+		testSetup.Teardown()
+		if !originallyEntitledToShared && Config.GetUseExistingOrganization() {
+			workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
+				v3_helpers.RevokeOrgEntitlementForIsolationSegment(orgGuid, SHARED_ISOLATION_SEGMENT_GUID)
+			})
+		}
+	})
+
+	Context("When an app is pushed to a space assigned the shared isolation segment", func() {
+		var appName string
+
+		BeforeEach(func() {
+			workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
+				v3_helpers.EntitleOrgToIsolationSegment(orgGuid, SHARED_ISOLATION_SEGMENT_GUID)
+				v3_helpers.AssignIsolationSegmentToSpace(spaceGuid, SHARED_ISOLATION_SEGMENT_GUID)
+				appName = random_name.CATSRandomName("APP")
+			})
+			Eventually(cf.Cf(
+				"push", appName,
+				"-p", assets.NewAssets().Binary,
+				"--no-start",
+				"-m", DEFAULT_MEMORY_LIMIT,
+				"-b", "binary_buildpack",
+				"-d", appsDomain,
+				"-c", "./app"),
+				Config.CfPushTimeoutDuration()).Should(Exit(0))
+
+			app_helpers.EnableDiego(appName)
+			Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
+		})
+
+		It("is reachable from the shared router", func() {
+			resp := v3_helpers.SendRequestWithSpoofedHeader(fmt.Sprintf("%s.%s", appName, appsDomain), appsDomain)
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(200))
+			htmlData, err := ioutil.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(htmlData)).To(ContainSubstring(binaryHi))
+		})
+
+		It("is not reachable from the isolation segment router", func() {
+			//send a request to app in the shared domain, but through the isolation segment router
+			resp := v3_helpers.SendRequestWithSpoofedHeader(fmt.Sprintf("%s.%s", appName, appsDomain), isoSegDomain)
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(404))
+		})
+	})
+
+	Context("When an app is pushed to a space that has been assigned an Isolation Segment", func() {
+		var appName string
+
+		BeforeEach(func() {
+			workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
+				isoSegGuid, created = v3_helpers.CreateOrGetIsolationSegment(isoSegName)
+				v3_helpers.EntitleOrgToIsolationSegment(orgGuid, isoSegGuid)
+				session := cf.Cf("curl", fmt.Sprintf("/v3/spaces?names=%s", spaceName))
+				bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
+				spaceGuid = v3_helpers.GetGuidFromResponse(bytes)
+				v3_helpers.AssignIsolationSegmentToSpace(spaceGuid, isoSegGuid)
+			})
+			appName = random_name.CATSRandomName("APP")
+			Eventually(cf.Cf(
+				"push", appName,
+				"-p", assets.NewAssets().Binary,
+				"--no-start",
+				"-m", DEFAULT_MEMORY_LIMIT,
+				"-b", "binary_buildpack",
+				"-d", isoSegDomain,
+				"-c", "./app"),
+				Config.CfPushTimeoutDuration()).Should(Exit(0))
+
+			app_helpers.EnableDiego(appName)
+			Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
+		})
+
+		AfterEach(func() {
+			if created {
+				workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
+					v3_helpers.UnassignIsolationSegmentFromSpace(spaceGuid)
+					v3_helpers.RevokeOrgEntitlementForIsolationSegment(orgGuid, isoSegGuid)
+					v3_helpers.DeleteIsolationSegment(isoSegGuid)
+				})
+			}
+		})
+		It("the app is reachable from the isolated router", func() {
+			resp := v3_helpers.SendRequestWithSpoofedHeader(fmt.Sprintf("%s.%s", appName, isoSegDomain), isoSegDomain)
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(200))
+			htmlData, err := ioutil.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(htmlData)).To(ContainSubstring(binaryHi))
+		})
+
+		It("the app is not reachable from the shared router", func() {
+
+			resp := v3_helpers.SendRequestWithSpoofedHeader(fmt.Sprintf("%s.%s", appName, isoSegDomain), appsDomain)
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(404))
+		})
+	})
+})


### PR DESCRIPTION
- Change isolation segment suite to know about routing isolation domain
- Add helper for unassigning an iso seg from space

Signed-off-by: Shash Reddy <sreddy@pivotal.io>

This is the other half of the pull request. Feel free to let us know if you have any questions/concerns

Thanks,
@belinda-liu & @jberkhahn 
CF Routing Team