### PR TITLE
make service_discovery test use proxy app

### DIFF
--- a/assets/proxy/Procfile
+++ b/assets/proxy/Procfile
@@ -1,0 +1,1 @@
+web: proxy

--- a/assets/proxy/README.md
+++ b/assets/proxy/README.md
@@ -1,0 +1,20 @@
+#### To use the example app:
+
+Push two differently named instances of the app
+```bash
+cd ~/workspace/cf-networking-release/src/example-apps/proxy
+cf push appA
+cf push appB
+```
+
+See that they are reachable and what their IPs are
+```bash
+curl appa.<system-domain>
+curl appb.<system-domain>
+```
+
+See that proxying from A to B works over both the router and overlay
+```bash
+curl appa.<system-domain>/proxy/appb.<system-domain>
+curl appa.<system-domain>/proxy/<overlay-ip-of-appB>:8080
+```

--- a/assets/proxy/handlers/download_handler.go
+++ b/assets/proxy/handlers/download_handler.go
@@ -1,0 +1,25 @@
+package handlers
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type DownloadHandler struct{}
+
+func (h *DownloadHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	requestBytes := strings.TrimPrefix(req.URL.Path, "/download/")
+	numBytes, err := strconv.Atoi(requestBytes)
+	if err != nil || numBytes < 0 {
+		resp.WriteHeader(http.StatusInternalServerError)
+		resp.Write([]byte(fmt.Sprintf("requested number of bytes must be a positive integer, got: %s", requestBytes)))
+		return
+	}
+
+	respBytes := make([]byte, numBytes)
+	rand.Read(respBytes)
+	resp.Write(respBytes)
+}

--- a/assets/proxy/handlers/download_handler_test.go
+++ b/assets/proxy/handlers/download_handler_test.go
@@ -1,0 +1,83 @@
+package handlers_test
+
+import (
+	"example-apps/proxy/handlers"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DownloadHandler", func() {
+	var (
+		handler *handlers.DownloadHandler
+		resp    *httptest.ResponseRecorder
+		req     *http.Request
+	)
+	BeforeEach(func() {
+		handler = &handlers.DownloadHandler{}
+		resp = httptest.NewRecorder()
+	})
+	Describe("GET", func() {
+		Context("when the request is for 1000000 bytes", func() {
+			BeforeEach(func() {
+				var err error
+				req, err = http.NewRequest("GET", "/download/1000000", nil)
+				Expect(err).NotTo(HaveOccurred())
+
+			})
+			It("returns a body with the 1000000 bytes", func() {
+				handler.ServeHTTP(resp, req)
+
+				Expect(resp.Code).To(Equal(http.StatusOK))
+				Expect(resp.Body.Len()).To(Equal(1000000))
+			})
+		})
+
+		Context("when the request is for 2000000 bytes", func() {
+			BeforeEach(func() {
+				var err error
+				req, err = http.NewRequest("GET", "/download/2000000", nil)
+				Expect(err).NotTo(HaveOccurred())
+
+			})
+			It("returns a body with the 2000000 bytes", func() {
+				handler.ServeHTTP(resp, req)
+
+				Expect(resp.Code).To(Equal(http.StatusOK))
+				Expect(resp.Body.Len()).To(Equal(2000000))
+			})
+		})
+
+		Context("when the number of requested bytes is negative", func() {
+			BeforeEach(func() {
+				var err error
+				req, err = http.NewRequest("GET", "/download/-42", nil)
+				Expect(err).NotTo(HaveOccurred())
+
+			})
+			It("returns an error", func() {
+				handler.ServeHTTP(resp, req)
+
+				Expect(resp.Code).To(Equal(http.StatusInternalServerError))
+				Expect(resp.Body.String()).To(Equal("requested number of bytes must be a positive integer, got: -42"))
+			})
+		})
+
+		Context("when the request is for non-numeric bytes", func() {
+			BeforeEach(func() {
+				var err error
+				req, err = http.NewRequest("GET", "/download/foo", nil)
+				Expect(err).NotTo(HaveOccurred())
+
+			})
+			It("returns an error", func() {
+				handler.ServeHTTP(resp, req)
+
+				Expect(resp.Code).To(Equal(http.StatusInternalServerError))
+				Expect(resp.Body.String()).To(Equal("requested number of bytes must be a positive integer, got: foo"))
+			})
+		})
+	})
+})

