### PR TITLE
Update download helper to handle immediate downloads

### DIFF
--- a/helpers/download/download.go
+++ b/helpers/download/download.go
@@ -2,6 +2,7 @@ package download
 
 import (
 	"fmt"
+	"io/ioutil"
 	"regexp"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
@@ -28,7 +29,8 @@ func WithRedirect(url, path string, config config.CatsConfig) error {
 
 	matches := locationHeaderRegex.FindStringSubmatch(string(downloadCurl.Err.Contents()))
 	if len(matches) < 2 {
-		return fmt.Errorf("didn't find location for redirect")
+		ioutil.WriteFile(path, downloadCurl.Out.Contents(), 0644)
+		return nil
 	}
 
 	redirectURI := matches[1]


### PR DESCRIPTION
When Cloud Controller is backed by an NFS blobstore its download endpoints don't return a redirect url, but instead send the file directly to the client. This meant that CATS using this helper would fail when run against an NFS-backed environment.

[#153418205](https://www.pivotaltracker.com/story/show/153418205)

Thanks!
Tim and @ericpromislow 