### PR TITLE
Add Update Instance / Create Binding Service Schemas

### DIFF
--- a/helpers/services/broker.go
+++ b/helpers/services/broker.go
@@ -32,6 +32,9 @@ type PlanSchemas struct {
 		Create struct {
 			Parameters map[string]interface{} `json:"parameters"`
 		} `json:"create"`
+		Update struct {
+			Parameters map[string]interface{} `json:"parameters"`
+		} `json:"update"`
 	} `json:"service_instance"`
 }
 

--- a/helpers/services/broker.go
+++ b/helpers/services/broker.go
@@ -36,6 +36,11 @@ type PlanSchemas struct {
 			Parameters map[string]interface{} `json:"parameters"`
 		} `json:"update"`
 	} `json:"service_instance"`
+	ServiceBinding struct {
+		Create struct {
+			Parameters map[string]interface{} `json:"parameters"`
+		} `json:"create"`
+	} `json:"service_binding"`
 }
 
 type ServiceBroker struct {

--- a/services/service_broker_lifecycle.go
+++ b/services/service_broker_lifecycle.go
@@ -70,6 +70,7 @@ var _ = ServicesDescribe("Service Broker Lifecycle", func() {
 				var emptySchemas PlanSchemas
 				emptySchemas.ServiceInstance.Create.Parameters = map[string]interface{}{}
 				emptySchemas.ServiceInstance.Update.Parameters = map[string]interface{}{}
+				emptySchemas.ServiceBinding.Create.Parameters = map[string]interface{}{}
 
 				Expect(plansResponse.Resources[0].Entity.Schemas).To(Equal(emptySchemas))
 
@@ -83,12 +84,17 @@ var _ = ServicesDescribe("Service Broker Lifecycle", func() {
 				basicSchema.ServiceInstance.Create.Parameters = map[string]interface{}{
 					"$schema": "http://json-schema.org/draft-04/schema#",
 					"type":    "object",
-					"title":   "create service schema",
+					"title":   "create instance schema",
 				}
 				basicSchema.ServiceInstance.Update.Parameters = map[string]interface{}{
 					"$schema": "http://json-schema.org/draft-04/schema#",
 					"type":    "object",
-					"title":   "update service schema",
+					"title":   "update instance schema",
+				}
+				basicSchema.ServiceBinding.Create.Parameters = map[string]interface{}{
+					"$schema": "http://json-schema.org/draft-04/schema#",
+					"type":    "object",
+					"title":   "create binding schema",
 				}
 				broker.SyncPlans[0].Schemas = basicSchema
 

--- a/services/service_broker_lifecycle.go
+++ b/services/service_broker_lifecycle.go
@@ -69,6 +69,7 @@ var _ = ServicesDescribe("Service Broker Lifecycle", func() {
 
 				var emptySchemas PlanSchemas
 				emptySchemas.ServiceInstance.Create.Parameters = map[string]interface{}{}
+				emptySchemas.ServiceInstance.Update.Parameters = map[string]interface{}{}
 
 				Expect(plansResponse.Resources[0].Entity.Schemas).To(Equal(emptySchemas))
 
@@ -80,7 +81,14 @@ var _ = ServicesDescribe("Service Broker Lifecycle", func() {
 
 				var basicSchema PlanSchemas
 				basicSchema.ServiceInstance.Create.Parameters = map[string]interface{}{
-					"$schema": "http://json-schema.org/draft-04/schema#", "type": "object",
+					"$schema": "http://json-schema.org/draft-04/schema#",
+					"type":    "object",
+					"title":   "create service schema",
+				}
+				basicSchema.ServiceInstance.Update.Parameters = map[string]interface{}{
+					"$schema": "http://json-schema.org/draft-04/schema#",
+					"type":    "object",
+					"title":   "update service schema",
 				}
 				broker.SyncPlans[0].Schemas = basicSchema
 


### PR DESCRIPTION

## Why
The Open Service Broker API is [proposing](https://github.com/openservicebrokerapi/servicebroker/issues/59) allowing brokers to define JSON schema for their configuration parameters.

[Create Instance Schema](https://github.com/cloudfoundry/cf-acceptance-tests/pull/229) CATs were previously added.

Support for [Update Service Instance Schema](https://github.com/cloudfoundry/cloud_controller_ng/pull/865) and [Create Binding Schema](https://github.com/cloudfoundry/cloud_controller_ng/pull/866) have now been added to the cloud_controller and have made their way to cf-release & cf-deployment.

## What
This PR adds tests for update instance and create binding.

Feedback welcome!

Thanks,
Sam & @jenspinney 
