### PR TITLE
Optionally use log-cache for logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ tags
 results
 .idea
 .DS_Store
-logs
+/logs
 assets/*/.bundle
 assets/catnip/bin
 assets/credhub-enabled-app/build

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ cat > integration_config.json <<EOF
   "admin_password": "admin",
   "skip_ssl_validation": true,
   "use_http": true,
+  "use_log_cache": false,
   "include_apps": true,
   "include_backend_compatibility": false,
   "include_capi_experimental": false,
@@ -191,6 +192,7 @@ include_capi_no_bridge
 * `include_routing_isolation_segments`: Flag to include routing isolation segments. [See below](#routing-isolation-segments)
 * `backend`: App tests push their apps using the backend specified. Incompatible tests will be skipped based on which backend is chosen. If left unspecified the default backend will be used where none is specified; all tests that specify a particular backend will be skipped.
 * `use_http`: Set to true if you would like CF Acceptance Tests to use HTTP when making api and application requests. (default is HTTPS)
+* `use_log_cache`: Set to true if you would like CF Acceptance Tests to use Log Cache for reading application logs. Log Cache must be deployed. (default is false)
 * `use_existing_organization`: Set to true when you need to specify an existing organization to use rather than creating a new organization.
 * `existing_organization`: Name of the existing organization to use.
 * `use_existing_user`: The admin user configured above will normally be used to create a temporary user (with lesser permissions) to perform actions (such as push applications) during tests, and then delete said user after the tests have run; set this to `true` if you want to use an existing user, configured via the following properties.

--- a/apps/default_environment_variables.go
+++ b/apps/default_environment_variables.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 
 	. "github.com/onsi/ginkgo"
@@ -162,7 +163,7 @@ exit 1
 
 			var taskStdout string
 			Eventually(func() string {
-				appLogsSession := cf.Cf("logs", "--recent", appName)
+				appLogsSession := logs.Tail(Config.GetUseLogCache(), appName)
 				appLogsSession.Wait(Config.DefaultTimeoutDuration())
 
 				taskStdout = string(appLogsSession.Out.Contents())

--- a/apps/environment_variables_group.go
+++ b/apps/environment_variables_group.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 
 	. "github.com/onsi/ginkgo"
@@ -134,7 +135,7 @@ exit 1
 			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(1))
 
 			Eventually(func() *Session {
-				appLogsSession := cf.Cf("logs", "--recent", appName)
+				appLogsSession := logs.Tail(Config.GetUseLogCache(), appName)
 				Expect(appLogsSession.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 				return appLogsSession
 			}, Config.DefaultTimeoutDuration()).Should(Say(envVarValue))

--- a/apps/healthcheck.go
+++ b/apps/healthcheck.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -55,7 +56,7 @@ var _ = AppsDescribe("Healthcheck", func() {
 
 			By("verifying it's up")
 			Eventually(func() *Session {
-				appLogsSession := cf.Cf("logs", "--recent", appName)
+				appLogsSession := logs.Tail(Config.GetUseLogCache(), appName)
 				Expect(appLogsSession.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 				return appLogsSession
 			}, Config.DefaultTimeoutDuration()).Should(gbytes.Say("I am working at"))

--- a/apps/loggregator.go
+++ b/apps/loggregator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	logshelper "github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	. "github.com/cloudfoundry/cf-acceptance-tests/helpers/matchers"
 	. "github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	"github.com/cloudfoundry/noaa"
@@ -58,13 +59,13 @@ var _ = AppsDescribe("loggregator", func() {
 		var logs *Session
 
 		BeforeEach(func() {
-			logs = cf.Cf("logs", appName)
+			logs = logshelper.TailFollow(Config.GetUseLogCache(), appName)
 		})
 
 		AfterEach(func() {
 			// logs might be nil if the BeforeEach panics
 			if logs != nil {
-				logs.Interrupt().Wait(Config.DefaultTimeoutDuration())
+				logs.Interrupt()
 			}
 		})
 
@@ -86,7 +87,7 @@ var _ = AppsDescribe("loggregator", func() {
 			}, Config.DefaultTimeoutDuration()).Should(ContainSubstring("Muahaha"))
 
 			Eventually(func() *Session {
-				appLogsSession := cf.Cf("logs", "--recent", appName)
+				appLogsSession := logshelper.Tail(Config.GetUseLogCache(), appName)
 				Expect(appLogsSession.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 				return appLogsSession
 			}, Config.DefaultTimeoutDuration()).Should(Say("Muahaha"))

--- a/helpers/app_helpers/app_helpers.go
+++ b/helpers/app_helpers/app_helpers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 )
@@ -42,5 +43,5 @@ func AppReport(appName string, timeout time.Duration) {
 		return
 	}
 	Eventually(cf.Cf("app", appName, "--guid"), timeout).Should(Exit())
-	Eventually(cf.Cf("logs", appName, "--recent"), timeout).Should(Exit())
+	Eventually(logs.Tail(Config.GetUseLogCache(), appName), timeout).Should(Exit())
 }

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -32,6 +32,7 @@ type CatsConfig interface {
 	GetIncludeRoutingIsolationSegments() bool
 	GetIncludeServiceInstanceSharing() bool
 	GetIncludeWindows() bool
+	GetUseLogCache() bool
 	GetShouldKeepUser() bool
 	GetSkipSSLValidation() bool
 	GetUseExistingUser() bool

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -93,6 +93,8 @@ type config struct {
 	IncludeIsolationSegments          *bool `json:"include_isolation_segments"`
 	IncludeRoutingIsolationSegments   *bool `json:"include_routing_isolation_segments"`
 
+	UseLogCache *bool `json:"use_log_cache"`
+
 	CredhubMode         *string `json:"credhub_mode"`
 	CredhubLocation     *string `json:"credhub_location"`
 	CredhubClientName   *string `json:"credhub_client"`
@@ -183,6 +185,8 @@ func getDefaults() config {
 	defaults.IncludeTasks = ptrToBool(false)
 	defaults.IncludeZipkin = ptrToBool(false)
 	defaults.IncludeServiceInstanceSharing = ptrToBool(false)
+
+	defaults.UseLogCache = ptrToBool(false)
 
 	defaults.IncludeWindows = ptrToBool(false)
 	defaults.NumWindowsCells = ptrToInt(0)
@@ -945,6 +949,10 @@ func (c *config) GetIncludeServiceInstanceSharing() bool {
 
 func (c *config) GetIncludeWindows() bool {
 	return *c.IncludeWindows
+}
+
+func (c *config) GetUseLogCache() bool {
+	return *c.UseLogCache
 }
 
 func (c *config) GetRubyBuildpackName() string {

--- a/helpers/logs/logs_helper.go
+++ b/helpers/logs/logs_helper.go
@@ -1,0 +1,22 @@
+package logs
+
+import (
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/onsi/gomega/gexec"
+)
+
+func Tail(useLogCache bool, appName string) *gexec.Session {
+	if useLogCache {
+		return cf.Cf("tail", appName, "--lines", "125")
+	}
+
+	return cf.Cf("logs", "--recent", appName)
+}
+
+func TailFollow(useLogCache bool, appName string) *gexec.Session {
+	if useLogCache {
+		return cf.Cf("tail", "--follow", appName)
+	}
+
+	return cf.Cf("logs", appName)
+}

--- a/route_services/route_services.go
+++ b/route_services/route_services.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	logshelper "github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 	. "github.com/onsi/ginkgo"
@@ -77,7 +78,7 @@ var _ = RouteServicesDescribe("Route Services", func() {
 			It("a request to the app is routed through the route service", func() {
 				Eventually(func() *Session {
 					helpers.CurlAppRoot(Config, appName)
-					logs := cf.Cf("logs", "--recent", routeServiceName)
+					logs := logshelper.Tail(Config.GetUseLogCache(), routeServiceName)
 					Expect(logs.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 					return logs
 				}, Config.DefaultTimeoutDuration()).Should(Say("Response Body: go, world"))
@@ -163,7 +164,7 @@ var _ = RouteServicesDescribe("Route Services", func() {
 				bindRouteToServiceWithParams(hostname, serviceInstanceName, "{\"key1\":[\"value1\",\"irynaparam\"],\"key2\":\"value3\"}")
 
 				Eventually(func() *Session {
-					logs := cf.Cf("logs", "--recent", brokerAppName)
+					logs := logshelper.Tail(Config.GetUseLogCache(), brokerAppName)
 					Expect(logs.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 					return logs
 				}, Config.DefaultTimeoutDuration()).Should(Say("irynaparam"))

--- a/routing/zipkin_tracing.go
+++ b/routing/zipkin_tracing.go
@@ -5,10 +5,10 @@ import (
 	"regexp"
 
 	"code.cloudfoundry.org/cf-routing-test-helpers/helpers"
-	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	cf_helpers "github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -45,7 +45,7 @@ var _ = ZipkinDescribe("Zipkin Tracing", func() {
 					return curlOutput
 				}, Config.DefaultTimeoutDuration()).Should(ContainSubstring("parents:"))
 
-				appLogsSession := cf.Cf("logs", "--recent", app1)
+				appLogsSession := logs.Tail(Config.GetUseLogCache(), app1)
 
 				Eventually(appLogsSession, Config.DefaultTimeoutDuration()).Should(gexec.Exit(0))
 
@@ -65,7 +65,7 @@ var _ = ZipkinDescribe("Zipkin Tracing", func() {
 					return curlOutput
 				}, Config.DefaultTimeoutDuration()).Should(ContainSubstring("parents:"))
 
-				appLogsSession = cf.Cf("logs", "--recent", hostname)
+				appLogsSession = logs.Tail(Config.GetUseLogCache(), hostname)
 
 				Eventually(appLogsSession, Config.DefaultTimeoutDuration()).Should(gexec.Exit(0))
 

--- a/security_groups/running_security_groups.go
+++ b/security_groups/running_security_groups.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 )
@@ -149,7 +150,7 @@ func deleteBuildpack(buildpack string) {
 
 func getStagingOutput(appName string) func() *Session {
 	return func() *Session {
-		appLogsSession := cf.Cf("logs", "--recent", appName)
+		appLogsSession := logs.Tail(Config.GetUseLogCache(), appName)
 		Expect(appLogsSession.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 		return appLogsSession
 	}

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 	. "github.com/onsi/ginkgo"
@@ -79,7 +80,9 @@ var _ = SshDescribe("SSH", func() {
 				Expect(string(stdErr)).To(MatchRegexp(fmt.Sprintf(`VCAP_APPLICATION=.*"application_name":"%s"`, appName)))
 				Expect(string(stdErr)).To(MatchRegexp("INSTANCE_INDEX=1"))
 
-				Eventually(func() *Buffer { return cf.Cf("logs", appName, "--recent").Wait(Config.DefaultTimeoutDuration()).Out }, Config.DefaultTimeoutDuration()).Should(Say("Successful remote access"))
+				Eventually(func() *Buffer {
+					return logs.Tail(Config.GetUseLogCache(), appName).Wait(Config.DefaultTimeoutDuration()).Out
+				}, Config.DefaultTimeoutDuration()).Should(Say("Successful remote access"))
 				Eventually(cf.Cf("events", appName), Config.DefaultTimeoutDuration()).Should(Say("audit.app.ssh-authorized"))
 			})
 		})
@@ -97,7 +100,9 @@ var _ = SshDescribe("SSH", func() {
 			Expect(string(stdErr)).To(MatchRegexp(fmt.Sprintf(`VCAP_APPLICATION=.*"application_name":"%s"`, appName)))
 			Expect(string(stdErr)).To(MatchRegexp("INSTANCE_INDEX=0"))
 
-			Eventually(func() *Buffer { return cf.Cf("logs", appName, "--recent").Wait(Config.DefaultTimeoutDuration()).Out }, Config.DefaultTimeoutDuration()).Should(Say("Successful remote access"))
+			Eventually(func() *Buffer {
+				return logs.Tail(Config.GetUseLogCache(), appName).Wait(Config.DefaultTimeoutDuration()).Out
+			}, Config.DefaultTimeoutDuration()).Should(Say("Successful remote access"))
 			Eventually(cf.Cf("events", appName), Config.DefaultTimeoutDuration()).Should(Say("audit.app.ssh-authorized"))
 		})
 
@@ -128,7 +133,9 @@ var _ = SshDescribe("SSH", func() {
 			Expect(string(output)).To(MatchRegexp(fmt.Sprintf(`VCAP_APPLICATION=.*"application_name":"%s"`, appName)))
 			Expect(string(output)).To(MatchRegexp("INSTANCE_INDEX=0"))
 
-			Eventually(func() *Buffer { return cf.Cf("logs", appName, "--recent").Wait(Config.DefaultTimeoutDuration()).Out }, Config.DefaultTimeoutDuration()).Should(Say("Successful remote access"))
+			Eventually(func() *Buffer {
+				return logs.Tail(Config.GetUseLogCache(), appName).Wait(Config.DefaultTimeoutDuration()).Out
+			}, Config.DefaultTimeoutDuration()).Should(Say("Successful remote access"))
 			Eventually(cf.Cf("events", appName), Config.DefaultTimeoutDuration()).Should(Say("audit.app.ssh-authorized"))
 		})
 
@@ -173,7 +180,9 @@ var _ = SshDescribe("SSH", func() {
 			Expect(string(output)).To(MatchRegexp(fmt.Sprintf(`VCAP_APPLICATION=.*"application_name":"%s"`, appName)))
 			Expect(string(output)).To(MatchRegexp("INSTANCE_INDEX=0"))
 
-			Eventually(func() *Buffer { return cf.Cf("logs", appName, "--recent").Wait(Config.DefaultTimeoutDuration()).Out }, Config.DefaultTimeoutDuration()).Should(Say("Successful remote access"))
+			Eventually(func() *Buffer {
+				return logs.Tail(Config.GetUseLogCache(), appName).Wait(Config.DefaultTimeoutDuration()).Out
+			}, Config.DefaultTimeoutDuration()).Should(Say("Successful remote access"))
 			Eventually(cf.Cf("events", appName), Config.DefaultTimeoutDuration()).Should(Say("audit.app.ssh-authorized"))
 		})
 


### PR DESCRIPTION
This PR adds the ability to use the new [log-cache](https://github.com/cloudfoundry/log-cache) and `log-cache-cli` for getting application logs.

Using log-cache is disabled by default and can be enabled via the CATs JSON config.