### PR TITLE
Increase memory for Java apps 512M -> 1024M

### DIFF
--- a/apps/encoding.go
+++ b/apps/encoding.go
@@ -23,7 +23,7 @@ var _ = AppsDescribe("Encoding", func() {
 			"--no-start",
 			"-b", Config.GetJavaBuildpackName(),
 			"-p", assets.NewAssets().Java,
-			"-m", "512M",
+			"-m", "1024M",
 			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		app_helpers.SetBackend(appName)
 		Expect(cf.Cf("set-env", appName, "JAVA_OPTS", "-Djava.security.egd=file:///dev/urandom").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))

--- a/detect/buildpacks.go
+++ b/detect/buildpacks.go
@@ -56,7 +56,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 
 	Describe("java", func() {
 		It("makes the app reachable via its bound route", func() {
-			Expect(cf.Cf("push", appName, "--no-start", "-p", assets.NewAssets().Java, "-m", "512M", "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+			Expect(cf.Cf("push", appName, "--no-start", "-p", assets.NewAssets().Java, "-m", "1024M", "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 			app_helpers.SetBackend(appName)
 			Expect(cf.Cf("set-env", appName, "JAVA_OPTS", "-Djava.security.egd=file:///dev/urandom").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 			Expect(cf.Cf("start", appName).Wait(CF_JAVA_TIMEOUT)).To(Exit(0))


### PR DESCRIPTION
We are moving the Java buildback from v3 to v4. As a result, Java apps now require a higher minimum memory allotment.