### PR TITLE
Add config to make services shareable

### DIFF
--- a/assets/service_broker/cats.json
+++ b/assets/service_broker/cats.json
@@ -24,7 +24,8 @@
                 "blurb": "fake broker that is fake",
                 "longDescription": "A long time ago, in a galaxy far far away..."
               },
-              "displayName": "The Fake Broker"
+              "displayName": "The Fake Broker",
+              "shareable": true
             },
             "dashboard_client": {
               "id": "<sso-test>",

--- a/assets/service_broker/data.json
+++ b/assets/service_broker/data.json
@@ -38,7 +38,8 @@
                 "blurb": "fake broker that is fake",
                 "longDescription": "A long time ago, in a galaxy far far away..."
               },
-              "displayName": "The Fake Broker"
+              "displayName": "The Fake Broker",
+              "shareable": true
             },
             "dashboard_client": {
               "id": "sso-test",


### PR DESCRIPTION
Newer cloud_controller versions (not yet included in a capi-release referenced in cf-release/cf-deployment) include checks that brokers have a sharable metadata property in order to be shared.

This change allows the service instance sharing CAT tests to be forward compatible with the latest version of capi.

Thanks,
Sam