--- a/assets/proxy/handlers/handlers_suite_test.go
+++ b/assets/proxy/handlers/handlers_suite_test.go
@@ -1,0 +1,13 @@
+package handlers_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Proxy Handlers Suite")
+}

--- a/assets/proxy/handlers/info_handler.go
+++ b/assets/proxy/handlers/info_handler.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"strings"
+)
+
+type InfoHandler struct {
+	Port int
+}
+
+func (h *InfoHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		panic(err)
+	}
+	addressStrings := []string{}
+	for _, addr := range addrs {
+		listenAddr := strings.Split(addr.String(), "/")[0]
+		addressStrings = append(addressStrings, listenAddr)
+	}
+
+	respBytes, err := json.Marshal(struct {
+		ListenAddresses []string
+		Port            int
+	}{
+		ListenAddresses: addressStrings,
+		Port:            h.Port,
+	})
+	if err != nil {
+		panic(err)
+	}
+	resp.Write(respBytes)
+	return
+}

--- a/assets/proxy/handlers/ping_handler.go
+++ b/assets/proxy/handlers/ping_handler.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type PingHandler struct {
+}
+
+func ipv4Address(ips []net.IP) (net.Addr, error) {
+	for _, ip := range ips {
+		if ip.To4() != nil {
+			return &net.UDPAddr{IP: ip}, nil
+		}
+	}
+	return nil, errors.New("No IPv4 found")
+}
+
+func handleError(err error, destination string, resp http.ResponseWriter) {
+	msg := fmt.Sprintf("Ping failed to destination: %s: %s", destination, err)
+	fmt.Fprintf(os.Stderr, msg)
+	resp.WriteHeader(http.StatusInternalServerError)
+	resp.Write([]byte(msg))
+}
+
+func (h *PingHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	destination := strings.TrimPrefix(req.URL.Path, "/ping/")
+	destination = strings.Split(destination, ":")[0]
+
+	pingPath := "/bin/ping"
+	_, err := os.Stat(pingPath)
+	if err != nil {
+		pingPath = "/sbin/ping"
+	}
+	cmd := exec.Command(pingPath, "-c", "1", destination)
+	err = cmd.Start()
+	if err != nil {
+		handleError(err, destination, resp)
+		return
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case <-time.After(10 * time.Second):
+		if err := cmd.Process.Kill(); err != nil {
+			handleError(fmt.Errorf("error killing hung ping: %s", err), destination, resp)
+			return
+		}
+		handleError(errors.New("killing ping after timed out"), destination, resp)
+		return
+
+	case err := <-done:
+		if err != nil {
+			handleError(err, destination, resp)
+			return
+		}
+	}
+
+	resp.Write([]byte(fmt.Sprintf("Ping succeeded to destination: %s", destination)))
+}

--- a/assets/proxy/handlers/proxy_handler.go
+++ b/assets/proxy/handlers/proxy_handler.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type ProxyHandler struct {
+	Stats *Stats
+}
+
+var httpClient = &http.Client{
+	Transport: &http.Transport{
+		DisableKeepAlives: true,
+		Dial: (&net.Dialer{
+			Timeout:   4 * time.Second,
+			KeepAlive: 0,
+		}).Dial,
+	},
+}
+
+func (h *ProxyHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	destination := strings.TrimPrefix(req.URL.Path, "/proxy/")
+	destination = "http://" + destination
+	before := time.Now()
+	getResp, err := httpClient.Get(destination)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "request failed: %s", err)
+		resp.WriteHeader(http.StatusInternalServerError)
+		resp.Write([]byte(fmt.Sprintf("request failed: %s", err)))
+		return
+	}
+	defer getResp.Body.Close()
+	h.Stats.Add(time.Since(before).Seconds())
+
+	readBytes, err := ioutil.ReadAll(getResp.Body)
+	if err != nil {
+		resp.WriteHeader(http.StatusInternalServerError)
+		resp.Write([]byte(fmt.Sprintf("read body failed: %s", err)))
+		return
+	}
+
+	resp.Write(readBytes)
+}

--- a/assets/proxy/handlers/stats_handler.go
+++ b/assets/proxy/handlers/stats_handler.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+)
+
+type Stats struct {
+	// Locker  sync.Locker
+	Latency []float64 `json:"latency"`
+	sync.RWMutex
+}
+
+func (s *Stats) Add(latency float64) {
+	s.Lock()
+	defer s.Unlock()
+	s.Latency = append(s.Latency, latency)
+}
+
+func (s *Stats) Clear() {
+	s.Lock()
+	defer s.Unlock()
+	s.Latency = []float64{}
+}
+
+func (s *Stats) GetLatency() []float64 {
+	s.RLock()
+	defer s.RUnlock()
+	return s.Latency
+}
+
+type StatsHandler struct {
+	Stats *Stats
+}
+
+func (h *StatsHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	if req.Method == "DELETE" {
+		h.Stats.Clear()
+		return
+	}
+
+	respBytes, err := json.Marshal(h.Stats)
+	if err != nil {
+		panic(err)
+	}
+	resp.Write(respBytes)
+	return
+}

