### PR TITLE
Make random IP configurable in security group test

### DIFF
--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -61,6 +61,7 @@ type CatsConfig interface {
 	GetPersistentAppQuotaName() string
 	GetPersistentAppSpace() string
 	GetRubyBuildpackName() string
+	GetUnallocatedIPForSecurityGroup() string
 	Protocol() string
 
 	AsyncServiceOperationTimeoutDuration() time.Duration

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -96,6 +96,8 @@ type config struct {
 	PrivateDockerRegistryPassword *string `json:"private_docker_registry_password"`
 	PublicDockerAppImage          *string `json:"public_docker_app_image"`
 
+	UnallocatedIPForSecurityGroup *string `json:"unallocated_ip_for_security_group"`
+
 	NamePrefix *string `json:"name_prefix"`
 }
 
@@ -187,6 +189,8 @@ func getDefaults() config {
 	defaults.PrivateDockerRegistryUsername = ptrToString("")
 	defaults.PrivateDockerRegistryPassword = ptrToString("")
 	defaults.PublicDockerAppImage = ptrToString("cloudfoundry/diego-docker-app-custom:latest")
+
+	defaults.UnallocatedIPForSecurityGroup = ptrToString("10.0.244.255")
 
 	defaults.NamePrefix = ptrToString("CATS")
 	return defaults
@@ -882,4 +886,8 @@ func (c *config) GetPrivateDockerRegistryPassword() string {
 
 func (c *config) GetPublicDockerAppImage() string {
 	return *c.PublicDockerAppImage
+}
+
+func (c *config) GetUnallocatedIPForSecurityGroup() string {
+	return *c.UnallocatedIPForSecurityGroup
 }

--- a/security_groups/running_security_groups.go
+++ b/security_groups/running_security_groups.go
@@ -266,7 +266,7 @@ var _ = SecurityGroupsDescribe("App Instance Networking", func() {
 
 		It("allows ip traffic from a container to a private, non-container destination after binding a security group and refuses it after unbinding the security group", func() {
 			dest := Destination{
-				IP:       "10.0.244.255", // some random IP that isn't covered by an existing Security Group rule
+				IP:       Config.GetUnallocatedIPForSecurityGroup(), // some random IP that isn't covered by an existing Security Group rule
 				Port:     80,
 				Protocol: "tcp",
 			}


### PR DESCRIPTION
Added a new parameter to configure unallocated IP for security group test, default is `10.0.244.255`

Signed-off-by: Josh Zarrabi <jzarrabi@pivotal.io>