### PR TITLE
Remove type from service schemas

### DIFF
--- a/services/service_broker_lifecycle.go
+++ b/services/service_broker_lifecycle.go
@@ -83,17 +83,14 @@ var _ = ServicesDescribe("Service Broker Lifecycle", func() {
 				var basicSchema PlanSchemas
 				basicSchema.ServiceInstance.Create.Parameters = map[string]interface{}{
 					"$schema": "http://json-schema.org/draft-04/schema#",
-					"type":    "object",
 					"title":   "create instance schema",
 				}
 				basicSchema.ServiceInstance.Update.Parameters = map[string]interface{}{
 					"$schema": "http://json-schema.org/draft-04/schema#",
-					"type":    "object",
 					"title":   "update instance schema",
 				}
 				basicSchema.ServiceBinding.Create.Parameters = map[string]interface{}{
 					"$schema": "http://json-schema.org/draft-04/schema#",
-					"type":    "object",
 					"title":   "create binding schema",
 				}
 				broker.SyncPlans[0].Schemas = basicSchema


### PR DESCRIPTION
This is no longer required as per v2.13 of the Open Service Broker Api Specification. Updating CATs to reflect the loosening of this requirement.

[#150877576](https://www.pivotaltracker.com/n/projects/2105761/stories/150877576)

Thanks,

Sapi (ablease, @jenspinney)