### PR TITLE
Add test for CredHub-enabled service keys

### DIFF
--- a/assets/credhub-enabled-app/README.md
+++ b/assets/credhub-enabled-app/README.md
@@ -1,0 +1,4 @@
+To rebuild credhub-enabled-app.jar:
+```bash
+./gradlew build jar
+```

--- a/assets/credhub-enabled-app/src/main/java/org/credhub/CredHubEnabledController.java
+++ b/assets/credhub-enabled-app/src/main/java/org/credhub/CredHubEnabledController.java
@@ -22,7 +22,8 @@ public class CredHubEnabledController {
   @GetMapping({"/test"})
   public Object runTests() throws Exception {
     String vcapServices = System.getenv("VCAP_SERVICES");
-    return ((Map)((List)this.interpolateServiceData(vcapServices).get("credhub-read")).get(0)).get("credentials");
+    String serviceOfferingName = System.getenv("SERVICE_NAME") != null ? System.getenv("SERVICE_NAME") : "credhub-read";
+    return ((Map)((List)this.interpolateServiceData(vcapServices).get(serviceOfferingName)).get(0)).get("credentials");
   }
 
   private ServicesData interpolateServiceData(String vcapServices) throws IOException {

--- a/assets/credhub-service-broker/main.go
+++ b/assets/credhub-service-broker/main.go
@@ -26,8 +26,10 @@ type Server struct {
 }
 
 type bindRequest struct {
-	AppGuid            string `json:"app_guid"`
-	CredentialClientId string `json:"credential_client_id"`
+	AppGuid      string `json:"app_guid"`
+	BindResource struct {
+								 CredentialClientId string `json:"credential_client_id"`
+							 } `json:"bind_resource"`
 }
 
 type permissions struct {
@@ -116,7 +118,7 @@ func (s *ServiceBroker) Bind(w http.ResponseWriter, r *http.Request) {
 	actorId := "mtls-app:" + body.AppGuid
 
 	if body.AppGuid == "" {
-		actorId = "uaa-client:" + body.CredentialClientId
+		actorId = "uaa-client:" + body.BindResource.CredentialClientId
 	}
 
 	permissionJson := permissions{

--- a/assets/credhub-service-broker/main.go
+++ b/assets/credhub-service-broker/main.go
@@ -26,7 +26,8 @@ type Server struct {
 }
 
 type bindRequest struct {
-	AppGuid string `json:"app_guid"`
+	AppGuid            string `json:"app_guid"`
+	CredentialClientId string `json:"credential_client_id"`
 }
 
 type permissions struct {
@@ -69,9 +70,14 @@ func (s *ServiceBroker) Catalog(w http.ResponseWriter, r *http.Request) {
 	serviceUUID := uuid.NewV4().String()
 	planUUID := uuid.NewV4().String()
 
+	serviceName := "credhub-read"
+	if os.Getenv("SERVICE_NAME") != "" {
+		serviceName = os.Getenv("SERVICE_NAME")
+	}
+
 	catalog := `{
 	"services": [{
-		"name": "credhub-read",
+		"name": "` + serviceName + `",
 		"id": "` + serviceUUID + `",
 		"description": "credhub read service for tests",
 		"bindable": true,
@@ -107,8 +113,14 @@ func (s *ServiceBroker) Bind(w http.ResponseWriter, r *http.Request) {
 		"password":  "rainbowDash",
 	}
 
+	actorId := "mtls-app:" + body.AppGuid
+
+	if body.AppGuid == "" {
+		actorId = "uaa-client:" + body.CredentialClientId
+	}
+
 	permissionJson := permissions{
-		Actor:      "mtls-app:" + body.AppGuid,
+		Actor:      actorId,
 		Operations: []string{"read", "delete"},
 	}
 

--- a/credhub/credhub_enabled.go
+++ b/credhub/credhub_enabled.go
@@ -146,6 +146,8 @@ var _ = CredHubDescribe("CredHub Integration", func() {
 
 			Context("when a service key for a service instance is requested from a CredHub-enabled broker", func() {
 				It("Cloud Controller retrieves the value from CredHub for the service key", func() {
+					TestSetup.RegularUserContext().TargetSpace()
+
 					serviceKeyName = random_name.CATSRandomName("SVKEY-CH")
 					createKey := cf.Cf("create-service-key", instanceName, serviceKeyName).Wait(Config.DefaultTimeoutDuration())
 					Expect(createKey).To(Exit(0), "failed to create key")

--- a/credhub/credhub_enabled.go
+++ b/credhub/credhub_enabled.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
 
 	"encoding/json"
@@ -25,7 +26,7 @@ var _ = CredHubDescribe("CredHub Integration", func() {
 	})
 
 	Context("when CredHub is configured", func() {
-		var appName, appURL, chBrokerName, instanceName string
+		var chBrokerName, chServiceName, instanceName string
 
 		BeforeEach(func() {
 			TestSetup.RegularUserContext().TargetSpace()
@@ -37,76 +38,125 @@ var _ = CredHubDescribe("CredHub Integration", func() {
 			pushBroker := cf.Cf("push", chBrokerName, "-b", Config.GetGoBuildpackName(), "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().CredHubServiceBroker, "-f", assets.NewAssets().CredHubServiceBroker+"/manifest.yml", "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())
 			Expect(pushBroker).To(Exit(0), "failed pushing credhub-enabled service broker")
 
+			chServiceName = random_name.CATSRandomName("SERVICE-NAME")
+			setServiceName := cf.Cf("set-env", chBrokerName, "SERVICE_NAME", chServiceName).Wait(Config.DefaultTimeoutDuration())
+			Expect(setServiceName).To(Exit(0), "failed setting SERVICE_NAME env var on credhub-enabled service broker")
+
+			restartBroker := cf.Cf("restart", chBrokerName).Wait(Config.CfPushTimeoutDuration())
+			Expect(restartBroker).To(Exit(0), "failed restarting credhub-enabled service broker")
+
 			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
 				serviceUrl := "https://" + chBrokerName + "." + Config.GetAppsDomain()
 				createServiceBroker := cf.Cf("create-service-broker", chBrokerName, Config.GetAdminUser(), Config.GetAdminPassword(), serviceUrl).Wait(Config.DefaultTimeoutDuration())
 				Expect(createServiceBroker).To(Exit(0), "failed creating credhub-enabled service broker")
 
-				enableAccess := cf.Cf("enable-service-access", "credhub-read", "-o", TestSetup.RegularUserContext().Org).Wait(Config.DefaultTimeoutDuration())
+				enableAccess := cf.Cf("enable-service-access", chServiceName, "-o", TestSetup.RegularUserContext().Org).Wait(Config.DefaultTimeoutDuration())
 				Expect(enableAccess).To(Exit(0), "failed to enable service access for credhub-enabled broker")
-			})
 
-			appName = random_name.CATSRandomName("APP-CH")
-			appURL = "https://" + appName + "." + Config.GetAppsDomain()
-			createApp := cf.Cf("push", appName, "--no-start", "-b", Config.GetJavaBuildpackName(), "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().CredHubEnabledApp, "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())
-			Expect(createApp).To(Exit(0), "failed creating credhub-enabled app")
-			app_helpers.SetBackend(appName)
-
-			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
 				TestSetup.RegularUserContext().TargetSpace()
 				instanceName = random_name.CATSRandomName("SVIN-CH")
-				createService := cf.Cf("create-service", "credhub-read", "credhub-read-plan", instanceName).Wait(Config.DefaultTimeoutDuration())
+				createService := cf.Cf("create-service", chServiceName, "credhub-read-plan", instanceName).Wait(Config.DefaultTimeoutDuration())
 				Expect(createService).To(Exit(0), "failed creating credhub enabled service")
-
-				bindService := cf.Cf("bind-service", appName, instanceName).Wait(Config.DefaultTimeoutDuration())
-				Expect(bindService).To(Exit(0), "failed binding app to service")
-				Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 			})
 		})
 
 		AfterEach(func() {
-			app_helpers.AppReport(appName, Config.DefaultTimeoutDuration())
-
 			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
 				TestSetup.RegularUserContext().TargetSpace()
-				unbindService := cf.Cf("unbind-service", appName, instanceName).Wait(Config.DefaultTimeoutDuration())
-				Expect(unbindService).To(Exit(0), "failed unbinding app and service")
 
-				Expect(cf.Cf("delete", appName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 				Expect(cf.Cf("delete-service", instanceName, "-f").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-				Expect(cf.Cf("purge-service-offering", "credhub-service").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+				Expect(cf.Cf("purge-service-offering", chServiceName).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 				Expect(cf.Cf("delete-service-broker", chBrokerName, "-f").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 			})
 		})
 
-		Context("when CredHub enabled broker is bound to application", func() {
-			It("the broker returns credhub-ref in the credentials block", func() {
-				restageApp := cf.Cf("restage", appName).Wait(Config.CfPushTimeoutDuration())
-				Expect(restageApp).To(Exit(0), "failed restaging app")
+		Describe("service bindings", func() {
+			var appName, appURL string
 
-				appEnv := string(cf.Cf("env", appName).Wait(Config.DefaultTimeoutDuration()).Out.Contents())
+			BeforeEach(func() {
+				appName = random_name.CATSRandomName("APP-CH")
+				appURL = "https://" + appName + "." + Config.GetAppsDomain()
+				createApp := cf.Cf("push", appName, "--no-start", "-b", Config.GetJavaBuildpackName(), "-m", "1024M", "-p", assets.NewAssets().CredHubEnabledApp, "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())
+				Expect(createApp).To(Exit(0), "failed creating credhub-enabled app")
+				app_helpers.SetBackend(appName)
 
-				Expect(appEnv).To(ContainSubstring("credentials"), "credential block missing from service")
-				Expect(appEnv).To(ContainSubstring("credhub-ref"), "credhub-ref not found")
+				Expect(chServiceName).ToNot(Equal(""))
+				setServiceName := cf.Cf("set-env", appName, "SERVICE_NAME", chServiceName).Wait(Config.DefaultTimeoutDuration())
+				Expect(setServiceName).To(Exit(0), "failed setting SERVICE_NAME env var on app")
+
+				workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+					TestSetup.RegularUserContext().TargetSpace()
+
+					bindService := cf.Cf("bind-service", appName, instanceName).Wait(Config.DefaultTimeoutDuration())
+					Expect(bindService).To(Exit(0), "failed binding app to service")
+					Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				})
 			})
 
-			It("the bound app retrieves the credentials for the ref from CredHub", func() {
-				curlCmd := helpers.CurlSkipSSL(true, appURL+"/test").Wait(Config.DefaultTimeoutDuration())
-				Expect(curlCmd).To(Exit(0))
+			AfterEach(func() {
+				app_helpers.AppReport(appName, Config.DefaultTimeoutDuration())
 
-				bytes := curlCmd.Out.Contents()
-				var response struct {
-					UserName string `json:"user-name"`
-					Password string `json:"password"`
-				}
+				workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+					TestSetup.RegularUserContext().TargetSpace()
+					unbindService := cf.Cf("unbind-service", appName, instanceName).Wait(Config.DefaultTimeoutDuration())
+					Expect(unbindService).To(Exit(0), "failed unbinding app and service")
 
-				json.Unmarshal(bytes, &response)
-				Expect(response.UserName).To(Equal("pinkyPie"))
-				Expect(response.Password).To(Equal("rainbowDash"))
+					Expect(cf.Cf("delete", appName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				})
 			})
 
+			Context("when CredHub enabled broker is bound to application", func() {
+				It("the broker returns credhub-ref in the credentials block", func() {
+					restageApp := cf.Cf("restage", appName).Wait(Config.CfPushTimeoutDuration())
+					Expect(restageApp).To(Exit(0), "failed restaging app")
+
+					appEnv := string(cf.Cf("env", appName).Wait(Config.DefaultTimeoutDuration()).Out.Contents())
+
+					Expect(appEnv).To(ContainSubstring("credentials"), "credential block missing from service")
+					Expect(appEnv).To(ContainSubstring("credhub-ref"), "credhub-ref not found")
+				})
+
+				It("the bound app retrieves the credentials for the ref from CredHub", func() {
+					curlCmd := helpers.CurlSkipSSL(true, appURL+"/test").Wait(Config.DefaultTimeoutDuration())
+					Expect(curlCmd).To(Exit(0))
+
+					bytes := curlCmd.Out.Contents()
+					var response struct {
+						UserName string `json:"user-name"`
+						Password string `json:"password"`
+					}
+
+					json.Unmarshal(bytes, &response)
+					Expect(response.UserName).To(Equal("pinkyPie"))
+					Expect(response.Password).To(Equal("rainbowDash"))
+				})
+			})
 		})
 
-	})
+		Describe("service keys", func() {
+			var serviceKeyName string
 
+			AfterEach(func() {
+				workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+					TestSetup.RegularUserContext().TargetSpace()
+
+					Expect(cf.Cf("delete-service-key", instanceName, serviceKeyName, "-f").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				})
+			})
+
+			Context("when a service key for a service instance is requested from a CredHub-enabled broker", func() {
+				It("Cloud Controller retrieves the value from CredHub for the service key", func() {
+					serviceKeyName = random_name.CATSRandomName("SVKEY-CH")
+					createKey := cf.Cf("create-service-key", instanceName, serviceKeyName).Wait(Config.DefaultTimeoutDuration())
+					Expect(createKey).To(Exit(0), "failed to create key")
+
+					keyInfo := cf.Cf("service-key", instanceName, serviceKeyName).Wait(Config.DefaultTimeoutDuration())
+					Expect(keyInfo).To(Exit(0), "failed key info")
+
+					Expect(keyInfo).To(Say(`"password": "rainbowDash"`))
+					Expect(keyInfo).To(Say(`"user-name": "pinkyPie"`))
+				})
+			})
+		})
+	})
 })


### PR DESCRIPTION
- Updates the Credhub Service Broker to take in a SERVICE_NAME
  environment variable that allows it to have a CATS-specified name for
  its service offering
- Also updates the Credhub Enabled App to look for this same env var to
  properly read the service from its VCAP_SERVICES env
- Credhub Service Broker can now create CredHub credentials with both
  mtls-app and uaa-client actors

[#150753759](https://www.pivotaltracker.com/story/show/150753759)