### PR TITLE
make regexp case insensitive

### DIFF
--- a/helpers/download/download.go
+++ b/helpers/download/download.go
@@ -22,7 +22,7 @@ func WithRedirect(url, path string, config config.CatsConfig) error {
 		return fmt.Errorf("curl exited with code: %d", downloadCurl.ExitCode())
 	}
 
-	locationHeaderRegex, err := regexp.Compile("Location: (.*)\r\n")
+	locationHeaderRegex, err := regexp.Compile("(?i)Location: (.*)\r\n")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This commit makes the regexp on the curl request case insensitive when it's looking for redirect locations. This was affecting certain curl commands depending on the infrastructure.