### PR TITLE
Update Service Instance sharing tests

### DIFF
--- a/capi_experimental/service_instances.go
+++ b/capi_experimental/service_instances.go
@@ -1,0 +1,70 @@
+package capi_experimental
+
+import (
+	"encoding/json"
+
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/services"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = CapiExperimentalDescribe("service instances", func() {
+	var (
+		broker               services.ServiceBroker
+		serviceInstance1Name string
+		serviceInstance2Name string
+	)
+
+	type ServiceInstance struct {
+		Name string
+	}
+	type Response struct {
+		Resources []ServiceInstance
+	}
+
+	BeforeEach(func() {
+		broker = services.NewServiceBroker(
+			random_name.CATSRandomName("BRKR"),
+			assets.NewAssets().ServiceBroker,
+			TestSetup,
+		)
+		broker.Push(Config)
+		broker.Configure()
+		broker.Create()
+		broker.PublicizePlans()
+
+		serviceInstance1Name = random_name.CATSRandomName("SVIN")
+		serviceInstance2Name = random_name.CATSRandomName("SVIN")
+
+		By("Creating a service instance")
+		createService := cf.Cf("create-service", broker.Service.Name, broker.SyncPlans[0].Name, serviceInstance1Name).Wait(Config.DefaultTimeoutDuration())
+		Expect(createService).To(Exit(0))
+
+		By("Creating another service instance")
+		createService2 := cf.Cf("create-service", broker.Service.Name, broker.SyncPlans[0].Name, serviceInstance2Name).Wait(Config.DefaultTimeoutDuration())
+		Expect(createService2).To(Exit(0))
+	})
+
+	It("Lists the service instances", func() {
+		expectedResources := []ServiceInstance{
+			{Name: serviceInstance1Name},
+			{Name: serviceInstance2Name},
+		}
+
+		listService := cf.Cf("curl", "/v3/service_instances").Wait(Config.DefaultTimeoutDuration())
+		Expect(listService).To(Exit(0))
+
+		var res Response
+		err := json.Unmarshal(listService.Out.Contents(), &res)
+		Expect(err).To(BeNil())
+
+		Expect(res.Resources).To(ConsistOf(expectedResources))
+	})
+})

--- a/services/service_instance_sharing.go
+++ b/services/service_instance_sharing.go
@@ -99,11 +99,6 @@ var _ = ServiceInstanceSharingDescribe("Service Instance Sharing", func() {
 				Expect(serviceCmd).To(Exit(0))
 				Expect(serviceCmd).To(Say("Service instance: " + serviceInstanceName))
 				Expect(serviceCmd).To(Say("Service: " + broker.Service.Name))
-
-				By("Asserting the User B sees the service instance in v3 `cf curl v3/service_instances`")
-				listService := cf.Cf("curl", "/v3/service_instances").Wait(Config.DefaultTimeoutDuration())
-				Expect(listService).To(Exit(0))
-				Expect(listService).To(Say(serviceInstanceName))
 			})
 		})
 

--- a/services/service_instance_sharing.go
+++ b/services/service_instance_sharing.go
@@ -100,8 +100,9 @@ var _ = ServiceInstanceSharingDescribe("Service Instance Sharing", func() {
 				By("Asserting the User B sees the service instance in `cf service service-name` output")
 				serviceCmd := cf.Cf("service", serviceInstanceName).Wait(Config.DefaultTimeoutDuration())
 				Expect(serviceCmd).To(Exit(0))
-				Expect(serviceCmd).To(Say("Service instance: " + serviceInstanceName))
-				Expect(serviceCmd).To(Say("Service: " + broker.Service.Name))
+				Expect(serviceCmd).To(Say(serviceInstanceName))
+				Expect(serviceCmd).To(Say(broker.Service.Name))
+				Expect(serviceCmd).To(Say("create succeeded"))
 			})
 		})
 

--- a/services/service_instance_sharing.go
+++ b/services/service_instance_sharing.go
@@ -87,13 +87,23 @@ var _ = ServiceInstanceSharingDescribe("Service Instance Sharing", func() {
 			}
 		})
 
