### PR TITLE
Add Service Broker Schema tests

### DIFF
--- a/assets/service_broker/cats.json
+++ b/assets/service_broker/cats.json
@@ -51,7 +51,8 @@
                       "content": "40 concurrent connections"
                     }
                   ]
-                }
+                },
+                "schemas": "<fake-plan-schema>"
               },
               {
                 "name": "<fake-plan-2>",

--- a/services/service_broker_lifecycle.go
+++ b/services/service_broker_lifecycle.go
@@ -59,11 +59,31 @@ var _ = ServicesDescribe("Service Broker Lifecycle", func() {
 				Expect(plans).To(Say(broker.SyncPlans[0].Name))
 				Expect(plans).To(Say(broker.SyncPlans[1].Name))
 
+				// Confirm default schemas show up in CAPI
+				cfResponse := cf.Cf("curl", fmt.Sprintf("/v2/service_plans?q=unique_id:%s", broker.SyncPlans[0].ID)).
+					Wait(Config.DefaultTimeoutDuration()).Out.Contents()
+
+				var plansResponse ServicePlansResponse
+				err := json.Unmarshal(cfResponse, &plansResponse)
+				Expect(err).To(BeNil())
+
+				var emptySchemas PlanSchemas
+				emptySchemas.ServiceInstance.Create.Parameters = map[string]interface{}{}
+
+				Expect(plansResponse.Resources[0].Entity.Schemas).To(Equal(emptySchemas))
+
 				// Changing the catalog on the broker
 				oldServiceName = broker.Service.Name
 				oldPlanName = broker.SyncPlans[0].Name
 				broker.Service.Name = random_name.CATSRandomName("SVC")
 				broker.SyncPlans[0].Name = random_name.CATSRandomName("SVC-PLAN")
+
+				var basicSchema PlanSchemas
+				basicSchema.ServiceInstance.Create.Parameters = map[string]interface{}{
+					"$schema": "http://example.com/broker/schema", "type": "object",
+				}
+				broker.SyncPlans[0].Schemas = basicSchema
+
 				broker.Configure()
 				broker.Update()
 
@@ -74,6 +94,14 @@ var _ = ServicesDescribe("Service Broker Lifecycle", func() {
 				Expect(plans).NotTo(Say(oldPlanName))
 				Expect(plans).To(Say(broker.Service.Name))
 				Expect(plans).To(Say(broker.Plans()[0].Name))
+
+				// Confirm plan schemas show up in CAPI
+				cfResponse = cf.Cf("curl", fmt.Sprintf("/v2/service_plans?q=unique_id:%s", broker.SyncPlans[0].ID)).
+					Wait(Config.DefaultTimeoutDuration()).Out.Contents()
+
+				err = json.Unmarshal(cfResponse, &plansResponse)
+				Expect(err).To(BeNil())
+				Expect(plansResponse.Resources[0].Entity.Schemas).To(Equal(broker.SyncPlans[0].Schemas))
 
 				// Deleting the service broker and confirming the plans no longer display
 				workflowhelpers.AsUser(TestSetup.AdminUserContext(), TestSetup.ShortTimeout(), func() {


### PR DESCRIPTION
As a service broker author, I can register a single plan with a create service instance schema [#145580729](https://www.pivotaltracker.com/story/show/145580729)

As a client tooling author, I can retrieve a create service instance schema for a plan [#146453595](https://www.pivotaltracker.com/story/show/146453595)

## Why

The Open Service Broker API is [proposing](https://github.com/openservicebrokerapi/servicebroker/issues/59) allowing brokers to define JSON schema for their configuration parameters. This will allow tooling to validate parameters and UIs to auto generate forms.

Schemas are to be defined as part of the catalog on a plan and support create/update parameters on a service instance and create parameters on a service binding (update does not exist yet).

The updated spec can be found [here](https://github.com/avade/servicebroker/blob/method-attached-schemas/spec.md#schema-object).

Example of what a new catalog with schemas will look like:
```
{
     ....
    "plans": [{
      "name": "fake-plan-1",
      "id": "d3031751-XXXX-XXXX-XXXX-a42377d3320e",
      "description": "Shared fake Server, 5tb persistent disk, 40 max concurrent connections",
      "schemas": {
        "service_instance": {
          "create": {
            "parameters": {
              "$schema": "http://json-schema.org/draft-04/schema#",
              "type": "object",
              "properties": {
                "billing-account": {
                  "description": "Billing account number used to charge use of shared fake server.",
                  "type": "string"
                }
              }
            }
          }
        }
      }
    }]
}
```

## What

This PR adds CATS for create instance schemas.
1. Test default schema for brokers that do not provide them.
1. Test brokers that provide schemas.

## Notes
For now this feature is only exposed through the CC API. So this PR uses `cf curl`. In the future, this should be replaced with the appropriate CF Cli command.
The feature is not complete in CAPI yet, there will be more PRs into CATS for additional tests down the line.

Feedback appreciated!

## PR 

Sam & @ablease

cc: @mattmcneeney @st3v 