### PR TITLE
Fix logic in CreateOrGetIsolationSegment

### DIFF
--- a/helpers/v3_helpers/v3.go
+++ b/helpers/v3_helpers/v3.go
@@ -114,10 +114,10 @@ func CreateOrGetIsolationSegment(name string) (string, bool) {
 	var created bool
 	if IsolationSegmentExists(name) {
 		isoSegGuid = GetIsolationSegmentGuid(name)
-		created = true
+		created = false
 	} else {
 		isoSegGuid = CreateIsolationSegment(name)
-		created = false
+		created = true
 	}
 	return isoSegGuid, created
 }


### PR DESCRIPTION
This fix is to correct the backward logic in CAT's helpers.

Signed-off-by: Belinda Liu <bliu@pivotal.io>