### PR TITLE
add a flag to differentiate between assisted and non-assisted modes

### DIFF
--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -239,11 +239,22 @@ func GuidForAppName(appName string) string {
 	return appGuid
 }
 
-func CredHubDescribe(description string, callback func()) bool {
-	return Describe("[credhub]", func() {
+func AssistedCredhubDescribe(description string, callback func()) bool {
+	return Describe("[assisted credhub]", func() {
 		BeforeEach(func() {
-			if !Config.GetIncludeCredHub() {
-				Skip(skip_messages.SkipCredHubMessage)
+			if !Config.GetIncludeCredhubAssisted() {
+				Skip(skip_messages.SkipAssistedCredhubMessage)
+			}
+		})
+		Describe(description, callback)
+	})
+}
+
+func NonAssistedCredhubDescribe(description string, callback func()) bool {
+	return Describe("[non-assisted credhub]", func() {
+		BeforeEach(func() {
+			if !Config.GetIncludeCredhubNonAssisted() {
+				Skip(skip_messages.SkipNonAssistedCredhubMessage)
 			}
 		})
 		Describe(description, callback)

--- a/credhub/credhub_enabled.go
+++ b/credhub/credhub_enabled.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 )
 
-var _ = CredHubDescribe("CredHub Integration", func() {
+var _ = NonAssistedCredhubDescribe("CredHub Integration", func() {
 	BeforeEach(func() {
 		if Config.GetBackend() != "diego" {
 			Skip(skip_messages.SkipDiegoMessage)
@@ -47,7 +47,7 @@ var _ = CredHubDescribe("CredHub Integration", func() {
 			chServiceName = random_name.CATSRandomName("SERVICE-NAME")
 			Expect(cf.Cf(
 				"set-env", chBrokerAppName,
-					"SERVICE_NAME", chServiceName,
+				"SERVICE_NAME", chServiceName,
 			).Wait(Config.DefaultTimeoutDuration())).To(Exit(0), "failed setting SERVICE_NAME env var on credhub-enabled service broker")
 
 			Expect(cf.Cf(
@@ -86,11 +86,11 @@ var _ = CredHubDescribe("CredHub Integration", func() {
 				appURL = "https://" + appName + "." + Config.GetAppsDomain()
 				createApp := cf.Cf(
 					"push", appName,
-						"--no-start",
-						"-b", Config.GetJavaBuildpackName(),
-						"-m", "1024M",
-						"-p", assets.NewAssets().CredHubEnabledApp,
-						"-d", Config.GetAppsDomain(),
+					"--no-start",
+					"-b", Config.GetJavaBuildpackName(),
+					"-m", "1024M",
+					"-p", assets.NewAssets().CredHubEnabledApp,
+					"-d", Config.GetAppsDomain(),
 				).Wait(Config.CfPushTimeoutDuration())
 				Expect(createApp).To(Exit(0), "failed creating credhub-enabled app")
 				app_helpers.SetBackend(appName)

--- a/docker/credhub_enabled.go
+++ b/docker/credhub_enabled.go
@@ -22,16 +22,12 @@ var _ = DockerDescribe("Docker", func() {
 		if Config.GetBackend() != "diego" {
 			Skip(skip_messages.SkipDiegoMessage)
 		}
-
-		if !Config.GetIncludeCredHub() {
-			Skip(skip_messages.SkipCredHubMessage)
-		}
 	})
 
 	Context("when CredHub is configured", func() {
 		var chBrokerName, chServiceName, instanceName string
 
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			TestSetup.RegularUserContext().TargetSpace()
 			cf.Cf("target", "-o", TestSetup.RegularUserContext().Org)
 			Expect(string(cf.Cf("running-environment-variable-group").Wait(Config.DefaultTimeoutDuration()).Out.Contents())).To(ContainSubstring("CREDHUB_API"), "CredHub API environment not set")
@@ -74,16 +70,16 @@ var _ = DockerDescribe("Docker", func() {
 		})
 
 		Describe("service bindings", func() {
-			var appName, appURL string
+			var appName, appURL, dockerImage string
 
-			BeforeEach(func() {
+			JustBeforeEach(func() {
 				appName = random_name.CATSRandomName("APP-CH")
 				appURL = "https://" + appName + "." + Config.GetAppsDomain()
 				Eventually(cf.Cf(
 					"push", appName,
 					"--no-start",
 					// app is defined by cloudfoundry-incubator/diego-dockerfiles
-					"-o", Config.GetPublicDockerAppImage(),
+					"-o", dockerImage,
 					"-m", DEFAULT_MEMORY_LIMIT,
 					"-d", Config.GetAppsDomain(),
 					"-i", "1",
@@ -113,11 +109,39 @@ var _ = DockerDescribe("Docker", func() {
 				})
 			})
 
-			It("the app should see the service creds", func() {
-				env := helpers.CurlApp(Config, appName, "/env")
-				Expect(env).NotTo(ContainSubstring("credhub-ref"), "credhub-ref not found")
-				Expect(env).To(ContainSubstring("pinkyPie"))
-				Expect(env).To(ContainSubstring("rainbowDash"))
+			Context("in assisted mode", func() {
+				BeforeEach(func() {
+					if !Config.GetIncludeCredhubAssisted() {
+						Skip(skip_messages.SkipAssistedCredhubMessage)
+					}
+
+					dockerImage = Config.GetPublicDockerAppImage()
+				})
+
+				It("the app should see the service creds", func() {
+					env := helpers.CurlApp(Config, appName, "/env")
+					Expect(env).NotTo(ContainSubstring("credhub-ref"), "credhub-ref not found")
+					Expect(env).To(ContainSubstring("pinkyPie"))
+					Expect(env).To(ContainSubstring("rainbowDash"))
+				})
+			})
+
+			Context("in non-assisted mode", func() {
+				BeforeEach(func() {
+					if !Config.GetIncludeCredhubNonAssisted() {
+						Skip(skip_messages.SkipNonAssistedCredhubMessage)
+					}
+
+					// TODO: use the credhub enabled app docker image and interpolate the vcap_services manually
+					dockerImage = Config.GetPublicDockerAppImage()
+				})
+
+				It("the app should not automatically see the service creds", func() {
+					env := helpers.CurlApp(Config, appName, "/env")
+					Expect(env).To(ContainSubstring("credhub-ref"), "credhub-ref not found")
+					Expect(env).NotTo(ContainSubstring("pinkyPie"))
+					Expect(env).NotTo(ContainSubstring("rainbowDash"))
+				})
 			})
 		})
 	})

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -10,7 +10,8 @@ type CatsConfig interface {
 	GetIncludeCapiExperimental() bool
 	GetIncludeCapiNoBridge() bool
 	GetIncludeContainerNetworking() bool
-	GetIncludeCredHub() bool
+	GetIncludeCredhubAssisted() bool
+	GetIncludeCredhubNonAssisted() bool
 	GetIncludeDetect() bool
 	GetIncludeDocker() bool
 	GetIncludeInternetDependent() bool

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -12,6 +12,11 @@ import (
 	. "github.com/cloudfoundry/cf-acceptance-tests/helpers/validationerrors"
 )
 
+const (
+	CredhubAssistedMode    = "assisted"
+	CredhubNonAssistedMode = "non-assisted"
+)
+
 type config struct {
 	ApiEndpoint *string `json:"api"`
 	AppsDomain  *string `json:"apps_domain"`
@@ -62,29 +67,29 @@ type config struct {
 	RubyBuildpackName       *string `json:"ruby_buildpack_name"`
 	StaticFileBuildpackName *string `json:"staticfile_buildpack_name"`
 
-	IncludeApps                       *bool `json:"include_apps"`
-	IncludeBackendCompatiblity        *bool `json:"include_backend_compatibility"`
-	IncludeCapiExperimental           *bool `json:"include_capi_experimental"`
-	IncludeCapiNoBridge               *bool `json:"include_capi_no_bridge"`
-	IncludeContainerNetworking        *bool `json:"include_container_networking"`
-	IncludeCredHub                    *bool `json:"include_credhub"`
-	IncludeDetect                     *bool `json:"include_detect"`
-	IncludeDocker                     *bool `json:"include_docker"`
-	IncludeInternetDependent          *bool `json:"include_internet_dependent"`
-	IncludePersistentApp              *bool `json:"include_persistent_app"`
-	IncludePrivateDockerRegistry      *bool `json:"include_private_docker_registry"`
-	IncludePrivilegedContainerSupport *bool `json:"include_privileged_container_support"`
-	IncludeRouteServices              *bool `json:"include_route_services"`
-	IncludeRouting                    *bool `json:"include_routing"`
-	IncludeSSO                        *bool `json:"include_sso"`
-	IncludeSecurityGroups             *bool `json:"include_security_groups"`
-	IncludeServices                   *bool `json:"include_services"`
-	IncludeSsh                        *bool `json:"include_ssh"`
-	IncludeTasks                      *bool `json:"include_tasks"`
-	IncludeV3                         *bool `json:"include_v3"`
-	IncludeZipkin                     *bool `json:"include_zipkin"`
-	IncludeIsolationSegments          *bool `json:"include_isolation_segments"`
-	IncludeRoutingIsolationSegments   *bool `json:"include_routing_isolation_segments"`
+	IncludeApps                       *bool   `json:"include_apps"`
+	IncludeBackendCompatiblity        *bool   `json:"include_backend_compatibility"`
+	IncludeCapiExperimental           *bool   `json:"include_capi_experimental"`
+	IncludeCapiNoBridge               *bool   `json:"include_capi_no_bridge"`
+	IncludeContainerNetworking        *bool   `json:"include_container_networking"`
+	CredhubMode                       *string `json:"credhub_mode"`
+	IncludeDetect                     *bool   `json:"include_detect"`
+	IncludeDocker                     *bool   `json:"include_docker"`
+	IncludeInternetDependent          *bool   `json:"include_internet_dependent"`
+	IncludePersistentApp              *bool   `json:"include_persistent_app"`
+	IncludePrivateDockerRegistry      *bool   `json:"include_private_docker_registry"`
+	IncludePrivilegedContainerSupport *bool   `json:"include_privileged_container_support"`
+	IncludeRouteServices              *bool   `json:"include_route_services"`
+	IncludeRouting                    *bool   `json:"include_routing"`
+	IncludeSSO                        *bool   `json:"include_sso"`
+	IncludeSecurityGroups             *bool   `json:"include_security_groups"`
+	IncludeServices                   *bool   `json:"include_services"`
+	IncludeSsh                        *bool   `json:"include_ssh"`
+	IncludeTasks                      *bool   `json:"include_tasks"`
+	IncludeV3                         *bool   `json:"include_v3"`
+	IncludeZipkin                     *bool   `json:"include_zipkin"`
+	IncludeIsolationSegments          *bool   `json:"include_isolation_segments"`
+	IncludeRoutingIsolationSegments   *bool   `json:"include_routing_isolation_segments"`
 
 	PrivateDockerRegistryImage    *string `json:"private_docker_registry_image"`
 	PrivateDockerRegistryUsername *string `json:"private_docker_registry_username"`
@@ -142,7 +147,7 @@ func getDefaults() config {
 	defaults.IncludeCapiExperimental = ptrToBool(false)
 	defaults.IncludeCapiNoBridge = ptrToBool(false)
 	defaults.IncludeContainerNetworking = ptrToBool(false)
-	defaults.IncludeCredHub = ptrToBool(false)
+	defaults.CredhubMode = ptrToString("")
 	defaults.IncludeDocker = ptrToBool(false)
 	defaults.IncludeInternetDependent = ptrToBool(false)
 	defaults.IncludeIsolationSegments = ptrToBool(false)
@@ -347,9 +352,6 @@ func validateConfig(config *config) Errors {
 
 	if config.IncludeContainerNetworking == nil {
 		errs.Add(fmt.Errorf("* 'include_container_networking' must not be null"))
-	}
-	if config.IncludeCredHub == nil {
-		errs.Add(fmt.Errorf("* 'include_credhub' must not be null"))
 	}
 	if config.IncludeDetect == nil {
 		errs.Add(fmt.Errorf("* 'include_detect' must not be null"))
@@ -830,8 +832,12 @@ func (c *config) GetIncludeCapiNoBridge() bool {
 	return *c.IncludeCapiNoBridge
 }
 
-func (c *config) GetIncludeCredHub() bool {
-	return *c.IncludeCredHub
+func (c *config) GetIncludeCredhubAssisted() bool {
+	return *c.CredhubMode == CredhubAssistedMode
+}
+
+func (c *config) GetIncludeCredhubNonAssisted() bool {
+	return *c.CredhubMode == CredhubNonAssistedMode
 }
 
 func (c *config) GetRubyBuildpackName() string {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -240,7 +240,8 @@ var _ = Describe("Config", func() {
 		Expect(config.GetIncludeZipkin()).To(BeFalse())
 		Expect(config.GetIncludeSSO()).To(BeFalse())
 		Expect(config.GetIncludeTasks()).To(BeFalse())
-		Expect(config.GetIncludeCredHub()).To(BeFalse())
+		Expect(config.GetIncludeCredhubAssisted()).To(BeFalse())
+		Expect(config.GetIncludeCredhubNonAssisted()).To(BeFalse())
 
 		Expect(config.GetBackend()).To(Equal(""))
 
@@ -349,8 +350,6 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(ContainSubstring("'include_v3' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_zipkin' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_isolation_segments' must not be null"))
-			Expect(err.Error()).To(ContainSubstring("'include_credhub' must not be null"))
-
 			Expect(err.Error()).To(ContainSubstring("'private_docker_registry_image' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'private_docker_registry_username' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'private_docker_registry_password' must not be null"))

--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -16,7 +16,9 @@ NOTE: Ensure that your platform has access to the internet before running this t
 const SkipPrivateDockerRegistryMessage string = `Skipping this test because config.IncludePrivateDockerRegistry is set to 'false'.
 NOTE: Ensure that you've provided values for config.PrivateDockerRegistryImage, config.PrivateDockerRegistryUsername,
 and config.PrivateDockerRegistryPassword before running this test.`
-const SkipCredHubMessage = `Skipping this test because Config.IncludeCredHub is set to 'false'.
+const SkipAssistedCredhubMessage = `Skipping this test because Config.CredhubMode is not set to 'assisted'.
+NOTE: Ensure instance identity credential is turned on and CredHub is deployed before enabling this test`
+const SkipNonAssistedCredhubMessage = `Skipping this test because Config.CredhubMode is not set to 'non-assisted'.
 NOTE: Ensure instance identity credential is turned on and CredHub is deployed before enabling this test`
 const SkipPersistentAppMessage string = `Skipping this test because config.IncludePersistentApp is set to 'false'.`
 const SkipPrivilegedContainerSupportMessage string = `Skipping this test because Config.IncludePrivilegedContainerSupport is set to 'false'.


### PR DESCRIPTION
also updated the docker credhub test to use the new flag and added a
non-assisted test to assert VCAP_SERVICES are not automatically interpolated in
that mode

[#151926448]