### PR TITLE
Cleanup leaky isolation segment relationships

### DIFF
--- a/helpers/v3_helpers/v3.go
+++ b/helpers/v3_helpers/v3.go
@@ -109,19 +109,6 @@ func CreateIsolationSegment(name string) string {
 	return isolation_segment.Guid
 }
 
-func CreateOrGetIsolationSegment(name string) (string, bool) {
-	var isoSegGuid string
-	var created bool
-	if IsolationSegmentExists(name) {
-		isoSegGuid = GetIsolationSegmentGuid(name)
-		created = false
-	} else {
-		isoSegGuid = CreateIsolationSegment(name)
-		created = true
-	}
-	return isoSegGuid, created
-}
-
 func CreatePackage(appGuid string) string {
 	packageCreateUrl := fmt.Sprintf("/v3/packages")
 	session := cf.Cf("curl", packageCreateUrl, "-X", "POST", "-d", fmt.Sprintf(`{"relationships":{"app":{"data":{"guid":"%s"}}},"type":"bits"}`, appGuid))
@@ -363,6 +350,16 @@ func UnassignIsolationSegmentFromSpace(spaceGuid string) {
 		"PATCH",
 		"-d",
 		`{"data":{"guid":null}}`),
+		Config.DefaultTimeoutDuration()).Should(Exit(0))
+}
+
+func UnsetDefaultIsolationSegment(orgGuid string) {
+	Eventually(cf.Cf("curl",
+		fmt.Sprintf("/v3/organizations/%s/relationships/default_isolation_segment", orgGuid),
+		"-X",
+		"PATCH",
+		"-d",
+		`{"data":{"guid": null}}`),
 		Config.DefaultTimeoutDuration()).Should(Exit(0))
 }
 

--- a/helpers/v3_helpers/v3.go
+++ b/helpers/v3_helpers/v3.go
@@ -109,6 +109,14 @@ func CreateIsolationSegment(name string) string {
 	return isolation_segment.Guid
 }
 
+func CreateOrGetIsolationSegment(name string) string {
+	if IsolationSegmentExists(name) {
+		return GetIsolationSegmentGuid(name)
+	}
+
+	return CreateIsolationSegment(name)
+}
+
 func CreatePackage(appGuid string) string {
 	packageCreateUrl := fmt.Sprintf("/v3/packages")
 	session := cf.Cf("curl", packageCreateUrl, "-X", "POST", "-d", fmt.Sprintf(`{"relationships":{"app":{"data":{"guid":"%s"}}},"type":"bits"}`, appGuid))

--- a/isolation_segments/isolation_segments.go
+++ b/isolation_segments/isolation_segments.go
@@ -30,10 +30,8 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 	var appsDomain, isoSegDomain string
 	var orgGuid, orgName string
 	var spaceGuid, spaceName string
-	var isoSegGuid, isoSegName, defaultIsoSegGuid string
+	var isoSegGuid, isoSegName string
 	var testSetup *workflowhelpers.ReproducibleTestSuiteSetup
-	var created bool
-	var originallyEntitled bool
 
 	BeforeEach(func() {
 		// New up a organization since we will be assigning isolation segments.
@@ -54,27 +52,24 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 		session := cf.Cf("curl", fmt.Sprintf("/v3/organizations?names=%s", orgName))
 		bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
 		orgGuid = v3_helpers.GetGuidFromResponse(bytes)
-		defaultIsoSegGuid = v3_helpers.GetDefaultIsolationSegment(orgGuid)
-		workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
-			originallyEntitled = v3_helpers.OrgEntitledToIsolationSegment(orgGuid, isoSegName)
-		})
 	})
 
 	AfterEach(func() {
 		workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
-			v3_helpers.SetDefaultIsolationSegment(orgGuid, defaultIsoSegGuid)
-			if !originallyEntitled && isoSegGuid != "" {
-				v3_helpers.RevokeOrgEntitlementForIsolationSegment(orgGuid, isoSegGuid)
+			v3_helpers.UnsetDefaultIsolationSegment(orgGuid)
+			v3_helpers.RevokeOrgEntitlementForIsolationSegment(orgGuid, isoSegGuid)
+			if isoSegGuid != SHARED_ISOLATION_SEGMENT_GUID {
+				v3_helpers.DeleteIsolationSegment(isoSegGuid)
 			}
 		})
-		testSetup.Teardown()
 	})
 
 	Context("When an organization has the shared segment as its default", func() {
 		BeforeEach(func() {
 			workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
-				v3_helpers.EntitleOrgToIsolationSegment(orgGuid, SHARED_ISOLATION_SEGMENT_GUID)
-				v3_helpers.SetDefaultIsolationSegment(orgGuid, SHARED_ISOLATION_SEGMENT_GUID)
+				isoSegGuid = SHARED_ISOLATION_SEGMENT_GUID
+				v3_helpers.EntitleOrgToIsolationSegment(orgGuid, isoSegGuid)
+				v3_helpers.SetDefaultIsolationSegment(orgGuid, isoSegGuid)
 			})
 		})
 