--- a/assets/proxy/handlers/stats_handler_test.go
+++ b/assets/proxy/handlers/stats_handler_test.go
@@ -1,0 +1,58 @@
+package handlers_test
+
+import (
+	"example-apps/proxy/handlers"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("StatsHandler", func() {
+	var (
+		handler *handlers.StatsHandler
+		resp    *httptest.ResponseRecorder
+		req     *http.Request
+		stats   *handlers.Stats
+	)
+	BeforeEach(func() {
+		stats = &handlers.Stats{}
+		stats.Latency = []float64{1, 2, 3}
+		handler = &handlers.StatsHandler{
+			Stats: stats,
+		}
+
+		resp = httptest.NewRecorder()
+	})
+	Describe("GET", func() {
+		BeforeEach(func() {
+			var err error
+			req, err = http.NewRequest("GET", "/stats", nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("returns the latency of the requests", func() {
+			handler.ServeHTTP(resp, req)
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			Expect(resp.Body.String()).To(MatchJSON(`{"latency" : [1.0,2.0,3.0]}`))
+		})
+	})
+	Describe("DELETE", func() {
+		BeforeEach(func() {
+			var err error
+			req, err = http.NewRequest("DELETE", "/stats", nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("clears all statistics", func() {
+			handler.ServeHTTP(resp, req)
+			Expect(resp.Code).To(Equal(http.StatusOK))
+
+			req, err := http.NewRequest("GET", "/stats", nil)
+			Expect(err).NotTo(HaveOccurred())
+			handler.ServeHTTP(resp, req)
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			Expect(resp.Body.String()).To(MatchJSON(`{"latency" : []}`))
+		})
+	})
+})

--- a/assets/proxy/handlers/upload_handler.go
+++ b/assets/proxy/handlers/upload_handler.go
@@ -1,0 +1,24 @@
+package handlers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type UploadHandler struct{}
+
+func (h *UploadHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	if req.Body == nil {
+		resp.Write([]byte("0 bytes received and read"))
+		return
+	}
+	bodyBytes, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		resp.WriteHeader(http.StatusInternalServerError)
+		resp.Write([]byte(fmt.Sprintf("error: %s", err)))
+		return
+	}
+
+	resp.Write([]byte(fmt.Sprintf("%d bytes received and read", len(bodyBytes))))
+}

--- a/assets/proxy/handlers/upload_handler_test.go
+++ b/assets/proxy/handlers/upload_handler_test.go
@@ -1,0 +1,57 @@
+package handlers_test
+
+import (
+	"bytes"
+	"example-apps/proxy/handlers"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UploadHandler", func() {
+	var (
+		handler *handlers.UploadHandler
+		resp    *httptest.ResponseRecorder
+		req     *http.Request
+	)
+
+	BeforeEach(func() {
+		handler = &handlers.UploadHandler{}
+		resp = httptest.NewRecorder()
+	})
+
+	Describe("POST", func() {
+		Context("when the request is for includes a 1000000 byte payload", func() {
+			BeforeEach(func() {
+				var err error
+				reqBytes := make([]byte, 1000000)
+				rand.Read(reqBytes)
+				req, err = http.NewRequest("POST", "/upload", bytes.NewBuffer([]byte(reqBytes)))
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("returns a body with the size of the bytes read in the request", func() {
+				handler.ServeHTTP(resp, req)
+
+				Expect(resp.Code).To(Equal(http.StatusOK))
+				Expect(resp.Body.String()).To(Equal("1000000 bytes received and read"))
+			})
+		})
+
+		Context("when the request body is nil", func() {
+			BeforeEach(func() {
+				var err error
+				req, err = http.NewRequest("POST", "/upload", nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("returns an error", func() {
+				handler.ServeHTTP(resp, req)
+
+				Expect(resp.Code).To(Equal(http.StatusOK))
+				Expect(resp.Body.String()).To(Equal("0 bytes received and read"))
+			})
+		})
+	})
+})

--- a/assets/proxy/integration/integration_suite_test.go
+++ b/assets/proxy/integration/integration_suite_test.go
@@ -1,0 +1,50 @@
+package integration_test
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	ginkgoConfig "github.com/onsi/ginkgo/config"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+
+	"testing"
+)
+
+var exampleAppPath string
+
+const DEFAULT_TIMEOUT = "5s"
+
+func TestIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Proxy Integration Suite")
+}
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	fmt.Fprintf(GinkgoWriter, "building binary...")
+	var err error
+	exampleAppPath, err = gexec.Build("example-apps/proxy", "-race")
+	fmt.Fprintf(GinkgoWriter, "done")
+	Expect(err).NotTo(HaveOccurred())
+
+	return []byte(exampleAppPath)
+}, func(data []byte) {
+	exampleAppPath = string(data)
+
+	rand.Seed(ginkgoConfig.GinkgoConfig.RandomSeed + int64(GinkgoParallelNode()))
+})
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	gexec.CleanupBuildArtifacts()
+})
+
+func VerifyTCPConnection(address string) error {
+	conn, err := net.Dial("tcp", address)
+	if err != nil {
+		return err
+	}
+	conn.Close()
+	return nil
+}

--- a/assets/proxy/integration/integration_test.go
+++ b/assets/proxy/integration/integration_test.go
@@ -1,0 +1,149 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Integration", func() {
+	var (
+		session    *gexec.Session
+		address    string
+		listenPort int
+
+		proxyDestinationServer *httptest.Server
+		destinationAddress     string
+	)
+
+	var serverIsAvailable = func() error {
+		return VerifyTCPConnection(address)
+	}
+
+	BeforeEach(func() {
+		proxyDestinationServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, "Example Domain")
+		}))
+		destinationAddress = strings.Replace(proxyDestinationServer.URL, "http://", "", 1)
+
+		listenPort = 44000 + GinkgoParallelNode()
+		address = fmt.Sprintf("127.0.0.1:%d", listenPort)
+
+		exampleAppCmd := exec.Command(exampleAppPath)
+		exampleAppCmd.Env = []string{
+			fmt.Sprintf("PORT=%d", listenPort),
+		}
+		var err error
+		session, err = gexec.Start(exampleAppCmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(serverIsAvailable, DEFAULT_TIMEOUT).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		session.Interrupt()
+		Eventually(session, DEFAULT_TIMEOUT).Should(gexec.Exit())
+		proxyDestinationServer.Close()
+	})
+
+	Describe("boring server behavior", func() {
+		It("should boot and gracefully terminate", func() {
+			Consistently(session).ShouldNot(gexec.Exit())
+
+			session.Interrupt()
+			Eventually(session, DEFAULT_TIMEOUT).Should(gexec.Exit())
+		})
+	})
+
+	Describe("endpoints", func() {
+		It("should respond to GET / with info", func() {
+			response, err := http.DefaultClient.Get("http://" + address + "/")
+			Expect(err).NotTo(HaveOccurred())
+			defer response.Body.Close()
+			Expect(response.StatusCode).To(Equal(200))
+
+			responseBytes, err := ioutil.ReadAll(response.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			var responseData struct {
+				ListenAddresses []string
+				Port            int
+			}
+
+			Expect(json.Unmarshal(responseBytes, &responseData)).To(Succeed())
+
+			Expect(responseData.ListenAddresses).To(ContainElement("127.0.0.1"))
+			Expect(responseData.Port).To(Equal(listenPort))
+		})
+
+		It("should respond to /ping by pinging the provided address", func() {
+			response, err := http.DefaultClient.Get("http://" + address + "/ping/" + destinationAddress)
+			Expect(err).NotTo(HaveOccurred())
+			defer response.Body.Close()
+			Expect(response.StatusCode).To(Equal(200))
+
+			responseBytes, err := ioutil.ReadAll(response.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(responseBytes).To(ContainSubstring("Ping succeeded"))
+		})
+
+		It("should respond to /proxy by proxying the request to the provided address", func() {
+			response, err := http.DefaultClient.Get("http://" + address + "/proxy/" + destinationAddress)
+			Expect(err).NotTo(HaveOccurred())
+			defer response.Body.Close()
+			Expect(response.StatusCode).To(Equal(200))
+
+			responseBytes, err := ioutil.ReadAll(response.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(responseBytes).To(ContainSubstring("Example Domain"))
+		})
+
+		It("should report latency stats on /stats", func() {
+			response, err := http.DefaultClient.Get("http://" + address + "/proxy/" + destinationAddress)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(200))
+
+			statsResponse, err := http.DefaultClient.Get("http://" + address + "/stats")
+			Expect(err).NotTo(HaveOccurred())
+			defer statsResponse.Body.Close()
+
+			responseBytes, err := ioutil.ReadAll(statsResponse.Body)
+			Expect(err).NotTo(HaveOccurred())
+			var statsJSON struct {
+				Latency []float64
+			}
+			Expect(json.Unmarshal(responseBytes, &statsJSON)).To(Succeed())
+			Expect(len(statsJSON.Latency)).To(BeNumerically(">=", 1))
+		})
+
+		Context("when the proxy destination is invalid", func() {
+			It("logs the error", func() {
+				response, err := http.DefaultClient.Get("http://" + address + "/proxy/////!!")
+				Expect(err).NotTo(HaveOccurred())
+				defer response.Body.Close()
+				Expect(response.StatusCode).To(Equal(500))
+
+				Eventually(session.Err.Contents).Should(ContainSubstring("request failed: Get"))
+			})
+		})
+
+		Context("when the ping destination is invalid", func() {
+			It("logs the error", func() {
+				response, err := http.DefaultClient.Get("http://" + address + "/ping/////!!")
+				Expect(err).NotTo(HaveOccurred())
+				defer response.Body.Close()
+				Expect(response.StatusCode).To(Equal(500))
+
+				Eventually(session.Err.Contents).Should(ContainSubstring("Ping failed"))
+			})
+		})
+	})
+})

--- a/assets/proxy/main.go
+++ b/assets/proxy/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"proxy/handlers"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+)
+
+func launchHandler(port int, downloadHandler, pingHandler, proxyHandler, statsHandler, uploadHandler http.Handler) {
+	mux := http.NewServeMux()
+	mux.Handle("/download/", downloadHandler)
+	mux.Handle("/ping/", pingHandler)
+	mux.Handle("/proxy/", proxyHandler)
+	mux.Handle("/stats", statsHandler)
+	mux.Handle("/upload", uploadHandler)
+	mux.Handle("/", &handlers.InfoHandler{
+		Port: port,
+	})
+	http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), mux)
+}
+
+func main() {
+	systemPortString := os.Getenv("PORT")
+	systemPort, err := strconv.Atoi(systemPortString)
+	if err != nil {
+		log.Fatal("invalid required env var PORT")
+	}
+
+	stats := &handlers.Stats{
+		Latency: []float64{},
+	}
+	downloadHandler := &handlers.DownloadHandler{}
+	pingHandler := &handlers.PingHandler{}
+	proxyHandler := &handlers.ProxyHandler{
+		Stats: stats,
+	}
+	statsHandler := &handlers.StatsHandler{
+		Stats: stats,
+	}
+	uploadHandler := &handlers.UploadHandler{}
+
+	launchHandler(systemPort, downloadHandler, pingHandler, proxyHandler, statsHandler, uploadHandler)
+}

