### PR TITLE
Add Service Broker Schema tests take two

### DIFF
--- a/assets/service_broker/cats.json
+++ b/assets/service_broker/cats.json
@@ -51,7 +51,8 @@
                       "content": "40 concurrent connections"
                     }
                   ]
-                }
+                },
+                "schemas": "<fake-plan-schema>"
               },
               {
                 "name": "<fake-plan-2>",

--- a/helpers/services/broker.go
+++ b/helpers/services/broker.go
@@ -22,8 +22,17 @@ import (
 )
 
 type Plan struct {
-	Name string `json:"name"`
-	ID   string `json:"id"`
+	Name    string      `json:"name"`
+	ID      string      `json:"id"`
+	Schemas PlanSchemas `json:"schemas"`
+}
+
+type PlanSchemas struct {
+	ServiceInstance struct {
+		Create struct {
+			Parameters map[string]interface{} `json:"parameters"`
+		} `json:"create"`
+	} `json:"service_instance"`
 }
 
 type ServiceBroker struct {
@@ -54,10 +63,15 @@ type ServiceResponse struct {
 	}
 }
 
+type ServicePlansResponse struct {
+	Resources []ServicePlanResponse
+}
+
 type ServicePlanResponse struct {
 	Entity struct {
-		Name   string
-		Public bool
+		Name    string
+		Public  bool
+		Schemas PlanSchemas
 	}
 	Metadata struct {
 		Url  string
@@ -89,6 +103,7 @@ func NewServiceBroker(name string, path string, TestSetup *workflowhelpers.Repro
 	b.Name = name
 	b.Service.Name = random_name.CATSRandomName("SVC")
 	b.Service.ID = random_name.CATSRandomName("SVC-ID")
+
 	b.SyncPlans = []Plan{
 		{Name: random_name.CATSRandomName("SVC-PLAN"), ID: random_name.CATSRandomName("SVC-PLAN-ID")},
 		{Name: random_name.CATSRandomName("SVC-PLAN"), ID: random_name.CATSRandomName("SVC-PLAN-ID")},
@@ -168,6 +183,9 @@ func (b ServiceBroker) ToJSON() string {
 	bytes, err := ioutil.ReadFile(assets.NewAssets().ServiceBroker + "/cats.json")
 	Expect(err).To(BeNil())
 
+	planSchema, err := json.Marshal(b.SyncPlans[0].Schemas)
+	Expect(err).To(BeNil())
+
 	replacer := strings.NewReplacer(
 		"<fake-service>", b.Service.Name,
 		"<fake-service-guid>", b.Service.ID,
@@ -182,6 +200,7 @@ func (b ServiceBroker) ToJSON() string {
 		"<fake-async-plan-guid>", b.AsyncPlans[0].ID,
 		"<fake-async-plan-2>", b.AsyncPlans[1].Name,
 		"<fake-async-plan-2-guid>", b.AsyncPlans[1].ID,
+		"\"<fake-plan-schema>\"", string(planSchema),
 	)
 
 	return replacer.Replace(string(bytes))


### PR DESCRIPTION
This PR is a dupe of https://github.com/cloudfoundry/cf-acceptance-tests/pull/227 except it has been updated to reflect the later version of capi-release which includes [extra validation](https://github.com/cloudfoundry/cloud_controller_ng/pull/847).

We have run these branch on our bosh-lite.