@@ -99,16 +94,10 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 	Context("When the user-provided Isolation Segment has an associated cell", func() {
 		BeforeEach(func() {
 			workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
-				isoSegGuid, created = v3_helpers.CreateOrGetIsolationSegment(isoSegName)
+				isoSegGuid = v3_helpers.CreateIsolationSegment(isoSegName)
 				v3_helpers.EntitleOrgToIsolationSegment(orgGuid, isoSegGuid)
 				v3_helpers.SetDefaultIsolationSegment(orgGuid, isoSegGuid)
 			})
-		})
-
-		AfterEach(func() {
-			if created {
-				v3_helpers.DeleteIsolationSegment(isoSegGuid)
-			}
 		})
 
 		It("can run an app to an org where the default is the user-provided isolation segment", func() {
@@ -145,10 +134,6 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 			})
 		})
 
-		AfterEach(func() {
-			v3_helpers.DeleteIsolationSegment(isoSegGuid)
-		})
-
 		It("fails to start an app in the Isolation Segment", func() {
 			appName := random_name.CATSRandomName("APP")
 			Eventually(cf.Cf(
@@ -169,14 +154,8 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 	Context("When the organization has not been entitled to the Isolation Segment", func() {
 		BeforeEach(func() {
 			workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
-				isoSegGuid, created = v3_helpers.CreateOrGetIsolationSegment(isoSegName)
+				isoSegGuid = v3_helpers.CreateIsolationSegment(isoSegName)
 			})
-		})
-
-		AfterEach(func() {
-			if created {
-				v3_helpers.DeleteIsolationSegment(isoSegGuid)
-			}
 		})
 
 		It("fails to set the isolation segment as the default", func() {
@@ -196,7 +175,7 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 	Context("When the space has been assigned an Isolation Segment", func() {
 		BeforeEach(func() {
 			workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
-				isoSegGuid, created = v3_helpers.CreateOrGetIsolationSegment(isoSegName)
+				isoSegGuid = v3_helpers.CreateIsolationSegment(isoSegName)
 				v3_helpers.EntitleOrgToIsolationSegment(orgGuid, isoSegGuid)
 				session := cf.Cf("curl", fmt.Sprintf("/v3/spaces?names=%s", spaceName))
 				bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
@@ -206,9 +185,9 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 		})
 
 		AfterEach(func() {
-			if created {
-				v3_helpers.DeleteIsolationSegment(isoSegGuid)
-			}
+			workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
+				v3_helpers.UnassignIsolationSegmentFromSpace(spaceGuid)
+			})
 		})
 
 		It("can run an app in that isolation segment", func() {

--- a/routing_isolation_segments/routing_isolation_segments.go
+++ b/routing_isolation_segments/routing_isolation_segments.go
@@ -22,7 +22,6 @@ import (
 const (
 	SHARED_ISOLATION_SEGMENT_GUID = "933b4c58-120b-499a-b85d-4b6fc9e2903b"
 	binaryHi                      = "Hello from a binary"
-	SHARED_ISOLATION_SEGMENT_NAME = "shared"
 )
 
 var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
@@ -31,8 +30,6 @@ var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
 	var spaceGuid, spaceName string
 	var isoSegGuid, isoSegName, isoSegDomain string
 	var testSetup *workflowhelpers.ReproducibleTestSuiteSetup
-	var created bool
-	var originallyEntitledToShared bool
 
 	BeforeEach(func() {
 		// New up a organization since we will be assigning isolation segments.
@@ -51,18 +48,17 @@ var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
 		session := cf.Cf("curl", fmt.Sprintf("/v3/organizations?names=%s", orgName))
 		bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
 		orgGuid = v3_helpers.GetGuidFromResponse(bytes)
-		workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
-			originallyEntitledToShared = v3_helpers.OrgEntitledToIsolationSegment(orgGuid, SHARED_ISOLATION_SEGMENT_NAME)
-		})
 	})
 
 	AfterEach(func() {
-		testSetup.Teardown()
-		if !originallyEntitledToShared && Config.GetUseExistingOrganization() {
-			workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
-				v3_helpers.RevokeOrgEntitlementForIsolationSegment(orgGuid, SHARED_ISOLATION_SEGMENT_GUID)
-			})
-		}
+		workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
+			v3_helpers.UnassignIsolationSegmentFromSpace(spaceGuid)
+			v3_helpers.UnsetDefaultIsolationSegment(orgGuid)
+			v3_helpers.RevokeOrgEntitlementForIsolationSegment(orgGuid, isoSegGuid)
+			if isoSegGuid != SHARED_ISOLATION_SEGMENT_GUID {
+				v3_helpers.DeleteIsolationSegment(isoSegGuid)
+			}
+		})
 	})
 
 	Context("When an app is pushed to a space assigned the shared isolation segment", func() {
@@ -70,8 +66,9 @@ var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
 
 		BeforeEach(func() {
 			workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
-				v3_helpers.EntitleOrgToIsolationSegment(orgGuid, SHARED_ISOLATION_SEGMENT_GUID)
-				v3_helpers.AssignIsolationSegmentToSpace(spaceGuid, SHARED_ISOLATION_SEGMENT_GUID)
+				isoSegGuid = SHARED_ISOLATION_SEGMENT_GUID
+				v3_helpers.EntitleOrgToIsolationSegment(orgGuid, isoSegGuid)
+				v3_helpers.AssignIsolationSegmentToSpace(spaceGuid, isoSegGuid)
 				appName = random_name.CATSRandomName("APP")
 			})
 			Eventually(cf.Cf(
@@ -112,7 +109,7 @@ var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
 
 		BeforeEach(func() {
 			workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
-				isoSegGuid, created = v3_helpers.CreateOrGetIsolationSegment(isoSegName)
+				isoSegGuid = v3_helpers.CreateIsolationSegment(isoSegName)
 				v3_helpers.EntitleOrgToIsolationSegment(orgGuid, isoSegGuid)
 				session := cf.Cf("curl", fmt.Sprintf("/v3/spaces?names=%s", spaceName))
 				bytes := session.Wait(Config.DefaultTimeoutDuration()).Out.Contents()
@@ -134,15 +131,6 @@ var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
 			Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
 		})
 
-		AfterEach(func() {
-			if created {
-				workflowhelpers.AsUser(testSetup.AdminUserContext(), testSetup.ShortTimeout(), func() {
-					v3_helpers.UnassignIsolationSegmentFromSpace(spaceGuid)
-					v3_helpers.RevokeOrgEntitlementForIsolationSegment(orgGuid, isoSegGuid)
-					v3_helpers.DeleteIsolationSegment(isoSegGuid)
-				})
-			}
-		})
 		It("the app is reachable from the isolated router", func() {
 			resp := v3_helpers.SendRequestWithSpoofedHeader(fmt.Sprintf("%s.%s", appName, isoSegDomain), isoSegDomain)
 			defer resp.Body.Close()


### PR DESCRIPTION
We don't have an environment that is setup to run the test at `routing_isolation_segments/routing_isolation_segments.go:103`, so we haven't been able to run this test, but we believe it's good.

[#145311439](https://www.pivotaltracker.com/story/show/145311439)

-- @anniesing && @mikexuu 