--- a/assets/proxy/manifest.yml
+++ b/assets/proxy/manifest.yml
@@ -1,0 +1,8 @@
+---
+applications:
+  - name: proxy
+    memory: 32M
+    disk_quota: 32M
+    buildpack: go_buildpack
+    env:
+      GOPACKAGENAME: proxy

--- a/helpers/assets/assets.go
+++ b/helpers/assets/assets.go
@@ -21,6 +21,7 @@ type Assets struct {
 	Node                     string
 	NodeWithProcfile         string
 	Php                      string
+	Proxy                    string
 	RubySimple               string
 	SecurityGroupBuildpack   string
 	ServiceBroker            string
@@ -54,6 +55,7 @@ func NewAssets() Assets {
 		Node:                   "assets/node",
 		NodeWithProcfile:       "assets/node-with-procfile",
 		Php:                    "assets/php",
+		Proxy:                  "assets/proxy",
 		Python:                 "assets/python",
 		RubySimple:             "assets/ruby_simple",
 		SecurityGroupBuildpack: "assets/security_group_buildpack.zip",


### PR DESCRIPTION
Use proxy app in service_discovery tests. 

There is an issue with using cf ssh with a curl command in cats. See open issue here: https://github.com/cloudfoundry/cf-acceptance-tests/issues/266

To mitigate this, we added our proxy app and are curling that instead.

[#155208790]

Signed-off-by: Aidan Obley <aobley@pivotal.io>