### PR TITLE
make service instance tests compatible with refactored CLI service command

### DIFF
--- a/apps/lifecycle.go
+++ b/apps/lifecycle.go
@@ -126,8 +126,9 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 						} `json:"entity"`
 					} `json:"resources"`
 				}
-				json.Unmarshal([]byte(routeBody), &routeJSON)
+				Expect(json.Unmarshal([]byte(routeBody), &routeJSON)).To(Succeed())
 
+				Expect(len(routeJSON.Resources)).To(BeNumerically(">=", 1))
 				spaceGuid := routeJSON.Resources[0].Entity.SpaceGuid
 				domainGuid := routeJSON.Resources[0].Entity.DomainGuid
 				appGuid := cf.Cf("app", app2, "--guid").Wait(Config.DefaultTimeoutDuration()).Out.Contents()


### PR DESCRIPTION
- made tests more flexible towards casing and spacing
- assert on combined stdout and stderr output
- tests are backwards compatible to pre service refactor