### PR TITLE
Test service instance sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ cat > integration_config.json <<EOF
   "include_routing_isolation_segments": false,
   "include_security_groups": true,
   "include_services": true,
+  "include_service_instance_sharing": false,
   "include_ssh": false,
   "include_sso": true,
   "include_tasks": true,
@@ -173,6 +174,7 @@ include_routing
 * `include_routing`: Flag to include the routing tests.
 * `include_security_groups`: Flag to include tests for security groups.
 * `include_services`: Flag to include test for the services API.
+* `include_service_instance_sharing`: Flag to include tests for service instance sharing between spaces. `include_services` must be set for these tests to run. The `service_instance_sharing` feature flag must also be enabled for these tests to pass.
 * `include_ssh`: Flag to include tests for Diego container ssh feature.
 * `include_sso`: Flag to include the services tests that integrate with Single Sign On. `include_services` must also be set for tests to run.
 * `include_tasks`: Flag to include the v3 task tests. `include_v3` must also be set for tests to run. The CC API task_creation feature flag must be enabled for these tests to pass.

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -29,6 +29,7 @@ type CatsConfig interface {
 	GetIncludeV3() bool
 	GetIncludeIsolationSegments() bool
 	GetIncludeRoutingIsolationSegments() bool
+	GetIncludeServiceInstanceSharing() bool
 	GetShouldKeepUser() bool
 	GetSkipSSLValidation() bool
 	GetUseExistingUser() bool

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -84,6 +84,7 @@ type config struct {
 	IncludeSSO                        *bool   `json:"include_sso"`
 	IncludeSecurityGroups             *bool   `json:"include_security_groups"`
 	IncludeServices                   *bool   `json:"include_services"`
+	IncludeServiceInstanceSharing     *bool   `json:"include_service_instance_sharing"`
 	IncludeSsh                        *bool   `json:"include_ssh"`
 	IncludeTasks                      *bool   `json:"include_tasks"`
 	IncludeV3                         *bool   `json:"include_v3"`
@@ -163,6 +164,7 @@ func getDefaults() config {
 	defaults.IncludeSsh = ptrToBool(false)
 	defaults.IncludeTasks = ptrToBool(false)
 	defaults.IncludeZipkin = ptrToBool(false)
+	defaults.IncludeServiceInstanceSharing = ptrToBool(false)
 
 	defaults.UseHttp = ptrToBool(false)
 	defaults.UseExistingUser = ptrToBool(false)
@@ -389,6 +391,9 @@ func validateConfig(config *config) Errors {
 	}
 	if config.IncludeServices == nil {
 		errs.Add(fmt.Errorf("* 'include_services' must not be null"))
+	}
+	if config.IncludeServiceInstanceSharing == nil {
+		errs.Add(fmt.Errorf("* 'include_service_instance_sharing' must not be null"))
 	}
 	if config.IncludeSsh == nil {
 		errs.Add(fmt.Errorf("* 'include_ssh' must not be null"))
@@ -842,6 +847,10 @@ func (c *config) GetIncludeCredhubAssisted() bool {
 
 func (c *config) GetIncludeCredhubNonAssisted() bool {
 	return *c.CredhubMode == CredhubNonAssistedMode
+}
+
+func (c *config) GetIncludeServiceInstanceSharing() bool {
+	return *c.IncludeServiceInstanceSharing
 }
 
 func (c *config) GetRubyBuildpackName() string {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -126,6 +126,7 @@ type allConfig struct {
 	IncludeSSO                        *bool `json:"include_sso"`
 	IncludeSecurityGroups             *bool `json:"include_security_groups"`
 	IncludeServices                   *bool `json:"include_services"`
+	IncludeServiceInstanceSharing     *bool `json:"include_service_instance_sharing"`
 	IncludeSsh                        *bool `json:"include_ssh"`
 	IncludeTasks                      *bool `json:"include_tasks"`
 	IncludeV3                         *bool `json:"include_v3"`
@@ -243,6 +244,7 @@ var _ = Describe("Config", func() {
 		Expect(config.GetIncludeTasks()).To(BeFalse())
 		Expect(config.GetIncludeCredhubAssisted()).To(BeFalse())
 		Expect(config.GetIncludeCredhubNonAssisted()).To(BeFalse())
+		Expect(config.GetIncludeServiceInstanceSharing()).To(BeFalse())
 
 		Expect(config.GetBackend()).To(Equal(""))
 
@@ -347,6 +349,7 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(ContainSubstring("'include_sso' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_security_groups' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_services' must not be null"))
+			Expect(err.Error()).To(ContainSubstring("'include_service_instance_sharing' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_ssh' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_tasks' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_v3' must not be null"))

--- a/services/service_instance_sharing.go
+++ b/services/service_instance_sharing.go
@@ -1,0 +1,97 @@
+package services_test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/services"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = ServicesDescribe("Service Instance Sharing", func() {
+	Context("when User A shares a service instance into User B's space", func() {
+		var (
+			broker              services.ServiceBroker
+			serviceInstanceName string
+			orgName             string
+		)
+		// Note: user A is admin and user B is regular user
+		BeforeEach(func() {
+			broker = services.NewServiceBroker(
+				random_name.CATSRandomName("BRKR"),
+				assets.NewAssets().ServiceBroker,
+				TestSetup,
+			)
+			broker.Push(Config)
+			broker.Configure()
+			broker.Create()
+			broker.PublicizePlans()
+
+			var userBSpaceGuid string
+
+			workflowhelpers.AsUser(TestSetup.RegularUserContext(), Config.DefaultTimeoutDuration(), func() {
+				spaceCmd := cf.Cf("space", TestSetup.RegularUserContext().Space, "--guid").Wait(Config.DefaultTimeoutDuration())
+				spaceGuid := string(spaceCmd.Out.Contents())
+				userBSpaceGuid = strings.Trim(spaceGuid, "\n")
+			})
+
+			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+				orgName = random_name.CATSRandomName("ORG")
+				createOrg := cf.Cf("create-org", orgName).Wait(Config.DefaultTimeoutDuration())
+				Expect(createOrg).To(Exit(0), "failed to create org")
+
+				spaceName := random_name.CATSRandomName("SPACE")
+				createSpace := cf.Cf("create-space", spaceName, "-o", orgName).Wait(Config.DefaultTimeoutDuration())
+				Expect(createSpace).To(Exit(0), "failed to create space")
+
+				target := cf.Cf("target", "-o", orgName, "-s", spaceName).Wait(Config.DefaultTimeoutDuration())
+				Expect(target).To(Exit(0), "failed targeting")
+
+				serviceInstanceName = random_name.CATSRandomName("SVIN")
+
+				createService := cf.Cf("create-service", broker.Service.Name, broker.SyncPlans[0].Name, serviceInstanceName).Wait(Config.DefaultTimeoutDuration())
+				Eventually(createService).Should(Exit(0))
+
+				serviceCmd := cf.Cf("service", serviceInstanceName, "--guid").Wait(Config.DefaultTimeoutDuration())
+				instanceGuid := string(serviceCmd.Out.Contents())
+				instanceGuid = strings.Trim(instanceGuid, "\n")
+
+				shareSpace := cf.Cf("curl",
+					fmt.Sprintf("/v3/service_instances/%s/relationships/shared_spaces", instanceGuid),
+					"-X", "POST", "-d", fmt.Sprintf(`{ "data": [ { "guid": "%s" } ] }`, userBSpaceGuid))
+				Eventually(shareSpace).Should(Exit(0))
+				Eventually(shareSpace).Should(Say("data"))
+			})
+		})
+
+		AfterEach(func() {
+			broker.Destroy()
+			if serviceInstanceName != "" {
+				Expect(cf.Cf("delete-service", serviceInstanceName, "-f").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+			}
+			if orgName != "" {
+				workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+					Expect(cf.Cf("delete-org", orgName, "-f").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+				})
+			}
+		})
+
+		It("allows User B to view the shared service instance", func() {
+			workflowhelpers.AsUser(TestSetup.RegularUserContext(), Config.DefaultTimeoutDuration(), func() {
+				spaceCmd := cf.Cf("services").Wait(Config.DefaultTimeoutDuration())
+				Expect(spaceCmd).To(Exit(0))
+				Expect(spaceCmd).To(Say(serviceInstanceName))
+			})
+		})
+	})
+})

--- a/services/service_instance_sharing.go
+++ b/services/service_instance_sharing.go
@@ -222,5 +222,9 @@ var _ = ServicesDescribe("Service Instance Sharing", func() {
 
 func getGuidFor(resourceType, resourceName string) string {
 	session := cf.Cf(resourceType, resourceName, "--guid").Wait(Config.DefaultTimeoutDuration())
-	return strings.TrimSpace(string(session.Out.Contents()))
+
+	// temporary for: https://github.com/cloudfoundry/cli/issues/1271
+	out := string(session.Out.Contents())
+	outs := strings.Split(out, "\n")
+	return strings.TrimSpace(outs[len(outs)-2])
 }

--- a/services/service_instance_sharing.go
+++ b/services/service_instance_sharing.go
@@ -60,7 +60,7 @@ var _ = ServicesDescribe("Service Instance Sharing", func() {
 
 				By("Creating a service instance in User A's space")
 				createService := cf.Cf("create-service", broker.Service.Name, broker.SyncPlans[0].Name, serviceInstanceName).Wait(Config.DefaultTimeoutDuration())
-				Eventually(createService).Should(Exit(0))
+				Expect(createService).To(Exit(0))
 
 				By("Sharing the service instance into User B's space")
 				serviceInstanceGuid = getGuidFor("service", serviceInstanceName)
@@ -68,9 +68,9 @@ var _ = ServicesDescribe("Service Instance Sharing", func() {
 
 				shareSpace := cf.Cf("curl",
 					fmt.Sprintf("/v3/service_instances/%s/relationships/shared_spaces", serviceInstanceGuid),
-					"-X", "POST", "-d", fmt.Sprintf(`{ "data": [ { "guid": "%s" } ] }`, userBSpaceGuid))
-				Eventually(shareSpace).Should(Exit(0))
-				Eventually(shareSpace).Should(Say("data"))
+					"-X", "POST", "-d", fmt.Sprintf(`{ "data": [ { "guid": "%s" } ] }`, userBSpaceGuid)).Wait(Config.DefaultTimeoutDuration())
+				Expect(shareSpace).To(Exit(0))
+				Expect(shareSpace).To(Say("data"))
 			})
 		})
 

--- a/services/service_instance_sharing.go
+++ b/services/service_instance_sharing.go
@@ -1,13 +1,16 @@
 package services_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/services"
@@ -20,12 +23,14 @@ import (
 
 var _ = ServicesDescribe("Service Instance Sharing", func() {
 	Context("when User A shares a service instance into User B's space", func() {
+		// Note: user A is admin and user B is regular user
 		var (
 			broker              services.ServiceBroker
 			serviceInstanceName string
-			orgName             string
+			serviceInstanceGuid string
+			appName             string
 		)
-		// Note: user A is admin and user B is regular user
+
 		BeforeEach(func() {
 			broker = services.NewServiceBroker(
 				random_name.CATSRandomName("BRKR"),
@@ -37,37 +42,32 @@ var _ = ServicesDescribe("Service Instance Sharing", func() {
 			broker.Create()
 			broker.PublicizePlans()
 
-			var userBSpaceGuid string
-
-			workflowhelpers.AsUser(TestSetup.RegularUserContext(), Config.DefaultTimeoutDuration(), func() {
-				spaceCmd := cf.Cf("space", TestSetup.RegularUserContext().Space, "--guid").Wait(Config.DefaultTimeoutDuration())
-				spaceGuid := string(spaceCmd.Out.Contents())
-				userBSpaceGuid = strings.Trim(spaceGuid, "\n")
-			})
-
 			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
-				orgName = random_name.CATSRandomName("ORG")
-				createOrg := cf.Cf("create-org", orgName).Wait(Config.DefaultTimeoutDuration())
-				Expect(createOrg).To(Exit(0), "failed to create org")
+				orgName := TestSetup.RegularUserContext().Org
 
-				spaceName := random_name.CATSRandomName("SPACE")
-				createSpace := cf.Cf("create-space", spaceName, "-o", orgName).Wait(Config.DefaultTimeoutDuration())
+				target := cf.Cf("target", "-o", orgName).Wait(Config.DefaultTimeoutDuration())
+				Expect(target).To(Exit(0), "failed targeting")
+
+				By("Creating a space that only User A can view")
+				userASpaceName := random_name.CATSRandomName("SPACE")
+				createSpace := cf.Cf("create-space", userASpaceName, "-o", orgName).Wait(Config.DefaultTimeoutDuration())
 				Expect(createSpace).To(Exit(0), "failed to create space")
 
-				target := cf.Cf("target", "-o", orgName, "-s", spaceName).Wait(Config.DefaultTimeoutDuration())
+				target = cf.Cf("target", "-s", userASpaceName).Wait(Config.DefaultTimeoutDuration())
 				Expect(target).To(Exit(0), "failed targeting")
 
 				serviceInstanceName = random_name.CATSRandomName("SVIN")
 
+				By("Creating a service instance in User A's space")
 				createService := cf.Cf("create-service", broker.Service.Name, broker.SyncPlans[0].Name, serviceInstanceName).Wait(Config.DefaultTimeoutDuration())
 				Eventually(createService).Should(Exit(0))
 
-				serviceCmd := cf.Cf("service", serviceInstanceName, "--guid").Wait(Config.DefaultTimeoutDuration())
-				instanceGuid := string(serviceCmd.Out.Contents())
-				instanceGuid = strings.Trim(instanceGuid, "\n")
+				By("Sharing the service instance into User B's space")
+				serviceInstanceGuid = getGuidFor("service", serviceInstanceName)
+				userBSpaceGuid := getGuidFor("space", TestSetup.RegularUserContext().Space)
 
 				shareSpace := cf.Cf("curl",
-					fmt.Sprintf("/v3/service_instances/%s/relationships/shared_spaces", instanceGuid),
+					fmt.Sprintf("/v3/service_instances/%s/relationships/shared_spaces", serviceInstanceGuid),
 					"-X", "POST", "-d", fmt.Sprintf(`{ "data": [ { "guid": "%s" } ] }`, userBSpaceGuid))
 				Eventually(shareSpace).Should(Exit(0))
 				Eventually(shareSpace).Should(Say("data"))
@@ -76,22 +76,53 @@ var _ = ServicesDescribe("Service Instance Sharing", func() {
 
 		AfterEach(func() {
 			broker.Destroy()
+
+			if appName != "" {
+				app_helpers.AppReport(appName, Config.DefaultTimeoutDuration())
+				Eventually(cf.Cf("delete", appName, "-f"), Config.DefaultTimeoutDuration()).Should(Exit(0))
+			}
+
 			if serviceInstanceName != "" {
 				Expect(cf.Cf("delete-service", serviceInstanceName, "-f").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 			}
-			if orgName != "" {
-				workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
-					Expect(cf.Cf("delete-org", orgName, "-f").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-				})
-			}
 		})
 
-		It("allows User B to view the shared service instance", func() {
+		It("allows User B to bind an app to the shared service instance", func() {
 			workflowhelpers.AsUser(TestSetup.RegularUserContext(), Config.DefaultTimeoutDuration(), func() {
+				By("Asserting the User B can see the shared service")
 				spaceCmd := cf.Cf("services").Wait(Config.DefaultTimeoutDuration())
 				Expect(spaceCmd).To(Exit(0))
 				Expect(spaceCmd).To(Say(serviceInstanceName))
+
+				By("Asserting the User B can bind to the shared service")
+				appName = random_name.CATSRandomName("APP")
+				Expect(cf.Cf("push",
+					appName,
+					"-b", Config.GetBinaryBuildpackName(),
+					"-m", DEFAULT_MEMORY_LIMIT,
+					"-p", assets.NewAssets().Catnip,
+					"-c", "./catnip",
+					"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+				appGuid := getGuidFor("app", appName)
+
+				bindCmd := cf.Cf("curl", "/v2/service_bindings", "-X", "POST", "-d",
+					fmt.Sprintf(`{ "service_instance_guid" : "%s", "app_guid": "%s" }`, serviceInstanceGuid, appGuid)).Wait(Config.DefaultTimeoutDuration())
+				Expect(bindCmd).To(Exit(0))
+				Expect(bindCmd).To(Say("entity"))
+
+				Expect(cf.Cf("restage", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				envJSON := helpers.CurlApp(Config, appName, "/env.json")
+				var envVars map[string]string
+				json.Unmarshal([]byte(envJSON), &envVars)
+
+				Expect(envVars["VCAP_SERVICES"]).To(ContainSubstring("credentials"))
 			})
 		})
 	})
 })
+
+func getGuidFor(resourceType, resourceName string) string {
+	session := cf.Cf(resourceType, resourceName, "--guid").Wait(Config.DefaultTimeoutDuration())
+	return strings.TrimSpace(string(session.Out.Contents()))
+}


### PR DESCRIPTION
This PR adds initial tests of the new service instance sharing feature. The new feature allows users who have the `service_instance_sharing` feature flag enabled to share a service instance with spaces other than the orginitating space of the instance.

Because this feature only works if the feature flag is on, we needed to add a new config option to the integration config. We called this `include_service_instance_sharing`. The test file itself is part of the services suite, so the tests will only run if both `include_service_instance_sharing` and `include_services` are true.

These tests pass on the lastest version of cf-release (v280), the latest version of capi-release (1.45.0), and the master branch of cf-deployment (which uses capi-release 1.45.0).