### PR TITLE
Use CLI for share and unshare

### DIFF
--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -35,7 +35,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const minCliVersion = "6.30.0"
+const minCliVersion = "6.33.1"
 
 func TestCATS(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
Since the [latest CLI version](https://github.com/cloudfoundry/cli/releases/tag/v6.34.0) contains the new `v3-share-service` and `v3-unshare-service` commands, we can replace the `cf curl` calls in the service instance sharing tests for better end-to-end coverage.

We've also removed some assertions about the additional sharing data returned by `cf service` because they are now covered in the CLI's [integration tests](https://github.com/cloudfoundry/cli/blob/master/integration/isolated/service_command_test.go).