+		It("allows User B to view the shared service", func() {
+			workflowhelpers.AsUser(TestSetup.RegularUserContext(), Config.DefaultTimeoutDuration(), func() {
+				By("Asserting the User B sees the service instance listed in `cf services`")
+				servicesCmd := cf.Cf("services").Wait(Config.DefaultTimeoutDuration())
+				Expect(servicesCmd).To(Exit(0))
+				Expect(servicesCmd).To(Say(serviceInstanceName))
+
+				By("Asserting the User B sees the service instance in `cf service service-name` output")
+				serviceCmd := cf.Cf("service", serviceInstanceName).Wait(Config.DefaultTimeoutDuration())
+				Expect(serviceCmd).To(Exit(0))
+				Expect(serviceCmd).To(Say("Service instance: " + serviceInstanceName))
+				Expect(serviceCmd).To(Say("Service: " + broker.Service.Name))
+			})
+		})
+
 		It("allows User B to bind an app to the shared service instance", func() {
 			workflowhelpers.AsUser(TestSetup.RegularUserContext(), Config.DefaultTimeoutDuration(), func() {
-				By("Asserting the User B can see the shared service")
-				spaceCmd := cf.Cf("services").Wait(Config.DefaultTimeoutDuration())
-				Expect(spaceCmd).To(Exit(0))
-				Expect(spaceCmd).To(Say(serviceInstanceName))
-
 				By("Asserting the User B can bind to the shared service")
 				appName = random_name.CATSRandomName("APP")
 				Expect(cf.Cf("push",

--- a/services/service_instance_sharing.go
+++ b/services/service_instance_sharing.go
@@ -62,11 +62,6 @@ var _ = ServiceInstanceSharingDescribe("Service Instance Sharing", func() {
 				createService := cf.Cf("create-service", broker.Service.Name, broker.SyncPlans[0].Name, serviceInstanceName).Wait(Config.DefaultTimeoutDuration())
 				Expect(createService).To(Exit(0))
 
-				By("Ensuring that the service instance exists")
-				listService := cf.Cf("curl", "/v3/service_instances").Wait(Config.DefaultTimeoutDuration())
-				Expect(listService).To(Exit(0))
-				Expect(listService).To(Say(serviceInstanceName))
-
 				By("Sharing the service instance into User B's space")
 				serviceInstanceGuid = getGuidFor("service", serviceInstanceName)
 				userBSpaceGuid := getGuidFor("space", TestSetup.RegularUserContext().Space)
@@ -104,6 +99,11 @@ var _ = ServiceInstanceSharingDescribe("Service Instance Sharing", func() {
 				Expect(serviceCmd).To(Exit(0))
 				Expect(serviceCmd).To(Say("Service instance: " + serviceInstanceName))
 				Expect(serviceCmd).To(Say("Service: " + broker.Service.Name))
+
+				By("Asserting the User B sees the service instance in v3 `cf curl v3/service_instances`")
+				listService := cf.Cf("curl", "/v3/service_instances").Wait(Config.DefaultTimeoutDuration())
+				Expect(listService).To(Exit(0))
+				Expect(listService).To(Say(serviceInstanceName))
 			})
 		})
 
@@ -132,7 +132,7 @@ var _ = ServiceInstanceSharingDescribe("Service Instance Sharing", func() {
 			})
 		})
 
-		It("Allows User B to unbind an app from the shared service instance", func() {
+		It("allows User B to unbind an app from the shared service instance", func() {
 			var appGuid string
 
 			workflowhelpers.AsUser(TestSetup.RegularUserContext(), Config.DefaultTimeoutDuration(), func() {

--- a/services/service_instance_sharing.go
+++ b/services/service_instance_sharing.go
@@ -62,6 +62,11 @@ var _ = ServiceInstanceSharingDescribe("Service Instance Sharing", func() {
 				createService := cf.Cf("create-service", broker.Service.Name, broker.SyncPlans[0].Name, serviceInstanceName).Wait(Config.DefaultTimeoutDuration())
 				Expect(createService).To(Exit(0))
 
+				By("Ensuring that the service instance exists")
+				listService := cf.Cf("curl", "/v3/service_instances").Wait(Config.DefaultTimeoutDuration())
+				Expect(listService).To(Exit(0))
+				Expect(listService).To(Say(serviceInstanceName))
+
 				By("Sharing the service instance into User B's space")
 				serviceInstanceGuid = getGuidFor("service", serviceInstanceName)
 				userBSpaceGuid := getGuidFor("space", TestSetup.RegularUserContext().Space)


### PR DESCRIPTION
This PR includes new CATs tests for the latest service instance sharing behaviour available in [1.46.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.46.0) of CAPI, included in [1.3.1](https://github.com/cloudfoundry/cf-deployment/releases/tag/v1.3.1) of cf-deployment and [v283](https://github.com/cloudfoundry/cf-release/releases/tag/v283) of cf-release

#### Changes

* Added new test to verify GET to /v3/service_instances
* Added service instance sharing test to verify GET to /v2/service_instances/:guid/shared_to
* Verify that `cf services` & `cf service <name>` work with shared services
* Verify that`cf bind-service <app> <service_instance>` & `cf unbind-service <app> <service_instance>` work with shared services

#### Works with
* Tested successfully against 1.3.1 of cf-deployment
* Tested successfully against current [master](https://github.com/cloudfoundry/cloud_controller_ng/commit/dfe91db4579c5d8b6b12b7bc202fa49798a881b1) of cloud_controller


Thanks SAPI team, @jenspinney & Samze
