### PR TITLE
Wrap the callback in a describe in order to avoid AfterEach invocations

### DIFF
--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -28,59 +28,59 @@ var (
 )
 
 func AppsDescribe(description string, callback func()) bool {
-	return Describe("[apps] "+description, func() {
+	return Describe("[apps]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeApps() {
 				Skip(`Skipping this test because Config.IncludeApps is set to 'false'.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
 func IsolationSegmentsDescribe(description string, callback func()) bool {
-	return Describe("[isolation_segments] "+description, func() {
+	return Describe("[isolation_segments]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeIsolationSegments() {
 				Skip(`Skipping this test because Config.IncludeIsolationSegments is set to 'false'.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
 func BackendCompatibilityDescribe(description string, callback func()) bool {
-	return Describe("[backend_compatibility] "+description, func() {
+	return Describe("[backend_compatibility]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeBackendCompatiblity() {
 				Skip(`Skipping this test because Config.IncludeBackendCompatibility is set to 'false'.
 			NOTE: Ensure that your deployment has deployed both DEA and Diego before running this test.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
 func DetectDescribe(description string, callback func()) bool {
-	return Describe("[detect] "+description, func() {
+	return Describe("[detect]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeDetect() {
 				Skip(`Skipping this test because Config.IncludeDetect is set to 'false'.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
 func DockerDescribe(description string, callback func()) bool {
-	return Describe("[docker] "+description, func() {
+	return Describe("[docker]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeDocker() {
 				Skip(`Skipping this test because Config.IncludeDocker is set to 'false'.
 				NOTE: Ensure Docker containers are enabled on your platform before enabling this test.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
@@ -90,53 +90,53 @@ func TestCliVersionCheck(t *testing.T) {
 }
 
 func InternetDependentDescribe(description string, callback func()) bool {
-	return Describe("[internet_dependent] "+description, func() {
+	return Describe("[internet_dependent]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeInternetDependent() {
 				Skip(`Skipping this test because Config.IncludeInternetDependent is set to 'false'.
 NOTE: Ensure that your deployment has access to the internet before running this test.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
 func RouteServicesDescribe(description string, callback func()) bool {
-	return Describe("[route_services] "+description, func() {
+	return Describe("[route_services]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeRouteServices() {
 				Skip(`Skipping this test because Config.IncludeRouteServices is set to 'false'.
 			NOTE: Ensure that route services are enabled in your deployment before running this test.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
 func RoutingDescribe(description string, callback func()) bool {
-	return Describe("[routing] "+description, func() {
+	return Describe("[routing]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeRouting() {
 				Skip(`Skipping this test because Config.IncludeRouting is set to 'false'.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
 func RoutingIsolationSegmentsDescribe(description string, callback func()) bool {
-	return Describe("[routing_isolation_segments] "+description, func() {
+	return Describe("[routing_isolation_segments]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeRoutingIsolationSegments() {
 				Skip(`Skipping this test because Config.IncludeRoutingIsolationSegments is set to 'false'.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
 func ZipkinDescribe(description string, callback func()) bool {
-	return Describe("[routing] "+description, func() {
+	return Describe("[routing]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeRouting() {
 				Skip(`Skipping this test because Config.IncludeRouting is set to 'false'`)
@@ -146,86 +146,86 @@ func ZipkinDescribe(description string, callback func()) bool {
 				Skip(`Skipping this test because Config.IncludeZipkin is set to 'false'`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
 func SecurityGroupsDescribe(description string, callback func()) bool {
-	return Describe("[security_groups] "+description, func() {
+	return Describe("[security_groups]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeSecurityGroups() {
 				Skip(`Skipping this test because Config.IncludeSecurityGroups is set to 'false'.
 			NOTE: Ensure that your deployment restricts internal network traffic by default in order to run this test.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
 func ServicesDescribe(description string, callback func()) bool {
-	return Describe("[services] "+description, func() {
+	return Describe("[services]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeServices() {
 				Skip(`Skipping this test because Config.IncludeServices is set to 'false'.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
 func SshDescribe(description string, callback func()) bool {
-	return Describe("[ssh] "+description, func() {
+	return Describe("[ssh]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeSsh() {
 				Skip(`Skipping this test because Config.IncludeSsh is set to 'false'.
 			NOTE: Ensure that your platform is deployed with a Diego SSH proxy in order to run this test.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
 func V3Describe(description string, callback func()) bool {
-	return Describe("[v3] "+description, func() {
+	return Describe("[v3]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeV3() {
 				Skip(`Skipping this test because Config.IncludeV3 is set to 'false'.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
 func CapiExperimentalDescribe(description string, callback func()) bool {
-	return Describe("[capi_experimental] "+description, func() {
+	return Describe("[capi_experimental]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeCapiExperimental() {
 				Skip(`Skipping this test because Config.IncludeCapiExperimental is set to 'false'.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
 func TasksDescribe(description string, callback func()) bool {
-	return Describe("[tasks] "+description, func() {
+	return Describe("[tasks]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeTasks() {
 				Skip(`Skipping this test because Config.IncludeTasks is set to 'false'.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
 func PersistentAppDescribe(description string, callback func()) bool {
-	return Describe("[persistent_app] "+description, func() {
+	return Describe("[persistent_app]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludePersistentApp() {
 				Skip(`Skipping this test because Config.IncludePersistentApp is set to 'false'.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }
 
@@ -240,12 +240,12 @@ func GuidForAppName(appName string) string {
 
 
 func CredHubDescribe(description string, callback func()) bool {
-	return Describe("[credhub] "+description, func() {
+	return Describe("[credhub]", func() {
 		BeforeEach(func() {
 			if !Config.GetIncludeCredHub() {
 				Skip(`Skipping this test because Config.IncludeCredHub is set to 'false'.`)
 			}
 		})
-		callback()
+		Describe(description, callback)
 	})
 }


### PR DESCRIPTION
When running no tests this dropped the time from 45s to ~20s (bosh-lite)

Signed-off-by: Vikram Yadav <vyadav@pivotal.io>