### PR TITLE
Support only one backend (diego)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ include_capi_no_bridge
 * `include_zipkin`: Flag to include tests for Zipkin tracing. `include_routing` must also be set for tests to run. CF must be deployed with `router.tracing.enable_zipkin` set for tests to pass.
 * `include_isolation_segments`: Flag to include isolation segment tests.
 * `include_routing_isolation_segments`: Flag to include routing isolation segments. [See below](#routing-isolation-segments)
-* `backend`: App tests push their apps using the backend specified. Incompatible tests will be skipped based on which backend is chosen. If left unspecified the default backend will be used where none is specified; all tests that specify a particular backend will be skipped.
 * `use_http`: Set to true if you would like CF Acceptance Tests to use HTTP when making api and application requests. (default is HTTPS)
 * `use_log_cache`: Set to true if you would like CF Acceptance Tests to use Log Cache for reading application logs. Log Cache must be deployed. (default is false)
 * `use_existing_organization`: Set to true when you need to specify an existing organization to use rather than creating a new organization.
@@ -368,22 +367,22 @@ You can of course combine the `-v` flag with the `-nodes=N` flag.
 
 ## Explanation of Test Groups
 
-Test Group Name| Compatible Backend | Description
---- | --- | ---
-`apps`| DEA or Diego | Tests the core functionalities of Cloud Foundry: staging, running, logging, routing, buildpacks, etc.  This test group should always pass against a sound Cloud Foundry deployment.
-`backend_compatibility` | Diego | Tests interoperability of droplets staged on the DEAs running on Diego
-`detect` | DEA or Diego | Tests the ability of the platform to detect the correct buildpack for compiling an application if no buildpack is explicitly specified.
-`docker`| Diego |Test our ability to run docker containers on diego and that we handle docker metadata correctly.
-`internet_dependent`| DEA or Diego | This test group tests the feature of being able to specify a buildpack via a Github URL.  As such, this depends on your Cloud Foundry application containers having access to the Internet.  You should take into account the configuration of the network into which you've deployed your Cloud Foundry, as well as any security group settings applied to application containers.
-`routing`| DEA or Diego |This package contains routing specific acceptance tests (Context path, wildcard, SSL termination, sticky sessions, zipkin tracing).
-`route_services` | Diego |This package contains route services acceptance tests.
-`security_groups`| DEA or Diego |This test group tests the security groups feature of Cloud Foundry that lets you apply rules-based controls to network traffic in and out of your containers.  These should pass for most recent Cloud Foundry installations.  `cf-release` versions `v200` and up should have support for most security group specs to pass.
-`services`| DEA or Diego | This test group tests various features related to services, e.g. registering a service broker via the service broker API.  Some of these tests exercise special integrations, such as Single Sign-On authentication; you may wish to run some tests in this package but selectively skip others if you haven't configured the required integrations.
-`ssh`| Diego |This test group tests our ability to communicate with Diego apps via ssh, scp, and sftp.
-`v3`| Diego| This test group contains tests for the next-generation v3 Cloud Controller API.  As of this writing, the v3 API is not officially supported.
-`isolation_segments` | Diego | This test group requires that Diego be deployed with a minimum of 2 cells. One of those cells must have been deployed with a `placement_tag`. If the deployment has been deployed with a routing isolation segment, `isolation_segment_domain` must also be set.
-`routing_isolation_segments` | Diego | This group tests that requests to isolated apps are only routed through isolated routers, and vice versa. It requires all of the setup for the isolation segments test suite. Additionally, a minimum of two Gorouter instances must be deployed. One instance must be configured with the property `routing_table_sharding_mode: shared-and-segments`. The other instance must have the properties `routing_table_sharding_mode: segments` and `isolation_segments: [YOUR_PLACEMENT_TAG_HERE]`. The `isolation_segment_name` in the CATs properties must match the `placement_tag` and `isolation_segment`.`isolation_segment_domain` must be set and traffic to that domain should go to the isolated router.
-`credhub`|Diego|Tests CredHub-delivered Secure Service credentials in the service binding. [CredHub configuration][credhub-secure-service-credentials] is required to run these tests. In addition to selecting a `credhub_mode`, `credhub_client` and `credhub_secret` values are required for these tests.
+Test Group Name| Description
+--- | ---
+`apps`| Tests the core functionalities of Cloud Foundry: staging, running, logging, routing, buildpacks, etc.  This test group should always pass against a sound Cloud Foundry deployment.
+`backend_compatibility` | Tests interoperability of droplets staged on the DEAs running on Diego
+`detect` | Tests the ability of the platform to detect the correct buildpack for compiling an application if no buildpack is explicitly specified.
+`docker`| Test our ability to run docker containers on diego and that we handle docker metadata correctly.
+`internet_dependent`| This test group tests the feature of being able to specify a buildpack via a Github URL.  As such, this depends on your Cloud Foundry application containers having access to the Internet.  You should take into account the configuration of the network into which you've deployed your Cloud Foundry, as well as any security group settings applied to application containers.
+`routing`| This package contains routing specific acceptance tests (Context path, wildcard, SSL termination, sticky sessions, zipkin tracing).
+`route_services` | This package contains route services acceptance tests.
+`security_groups`| This test group tests the security groups feature of Cloud Foundry that lets you apply rules-based controls to network traffic in and out of your containers.  These should pass for most recent Cloud Foundry installations.  `cf-release` versions `v200` and up should have support for most security group specs to pass.
+`services`| This test group tests various features related to services, e.g. registering a service broker via the service broker API.  Some of these tests exercise special integrations, such as Single Sign-On authentication; you may wish to run some tests in this package but selectively skip others if you haven't configured the required integrations.
+`ssh`| This test group tests our ability to communicate with Diego apps via ssh, scp, and sftp.
+`v3`| This test group contains tests for the next-generation v3 Cloud Controller API.  As of this writing, the v3 API is not officially supported.
+`isolation_segments` | This test group requires that Diego be deployed with a minimum of 2 cells. One of those cells must have been deployed with a `placement_tag`. If the deployment has been deployed with a routing isolation segment, `isolation_segment_domain` must also be set.
+`routing_isolation_segments` | This group tests that requests to isolated apps are only routed through isolated routers, and vice versa. It requires all of the setup for the isolation segments test suite. Additionally, a minimum of two Gorouter instances must be deployed. One instance must be configured with the property `routing_table_sharding_mode: shared-and-segments`. The other instance must have the properties `routing_table_sharding_mode: segments` and `isolation_segments: [YOUR_PLACEMENT_TAG_HERE]`. The `isolation_segment_name` in the CATs properties must match the `placement_tag` and `isolation_segment`.`isolation_segment_domain` must be set and traffic to that domain should go to the isolated router.
+`credhub`| Tests CredHub-delivered Secure Service credentials in the service binding. [CredHub configuration][credhub-secure-service-credentials] is required to run these tests. In addition to selecting a `credhub_mode`, `credhub_client` and `credhub_secret` values are required for these tests.
 
 ## Contributing
 
@@ -401,7 +400,6 @@ There are a number of conventions we recommend developers of CF acceptance tests
 adopt:
 
 1. When pushing an app:
-  * set the **backend**,
   * set the **memory** requirement, and use the suite's `DEFAULT_MEMORY_LIMIT` unless the test specifically needs to test a different value,
   * set the **buildpack** unless the test specifically needs to test the case where a buildpack is unspecified, and use one of `config.RubyBuildpack`, `config.JavaBuildpack`, etc.
 unless the test specifically needs to use a buildpack name or URL specific to the test,
@@ -411,16 +409,10 @@ unless the test specifically needs to use a buildpack name or URL specific to th
 
   ```go
   Expect(cf.Cf("push", appName,
-      "--no-start"                          // don't start before setting backend
       "-b", buildpackName,                  // specify buildpack
       "-m", DEFAULT_MEMORY_LIMIT,           // specify memory limit
       "-d", Config.AppsDomain,              // specify app domain
-  ).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-
-  //use the config-file specified backend when starting this app
-  app_helpers.SetBackend(appName)
-
-  Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+  ).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
   ```
 1. Delete all resources that are created, e.g. apps, routes, quotas, etc.  This is in order to leave the system in the same state it was found in.  For example, to delete apps and their associated routes:
     ```
@@ -435,9 +427,7 @@ unless the test specifically needs to use a buildpack name or URL specific to th
     ```
 1. Document the purpose of your test groups in this repo's README.md.  This is especially important when changing the explicit behavior of existing test groups or adding new test groups.
 1. Document all changes to the config object in this repo's README.md.
-1. Document the compatible backends in this repo's README.md.
 1. If you add a test that requires a new minimum `cf` CLI version, update the `minCliVersion` in `cats_suite_test.go`.
-1. If you add a test that is unsupported on a particular backend, add a ginkgo Skip() in an if Config.Backend != "your_backend" {} clause, [see Ginkgo's skip](https://onsi.github.io/ginkgo/#the-spec-runner).
 
 [networking-releases]: https://github.com/cloudfoundry-incubator/cf-networking-release/releases
 [credhub-secure-service-credentials]: https://github.com/pivotal-cf/credhub-release/blob/master/docs/secure-service-credentials.md

--- a/apps/app_bits_copy.go
+++ b/apps/app_bits_copy.go
@@ -45,7 +45,6 @@ var _ = AppsDescribe("Copy app bits", func() {
 	})
 
 	It("Copies over the package from the source app to the destination app", func() {
-		app_helpers.SetBackend(golangAppName)
 		Expect(cf.Cf("copy-source", helloWorldAppName, golangAppName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 		Eventually(func() string {

--- a/apps/app_stack.go
+++ b/apps/app_stack.go
@@ -123,20 +123,16 @@ EOF
 		stackName := "cflinuxfs2"
 		expected_lsb_release := "DISTRIB_CODENAME=trusty"
 
-		Expect(cf.Cf("push", appName,
-			"--no-start",
+		push := cf.Cf("push", appName,
 			"-b", BuildpackName,
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", appPath,
 			"-s", stackName,
 			"-d", Config.GetAppsDomain(),
-		).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-
-		start := cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())
-		Expect(start).To(Exit(0))
-		Expect(start).To(Say(expected_lsb_release))
-		Expect(start).To(Say(""))
+		).Wait(Config.CfPushTimeoutDuration())
+		Expect(push).To(Exit(0))
+		Expect(push).To(Say(expected_lsb_release))
+		Expect(push).To(Say(""))
 
 		Eventually(func() string {
 			return helpers.CurlAppRoot(Config, appName)

--- a/apps/app_staging_environment.go
+++ b/apps/app_staging_environment.go
@@ -120,17 +120,13 @@ EOF
 	})
 
 	It("uses a ruby binary for staging", func() {
-		Expect(cf.Cf("push", appName,
-			"--no-start",
+		push := cf.Cf("push", appName,
 			"-b", BuildpackName,
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", appPath,
 			"-d", Config.GetAppsDomain(),
-		).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-
-		start := cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())
-		Expect(start).To(Exit(0))
-		Expect(start).To(Say("RUBY_LOCATION=/usr/bin/ruby"))
+		).Wait(Config.DefaultTimeoutDuration())
+		Expect(push).To(Exit(0))
+		Expect(push).To(Say("RUBY_LOCATION=/usr/bin/ruby"))
 	})
 })

--- a/apps/buildpack_cache.go
+++ b/apps/buildpack_cache.go
@@ -124,16 +124,11 @@ EOF
 
 	It("uses the buildpack cache after first staging", func() {
 		Expect(cf.Cf("push", appName,
-			"--no-start",
 			"-b", BuildpackName,
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", appPath,
 			"-d", Config.GetAppsDomain(),
-		).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-
-		start := cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())
-		Expect(start).To(Exit(0))
+		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 		Eventually(func() string {
 			return helpers.CurlAppRoot(Config, appName)

--- a/apps/changing_start_command.go
+++ b/apps/changing_start_command.go
@@ -43,15 +43,12 @@ var _ = AppsDescribe("Changing an app's start command", func() {
 
 			Expect(cf.Cf(
 				"push", appName,
-				"--no-start",
 				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Catnip,
 				"-d", Config.GetAppsDomain(),
 				"-c", "FOO=foo ./catnip",
-			).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		})
 
 		It("takes effect after a restart, not requiring a push", func() {
@@ -96,9 +93,7 @@ var _ = AppsDescribe("Changing an app's start command", func() {
 		}
 
 		BeforeEach(func() {
-			Expect(cf.Cf("push", appName, "--no-start", "-b", Config.GetNodejsBuildpackName(), "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().NodeWithProcfile, "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-b", Config.GetNodejsBuildpackName(), "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().NodeWithProcfile, "-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		})
 
 		It("detects the use of the start command in the 'web' process type", func() {

--- a/apps/crashing.go
+++ b/apps/crashing.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 )
 
 var _ = AppsDescribe("Crashing", func() {
@@ -28,26 +27,16 @@ var _ = AppsDescribe("Crashing", func() {
 	})
 
 	Describe("a continuously crashing app", func() {
-		BeforeEach(func() {
-			if Config.GetBackend() != "diego" {
-				Skip(skip_messages.SkipDiegoMessage)
-			}
-		})
-
 		It("emits crash events and reports as 'crashed' after enough crashes", func() {
 			Expect(cf.Cf(
 				"push",
 				appName,
 				"-c", "/bin/false",
-				"--no-start",
 				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Catnip,
 				"-d", Config.GetAppsDomain(),
-			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(1))
+			).Wait(Config.CfPushTimeoutDuration())).To(Exit(1))
 
 			Eventually(func() string {
 				return string(cf.Cf("events", appName).Wait(Config.DefaultTimeoutDuration()).Out.Contents())
@@ -62,16 +51,12 @@ var _ = AppsDescribe("Crashing", func() {
 			Expect(cf.Cf(
 				"push",
 				appName,
-				"--no-start",
 				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Catnip,
 				"-c", "./catnip",
 				"-d", Config.GetAppsDomain(),
-			).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		})
 
 		It("shows crash events", func() {

--- a/apps/delete_route.go
+++ b/apps/delete_route.go
@@ -29,14 +29,11 @@ var _ = AppsDescribe("Delete Route", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-b", Config.GetBinaryBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Catnip,
 			"-c", "./catnip",
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(func() string {
 			return helpers.CurlAppRoot(Config, appName)
 		}, Config.DefaultTimeoutDuration()).Should(ContainSubstring("Catnip?"))

--- a/apps/droplet_uploading_and_downloading.go
+++ b/apps/droplet_uploading_and_downloading.go
@@ -55,9 +55,7 @@ var _ = AppsDescribe("Uploading and Downloading droplets", func() {
 	BeforeEach(func() {
 		helloWorldAppName = random_name.CATSRandomName("APP")
 
-		Expect(cf.Cf("push", helloWorldAppName, "--no-start", "-b", Config.GetRubyBuildpackName(), "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().HelloWorld, "-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(helloWorldAppName)
-		Expect(cf.Cf("start", helloWorldAppName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+		Expect(cf.Cf("push", helloWorldAppName, "-b", Config.GetRubyBuildpackName(), "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().HelloWorld, "-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 	})
 
 	AfterEach(func() {

--- a/apps/dynamic_info.go
+++ b/apps/dynamic_info.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 )
 
 var _ = AppsDescribe("A running application", func() {
@@ -23,38 +22,17 @@ var _ = AppsDescribe("A running application", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-b", Config.GetBinaryBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Catnip,
 			"-c", "./catnip",
 			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 	})
 
 	AfterEach(func() {
 		app_helpers.AppReport(appName, Config.DefaultTimeoutDuration())
 
 		Expect(cf.Cf("delete", appName, "-f", "-r").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-	})
-
-	It("can have its files inspected", func() {
-		// Currently cannot work with multiple instances since CF always checks instance 0
-		if Config.GetBackend() != "dea" {
-			Skip(skip_messages.SkipDeaMessage)
-		}
-		files := cf.Cf("files", appName).Wait(Config.DefaultTimeoutDuration())
-		Expect(files).To(Exit(0))
-		Expect(files).To(Say("app/"))
-
-		files = cf.Cf("files", appName, "app/").Wait(Config.DefaultTimeoutDuration())
-		Expect(files).To(Exit(0))
-		Expect(files).To(Say("main.go"))
-
-		files = cf.Cf("files", appName, "app/main.go").Wait(Config.DefaultTimeoutDuration())
-		Expect(files).To(Exit(0))
-		Expect(files).To(Say("package main"))
 	})
 
 	It("shows crash events and recovers from crashes", func() {

--- a/apps/encoding.go
+++ b/apps/encoding.go
@@ -25,7 +25,6 @@ var _ = AppsDescribe("Encoding", func() {
 			"-p", assets.NewAssets().Java,
 			"-m", "1024M",
 			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
 		Expect(cf.Cf("set-env", appName, "JAVA_OPTS", "-Djava.security.egd=file:///dev/urandom").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 		Expect(cf.Cf("start", appName).Wait(CF_JAVA_TIMEOUT)).To(Exit(0))
 	})

--- a/apps/environment_variables_group.go
+++ b/apps/environment_variables_group.go
@@ -130,9 +130,7 @@ exit 1
 				Expect(cf.Cf("create-buildpack", buildpackName, buildpackZip, "999").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 			})
 
-			Expect(cf.Cf("push", appName, "--no-start", "-m", DEFAULT_MEMORY_LIMIT, "-b", buildpackName, "-p", assets.NewAssets().HelloWorld, "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(1))
+			Expect(cf.Cf("push", appName, "-m", DEFAULT_MEMORY_LIMIT, "-b", buildpackName, "-p", assets.NewAssets().HelloWorld, "-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(1))
 
 			Eventually(func() *Session {
 				appLogsSession := logs.Tail(Config.GetUseLogCache(), appName)
@@ -169,14 +167,11 @@ exit 1
 
 			Expect(cf.Cf("push",
 				appName,
-				"--no-start",
 				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Catnip,
 				"-c", "./catnip",
-				"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 			env := helpers.CurlApp(Config, appName, "/env.json")
 

--- a/apps/fuse.go
+++ b/apps/fuse.go
@@ -32,9 +32,7 @@ var _ = AppsDescribe("FUSE", func() {
 	})
 
 	It("Can mount a fuse endpoint", func() {
-		Expect(cf.Cf("push", appName, "--no-start", "-b", Config.GetRubyBuildpackName(), "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Fuse, "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+		Expect(cf.Cf("push", appName, "-b", Config.GetRubyBuildpackName(), "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Fuse, "-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 		Eventually(func() string {
 			return helpers.CurlAppRoot(Config, appName)

--- a/apps/instance_reporting.go
+++ b/apps/instance_reporting.go
@@ -27,15 +27,11 @@ var _ = AppsDescribe("Getting instance information", func() {
 			Eventually(cf.Cf(
 				"push", appName,
 				"-p", assets.NewAssets().Binary,
-				"--no-start",
 				"-b", "binary_buildpack",
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-d", Config.GetAppsDomain(),
 				"-c", "./app"),
 				Config.CfPushTimeoutDuration()).Should(Exit(0))
-
-			app_helpers.SetBackend(appName)
-			Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
 		})
 
 		AfterEach(func() {

--- a/apps/large_payload.go
+++ b/apps/large_payload.go
@@ -29,14 +29,11 @@ var _ = AppsDescribe("Large_payload", func() {
 		appName = random_name.CATSRandomName("APP")
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-b", Config.GetBinaryBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Catnip,
 			"-c", "./catnip",
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 		Eventually(func() int {
 			curlResponse := helpers.CurlApp(Config, appName, fmt.Sprintf("/largetext/%d", payloadSize))

--- a/apps/lifecycle.go
+++ b/apps/lifecycle.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 )
 
 type AppUsageEvent struct {
@@ -73,15 +72,11 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 		It("makes the app reachable via its bound route", func() {
 			Expect(cf.Cf("push",
 				appName,
-				"--no-start",
 				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Catnip,
 				"-c", "./catnip",
-				"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, appName)
@@ -95,20 +90,14 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 			BeforeEach(func() {
 				Expect(cf.Cf("push",
 					appName,
-					"--no-start",
 					"-b", Config.GetBinaryBuildpackName(),
 					"-m", DEFAULT_MEMORY_LIMIT,
 					"-p", assets.NewAssets().Catnip,
 					"-c", "./catnip",
-					"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-				app_helpers.SetBackend(appName)
-
-				Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+					"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 				app2 = random_name.CATSRandomName("APP")
-				Expect(cf.Cf("push", app2, "--no-start", "-b", Config.GetRubyBuildpackName(), "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().HelloWorld, "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-				app_helpers.SetBackend(app2)
-				Expect(cf.Cf("start", app2).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				Expect(cf.Cf("push", app2, "-b", Config.GetRubyBuildpackName(), "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().HelloWorld, "-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 			})
 
 			AfterEach(func() {
@@ -160,19 +149,15 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 			BeforeEach(func() {
 				Expect(cf.Cf("push",
 					appName,
-					"--no-start",
 					"-b", Config.GetBinaryBuildpackName(),
 					"-m", DEFAULT_MEMORY_LIMIT,
 					"-p", assets.NewAssets().Catnip,
 					"-c", "./catnip",
-					"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-				app_helpers.SetBackend(appName)
-				Expect(cf.Cf("scale", appName, "-i", "2").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+					"-i", "2",
+					"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 			})
 
 			It("is able to start all instances", func() {
-				Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-
 				Eventually(func() *Session {
 					return cf.Cf("app", appName).Wait(Config.DefaultTimeoutDuration())
 				}, Config.DefaultTimeoutDuration()).Should(Say("#0   running"))
@@ -184,20 +169,13 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 		})
 
 		It("makes system environment variables available", func() {
-			if Config.GetBackend() != "diego" {
-				Skip(skip_messages.SkipDiegoMessage)
-			}
 			Expect(cf.Cf("push",
 				appName,
-				"--no-start",
 				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Catnip,
 				"-c", "./catnip",
-				"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 			var envOutput string
 			Eventually(func() string {
@@ -234,16 +212,12 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 		It("generates an app usage 'started' event", func() {
 			Expect(cf.Cf("push",
 				appName,
-				"--no-start",
 				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Catnip,
 				"-c", "./catnip",
-				"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration()),
+				"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration()),
 			).To(Exit(0))
-			app_helpers.SetBackend(appName)
-
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 			found, _ := lastAppUsageEvent(appName, "STARTED")
 			Expect(found).To(BeTrue())
@@ -252,15 +226,11 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 		It("generates an app usage 'buildpack_set' event", func() {
 			Expect(cf.Cf("push",
 				appName,
-				"--no-start",
 				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Catnip,
 				"-c", "./catnip",
-				"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 			found, matchingEvent := lastAppUsageEvent(appName, "BUILDPACK_SET")
 
@@ -274,15 +244,11 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 		BeforeEach(func() {
 			Expect(cf.Cf("push",
 				appName,
-				"--no-start",
 				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Catnip,
 				"-c", "./catnip",
-				"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		})
 
 		It("makes the app unreachable", func() {
@@ -322,15 +288,11 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 		BeforeEach(func() {
 			Expect(cf.Cf("push",
 				appName,
-				"--no-start",
 				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Catnip,
 				"-c", "./catnip",
-				"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		})
 
 		It("is reflected through another push", func() {
@@ -340,14 +302,11 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 
 			Expect(cf.Cf("push",
 				appName,
-				"--no-start",
 				"-b", Config.GetRubyBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().HelloWorld,
 				"-c", "null",
-				"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, appName)
@@ -365,15 +324,11 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 
 			Expect(cf.Cf("push",
 				appName,
-				"--no-start",
 				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Catnip,
 				"-c", "./catnip",
-				"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		})
 
 		It("removes the application", func() {

--- a/apps/loggregator.go
+++ b/apps/loggregator.go
@@ -39,14 +39,11 @@ var _ = AppsDescribe("loggregator", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-b", Config.GetRubyBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().LoggregatorLoadGenerator,
 			"-i", "2",
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 	})
 
 	AfterEach(func() {

--- a/apps/one_push_many_restarts.go
+++ b/apps/one_push_many_restarts.go
@@ -3,7 +3,7 @@
 // the blobstore changes without being backwards-compatible.
 //
 // If this is not caught before a deploy, all running apps will go down, as
-// during evacuation of the DEAs, the CC will not know to look in their old
+// during evacuation of the Diego cells, the CC will not know to look in their old
 // path format in the blob store.
 //
 // This tests pushes the app once (checking if it already exists), and then
@@ -66,7 +66,6 @@ var _ = PersistentAppDescribe("An application that's already been pushed", func(
 				Expect(cf.Cf("delete", "-f", "-r", appName).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 				Fail("failed to create app")
 			}
-			app_helpers.SetBackend(appName)
 			startCommand := cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())
 			if startCommand.ExitCode() != 0 {
 				Expect(cf.Cf("delete", "-f", "-r", appName).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))

--- a/apps/output_volume.go
+++ b/apps/output_volume.go
@@ -24,14 +24,11 @@ var _ = AppsDescribe("An application printing a bunch of output", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-b", Config.GetBinaryBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Catnip,
 			"-c", "./catnip",
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 	})
 
 	AfterEach(func() {

--- a/apps/routing_transparency.go
+++ b/apps/routing_transparency.go
@@ -21,14 +21,11 @@ var _ = AppsDescribe("Routing Transparency", func() {
 		appName = random_name.CATSRandomName("APP")
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-b", Config.GetGoBuildpackName(),
 			"-p", assets.NewAssets().Golang,
 			"-f", filepath.Join(assets.NewAssets().Golang, "manifest.yml"),
 			"-m", DEFAULT_MEMORY_LIMIT,
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 	})
 
 	AfterEach(func() {

--- a/apps/staging_log.go
+++ b/apps/staging_log.go
@@ -29,18 +29,16 @@ var _ = AppsDescribe("An application being staged", func() {
 	})
 
 	It("has its staging log streamed during a push", func() {
-		Eventually(cf.Cf("push",
+		push := cf.Cf("push",
 			appName,
-			"--no-start",
 			"-b", Config.GetBinaryBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Catnip,
 			"-c", "./catnip",
-			"-d", Config.GetAppsDomain()), Config.DefaultTimeoutDuration()).Should(Exit(0))
-		app_helpers.SetBackend(appName)
-		start := cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())
+		Expect(push).To(Exit(0))
 
-		output := string(start.Buffer().Contents())
+		output := string(push.Out.Contents())
 		expected := []string{"Installing dependencies", "Uploading droplet", "App started"}
 		found := false
 		for _, value := range expected {

--- a/apps/syslog_drain.go
+++ b/apps/syslog_drain.go
@@ -37,24 +37,22 @@ var _ = AppsDescribe("Logging", func() {
 			Eventually(cf.Cf(
 				"push",
 				listenerAppName,
-				"--no-start",
 				"--health-check-type", "port",
 				"-b", Config.GetGoBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().SyslogDrainListener,
 				"-d", Config.GetAppsDomain(),
 				"-f", assets.NewAssets().SyslogDrainListener+"/manifest.yml",
-			), Config.DefaultTimeoutDuration()).Should(Exit(0), "Failed to push app")
+			), Config.CfPushTimeoutDuration()).Should(Exit(0), "Failed to push app")
 
 			Eventually(cf.Cf(
 				"push",
 				logWriterAppName1,
-				"--no-start",
 				"-b", Config.GetRubyBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().RubySimple,
 				"-d", Config.GetAppsDomain(),
-			), Config.DefaultTimeoutDuration()).Should(Exit(0), "Failed to push app")
+			), Config.CfPushTimeoutDuration()).Should(Exit(0), "Failed to push app")
 
 			Eventually(cf.Cf(
 				"push",
@@ -64,15 +62,7 @@ var _ = AppsDescribe("Logging", func() {
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().RubySimple,
 				"-d", Config.GetAppsDomain(),
-			), Config.DefaultTimeoutDuration()).Should(Exit(0), "Failed to push app")
-
-			app_helpers.SetBackend(listenerAppName)
-			app_helpers.SetBackend(logWriterAppName1)
-			app_helpers.SetBackend(logWriterAppName2)
-
-			Expect(cf.Cf("start", listenerAppName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-			Expect(cf.Cf("start", logWriterAppName1).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-			Expect(cf.Cf("start", logWriterAppName2).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			), Config.CfPushTimeoutDuration()).Should(Exit(0), "Failed to push app")
 		})
 
 		AfterEach(func() {

--- a/apps/wildcard_routes.go
+++ b/apps/wildcard_routes.go
@@ -44,7 +44,6 @@ var _ = AppsDescribe("Wildcard Routes", func() {
 
 		Expect(cf.Cf(
 			"push", appNameCatnip,
-			"--no-start",
 			"-b", Config.GetBinaryBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Catnip,
@@ -52,20 +51,13 @@ var _ = AppsDescribe("Wildcard Routes", func() {
 			"-d", Config.GetAppsDomain(),
 		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
-		app_helpers.SetBackend(appNameCatnip)
-		Expect(cf.Cf("start", appNameCatnip).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-
 		Expect(cf.Cf(
 			"push", appNameSimple,
-			"--no-start",
 			"-b", Config.GetRubyBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().HelloWorld,
 			"-d", Config.GetAppsDomain(),
 		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-
-		app_helpers.SetBackend(appNameSimple)
-		Expect(cf.Cf("start", appNameSimple).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 	})
 
 	AfterEach(func() {

--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -2,7 +2,6 @@ package cats_suite_helpers
 
 import (
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
@@ -83,11 +82,6 @@ func DockerDescribe(description string, callback func()) bool {
 		})
 		Describe(description, callback)
 	})
-}
-
-func TestCliVersionCheck(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "CliVersionCheck Suite")
 }
 
 func InternetDependentDescribe(description string, callback func()) bool {
@@ -264,9 +258,6 @@ func GuidForAppName(appName string) string {
 func CredhubDescribe(description string, callback func()) bool {
 	return Describe("[credhub]", func() {
 		BeforeEach(func() {
-			if Config.GetBackend() != "diego" {
-				Skip(skip_messages.SkipDiegoMessage)
-			}
 			if !(Config.GetIncludeCredhubAssisted() || Config.GetIncludeCredhubNonAssisted()) {
 				Skip(skip_messages.SkipCredhubMessage)
 			}
@@ -302,9 +293,6 @@ func WindowsCredhubDescribe(description string, callback func()) bool {
 		BeforeEach(func() {
 			if !Config.GetIncludeWindows() {
 				Skip(skip_messages.SkipWindowsMessage)
-			}
-			if Config.GetBackend() != "diego" {
-				Skip(skip_messages.SkipDiegoMessage)
 			}
 			if !(Config.GetIncludeCredhubAssisted() || Config.GetIncludeCredhubNonAssisted()) {
 				Skip(skip_messages.SkipCredhubMessage)

--- a/credhub/service_bindings.go
+++ b/credhub/service_bindings.go
@@ -101,8 +101,6 @@ var _ = CredhubDescribe("service bindings", func() {
 	})
 
 	bindServiceAndStartApp := func(appName string) {
-		app_helpers.SetBackend(appName)
-
 		Expect(chServiceName).ToNot(Equal(""))
 		setServiceName := cf.Cf("set-env", appName, "SERVICE_NAME", chServiceName).Wait(Config.DefaultTimeoutDuration())
 		Expect(setServiceName).To(Exit(0), "failed setting SERVICE_NAME env var on app")
@@ -202,7 +200,6 @@ EOF
 				"-d", Config.GetAppsDomain(),
 			).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 
-			app_helpers.SetBackend(appName)
 			bindServiceAndStartApp(appName)
 		})
 

--- a/detect/buildpacks.go
+++ b/detect/buildpacks.go
@@ -34,12 +34,9 @@ var _ = DetectDescribe("Buildpacks", func() {
 		It("makes the app reachable via its bound route", func() {
 			Expect(cf.Cf("push",
 				appName,
-				"--no-start",
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().HelloWorld,
-				"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
+				"-d", Config.GetAppsDomain()).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, appName)
@@ -49,9 +46,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 
 	Describe("node", func() {
 		It("makes the app reachable via its bound route", func() {
-			Expect(cf.Cf("push", appName, "--no-start", "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Node, "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Node, "-d", Config.GetAppsDomain()).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, appName)
@@ -62,7 +57,6 @@ var _ = DetectDescribe("Buildpacks", func() {
 	Describe("java", func() {
 		It("makes the app reachable via its bound route", func() {
 			Expect(cf.Cf("push", appName, "--no-start", "-p", assets.NewAssets().Java, "-m", "1024M", "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
 			Expect(cf.Cf("set-env", appName, "JAVA_OPTS", "-Djava.security.egd=file:///dev/urandom").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 			Expect(cf.Cf("start", appName).Wait(CF_JAVA_TIMEOUT)).To(Exit(0))
 
@@ -74,9 +68,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 
 	Describe("golang", func() {
 		It("makes the app reachable via its bound route", func() {
-			Expect(cf.Cf("push", appName, "--no-start", "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Golang, "-f", filepath.Join(assets.NewAssets().Golang, "manifest.yml"), "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Golang, "-f", filepath.Join(assets.NewAssets().Golang, "manifest.yml"), "-d", Config.GetAppsDomain()).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, appName)
@@ -86,9 +78,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 
 	Describe("python", func() {
 		It("makes the app reachable via its bound route", func() {
-			Expect(cf.Cf("push", appName, "--no-start", "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Python, "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Python, "-d", Config.GetAppsDomain()).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, appName)
@@ -105,9 +95,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 		})
 
 		It("makes the app reachable via its bound route", func() {
-			Expect(cf.Cf("push", appName, "--no-start", "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Php, "-d", Config.GetAppsDomain()).Wait(phpPushTimeout)).To(Exit(0))
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Php, "-d", Config.GetAppsDomain()).Wait(phpPushTimeout)).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, appName)
@@ -120,9 +108,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 		// from the dotnet core buildpack until end of the version's LTS in 2019
 
 		It("makes the app reachable via its bound route", func() {
-			Expect(cf.Cf("push", appName, "--no-start", "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().DotnetCore, "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().DotnetCore, "-d", Config.GetAppsDomain()).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, appName)
@@ -132,9 +118,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 
 	Describe("staticfile", func() {
 		It("makes the app reachable via its bound route", func() {
-			Expect(cf.Cf("push", appName, "--no-start", "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Staticfile, "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Staticfile, "-d", Config.GetAppsDomain()).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, appName)
@@ -144,9 +128,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 
 	Describe("binary", func() {
 		It("makes the app reachable via its bound route", func() {
-			Expect(cf.Cf("push", appName, "--no-start", "-b", Config.GetBinaryBuildpackName(), "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Binary, "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
+			Expect(cf.Cf("push", appName, "-b", Config.GetBinaryBuildpackName(), "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Binary, "-d", Config.GetAppsDomain()).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, appName)

--- a/docker/credhub_enabled.go
+++ b/docker/credhub_enabled.go
@@ -19,12 +19,6 @@ import (
 )
 
 var _ = DockerDescribe("Docker App Lifecycle CredHub Integration", func() {
-	BeforeEach(func() {
-		if Config.GetBackend() != "diego" {
-			Skip(skip_messages.SkipDiegoMessage)
-		}
-	})
-
 	Context("when CredHub is configured", func() {
 		var chBrokerName, chServiceName, instanceName string
 
@@ -105,7 +99,6 @@ var _ = DockerDescribe("Docker App Lifecycle CredHub Integration", func() {
 					"-c", fmt.Sprintf("/myapp/dockerapp -name=%s", appName)),
 					Config.DefaultTimeoutDuration(),
 				).Should(Exit(0))
-				app_helpers.SetBackend(appName)
 
 				workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
 					TestSetup.RegularUserContext().TargetSpace()

--- a/docker/docker_lifecycle.go
+++ b/docker/docker_lifecycle.go
@@ -12,8 +12,6 @@ import (
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -21,15 +19,8 @@ import (
 
 var _ = DockerDescribe("Docker Application Lifecycle", func() {
 	var appName string
-	BeforeEach(func() {
-		if Config.GetBackend() != "diego" {
-			Skip(skip_messages.SkipDiegoMessage)
-		}
-	})
 
 	JustBeforeEach(func() {
-		app_helpers.SetBackend(appName)
-
 		By("downloading from dockerhub (starting the app)")
 		Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
 		Eventually(func() string {

--- a/docker/private_docker_lifecycle.go
+++ b/docker/private_docker_lifecycle.go
@@ -41,10 +41,6 @@ var _ = DockerDescribe("Private Docker Registry Application Lifecycle", func() {
 	}
 
 	BeforeEach(func() {
-		if Config.GetBackend() != "diego" {
-			Skip(skip_messages.SkipDiegoMessage)
-		}
-
 		if !Config.GetIncludePrivateDockerRegistry() {
 			Skip(skip_messages.SkipPrivateDockerRegistryMessage)
 		}

--- a/helpers/app_helpers/app_helpers.go
+++ b/helpers/app_helpers/app_helpers.go
@@ -20,24 +20,6 @@ func GetAppGuid(appName string) string {
 	return appGuid
 }
 
-func SetBackend(appName string) {
-	if Config.GetBackend() == "diego" {
-		EnableDiego(appName)
-	} else if Config.GetBackend() == "dea" {
-		DisableDiego(appName)
-	}
-}
-
-func EnableDiego(appName string) {
-	guid := GetAppGuid(appName)
-	Eventually(cf.Cf("curl", "/v2/apps/"+guid, "-X", "PUT", "-d", `{"diego": true}`), Config.DefaultTimeoutDuration()).Should(Exit(0))
-}
-
-func DisableDiego(appName string) {
-	guid := GetAppGuid(appName)
-	Eventually(cf.Cf("curl", "/v2/apps/"+guid, "-X", "PUT", "-d", `{"diego": false}`), Config.DefaultTimeoutDuration()).Should(Exit(0))
-}
-
 func AppReport(appName string, timeout time.Duration) {
 	if appName == "" {
 		return

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -42,7 +42,6 @@ type CatsConfig interface {
 	GetApiEndpoint() string
 	GetAppsDomain() string
 	GetArtifactsDirectory() string
-	GetBackend() string
 	GetBinaryBuildpackName() string
 	GetConfigurableTestPassword() string
 	GetCredHubBrokerClientCredential() string

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -43,8 +43,7 @@ type config struct {
 	IsolationSegmentName   *string `json:"isolation_segment_name"`
 	IsolationSegmentDomain *string `json:"isolation_segment_domain"`
 
-	Backend           *string `json:"backend"`
-	SkipSSLValidation *bool   `json:"skip_ssl_validation"`
+	SkipSSLValidation *bool `json:"skip_ssl_validation"`
 
 	ArtifactsDirectory *string `json:"artifacts_directory"`
 
@@ -135,7 +134,6 @@ func ptrToFloat(f float64) *float64 {
 }
 
 func getDefaults() config {
-	defaults.Backend = ptrToString("")
 	defaults.PersistentAppHost = ptrToString("CATS-persistent-app")
 
 	defaults.PersistentAppOrg = ptrToString("CATS-persistent-org")
@@ -255,11 +253,6 @@ func validateConfig(config *config) Errors {
 	}
 
 	err = validateAppsDomain(config)
-	if err != nil {
-		errs.Add(err)
-	}
-
-	err = validateBackend(config)
 	if err != nil {
 		errs.Add(err)
 	}
@@ -466,18 +459,6 @@ func validateConfig(config *config) Errors {
 	}
 
 	return errs
-}
-
-func validateBackend(config *config) error {
-	if config.Backend == nil {
-		return fmt.Errorf("* 'backend' must not be null")
-	}
-
-	if config.GetBackend() != "dea" && config.GetBackend() != "diego" && config.GetBackend() != "" {
-		return fmt.Errorf("* Invalid configuration: 'backend' must be 'diego', 'dea', or empty but was set to '%s'", config.GetBackend())
-	}
-
-	return nil
 }
 
 func validateApiEndpoint(config *config) error {
@@ -979,10 +960,6 @@ func (c *config) GetBinaryBuildpackName() string {
 
 func (c *config) GetPersistentAppHost() string {
 	return *c.PersistentAppHost
-}
-
-func (c *config) GetBackend() string {
-	return *c.Backend
 }
 
 func (c *config) GetPrivateDockerRegistryImage() string {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -45,7 +45,6 @@ type testConfig struct {
 	TimeoutScale *float64 `json:"timeout_scale,omitempty"`
 
 	// optional
-	Backend                       *string `json:"backend,omitempty"`
 	IncludePrivateDockerRegistry  *bool   `json:"include_private_docker_registry,omitempty"`
 	PrivateDockerRegistryImage    *string `json:"private_docker_registry_image,omitempty"`
 	PrivateDockerRegistryUsername *string `json:"private_docker_registry_username,omitempty"`
@@ -91,8 +90,7 @@ type allConfig struct {
 	IsolationSegmentName   *string `json:"isolation_segment_name"`
 	IsolationSegmentDomain *string `json:"isolation_segment_domain"`
 
-	Backend           *string `json:"backend"`
-	SkipSSLValidation *bool   `json:"skip_ssl_validation"`
+	SkipSSLValidation *bool `json:"skip_ssl_validation"`
 
 	ArtifactsDirectory *string `json:"artifacts_directory"`
 
@@ -260,8 +258,6 @@ var _ = Describe("Config", func() {
 		Expect(config.GetUseWindowsContextPath()).To(BeFalse())
 		Expect(config.GetWindowsStack()).To(Equal("windows2012R2"))
 
-		Expect(config.GetBackend()).To(Equal(""))
-
 		Expect(config.GetUseExistingUser()).To(Equal(false))
 		Expect(config.GetConfigurableTestPassword()).To(Equal(""))
 		Expect(config.GetShouldKeepUser()).To(Equal(false))
@@ -321,7 +317,6 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(ContainSubstring("'isolation_segment_name' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'isolation_segment_domain' must not be null"))
 
-			Expect(err.Error()).To(ContainSubstring("'backend' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'skip_ssl_validation' must not be null"))
 
 			Expect(err.Error()).To(ContainSubstring("'artifacts_directory' must not be null"))
@@ -347,7 +342,6 @@ var _ = Describe("Config", func() {
 
 			Expect(err.Error()).To(ContainSubstring("'include_apps' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_backend_compatibility' must not be null"))
-			Expect(err.Error()).To(ContainSubstring("'backend' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_capi_experimental' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_capi_no_bridge' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_detect' must not be null"))
@@ -599,56 +593,6 @@ var _ = Describe("Config", func() {
 
 			Expect(err.Error()).To(ContainSubstring("* 'admin_password' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("* Invalid configuration for 'api' <invalid-url.asdf>"))
-		})
-	})
-
-	Describe(`GetBackend`, func() {
-		Context("when the backend is set to `dea`", func() {
-			BeforeEach(func() {
-				testCfg.Backend = ptrToString("dea")
-			})
-
-			It("returns `dea`", func() {
-				cfg, err := cfg.NewCatsConfig(tmpFilePath)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(cfg.GetBackend()).To(Equal("dea"))
-			})
-		})
-
-		Context("when the backend is set to `diego`", func() {
-			BeforeEach(func() {
-				testCfg.Backend = ptrToString("diego")
-			})
-
-			It("returns `diego`", func() {
-				cfg, err := cfg.NewCatsConfig(tmpFilePath)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(cfg.GetBackend()).To(Equal("diego"))
-			})
-		})
-
-		Context("when the backend is empty", func() {
-			BeforeEach(func() {
-				testCfg.Backend = ptrToString("")
-			})
-
-			It("returns an empty string", func() {
-				cfg, err := cfg.NewCatsConfig(tmpFilePath)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(cfg.GetBackend()).To(Equal(""))
-			})
-		})
-
-		Context("when the backend is set to any other value", func() {
-			BeforeEach(func() {
-				testCfg.Backend = ptrToString("asdfasdf")
-			})
-
-			It("returns an error", func() {
-				_, err := cfg.NewCatsConfig(tmpFilePath)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError("* Invalid configuration: 'backend' must be 'diego', 'dea', or empty but was set to 'asdfasdf'"))
-			})
 		})
 	})
 

--- a/helpers/services/broker.go
+++ b/helpers/services/broker.go
@@ -16,7 +16,6 @@ import (
 	cats_config "github.com/cloudfoundry/cf-acceptance-tests/helpers/config"
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 )
@@ -136,7 +135,6 @@ func (b ServiceBroker) Push(config cats_config.CatsConfig) {
 		"-p", b.Path,
 		"-d", config.GetAppsDomain(),
 	).Wait(Config.BrokerStartTimeoutDuration())).To(Exit(0))
-	app_helpers.SetBackend(b.Name)
 	Expect(cf.Cf("set-health-check", b.Name, "http", "--endpoint", "/v2/catalog").Wait(Config.BrokerStartTimeoutDuration())).To(Exit(0))
 	Expect(cf.Cf("start", b.Name).Wait(Config.BrokerStartTimeoutDuration())).To(Exit(0))
 }
@@ -151,7 +149,6 @@ func (b ServiceBroker) PushWithBuildpackAndManifest(config cats_config.CatsConfi
 		"-f", b.Path+"/manifest.yml",
 		"-d", config.GetAppsDomain(),
 	).Wait(Config.BrokerStartTimeoutDuration())).To(Exit(0))
-	app_helpers.SetBackend(b.Name)
 	Expect(cf.Cf("set-health-check", b.Name, "http", "--endpoint", "/v2/catalog").Wait(Config.BrokerStartTimeoutDuration())).To(Exit(0))
 	Expect(cf.Cf("start", b.Name).Wait(Config.BrokerStartTimeoutDuration())).To(Exit(0))
 }

--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -4,11 +4,7 @@ const SkipAppsMessage string = `Skipping this test because config.IncludeApps is
 const SkipBackendCompatibilityMessage string = `Skipping this test because config.IncludeBackendCompatibility is set to 'false'.
 NOTE: Ensure that your platform is running both DEA and Diego before running this test.`
 const SkipContainerNetworkingMessage string = `Skipping this test because Config.IncludeContainerNetworking is set to 'false' or config.SecureAddress is not set.`
-const SkipDeaMessage string = `Skipping this test because Config.Backend is not set to 'dea'.
-NOTE: Ensure that your platform is running DEAs before enabling this test.`
 const SkipDetectMessage string = `Skipping this test because config.IncludeDetect is set to 'false'.`
-const SkipDiegoMessage string = `Skipping this test because Config.Backend is not set to 'diego'.
-NOTE: Ensure that your platform is running Diego before enabling this test.`
 const SkipDockerMessage string = `Skipping this test because config.IncludeDocker is set to 'false'.
 NOTE: Ensure Docker containers are enabled on your platform before enabling this test.`
 const SkipInternetDependentMessage string = `Skipping this test because config.IncludeInternetDependent is set to 'false'.

--- a/internet_dependent/app_dns_resolution.go
+++ b/internet_dependent/app_dns_resolution.go
@@ -27,13 +27,11 @@ type CatnipCurlResponse struct {
 func pushApp(appName, buildpack string) {
 	Expect(cf.Cf("push",
 		appName,
-		"--no-start",
 		"-b", buildpack,
 		"-m", DEFAULT_MEMORY_LIMIT,
 		"-p", assets.NewAssets().Catnip,
 		"-c", "./catnip",
-		"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-	app_helpers.SetBackend(appName)
+		"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 }
 
 func testAppConnectivity(clientAppName string, privateHost string, privatePort int) CatnipCurlResponse {
@@ -63,7 +61,6 @@ var _ = InternetDependentDescribe("App container DNS behavior", func() {
 	It("allows app containers to resolve public DNS", func() {
 		clientAppName = random_name.CATSRandomName("APP")
 		pushApp(clientAppName, Config.GetBinaryBuildpackName())
-		Expect(cf.Cf("start", clientAppName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 		By("Connecting from running container to an external destination")
 		catnipCurlResponse = testAppConnectivity(clientAppName, "www.google.com", 80)

--- a/internet_dependent/git_buildpack.go
+++ b/internet_dependent/git_buildpack.go
@@ -20,9 +20,7 @@ var _ = InternetDependentDescribe("GitBuildpack", func() {
 
 	It("uses a buildpack from a git url", func() {
 		appName = random_name.CATSRandomName("APP")
-		Expect(cf.Cf("push", appName, "--no-start", "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Node, "-b", "https://github.com/cloudfoundry/nodejs-buildpack.git#v1.3.1", "-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+		Expect(cf.Cf("push", appName, "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Node, "-b", "https://github.com/cloudfoundry/nodejs-buildpack.git#v1.3.1", "-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 		Eventually(func() string {
 			return helpers.CurlAppRoot(Config, appName)

--- a/isolation_segments/isolation_segments.go
+++ b/isolation_segments/isolation_segments.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers"
@@ -93,15 +92,12 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 				Eventually(cf.Cf(
 					"push", appName,
 					"-p", assets.NewAssets().Binary,
-					"--no-start",
 					"-m", DEFAULT_MEMORY_LIMIT,
 					"-b", "binary_buildpack",
 					"-d", appsDomain,
 					"-c", "./app"),
 					Config.CfPushTimeoutDuration()).Should(Exit(0))
 
-				app_helpers.EnableDiego(appName)
-				Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
 				Eventually(helpers.CurlingAppRoot(Config, appName), Config.DefaultTimeoutDuration()).Should(ContainSubstring(binaryHi))
 			})
 		})
@@ -124,15 +120,11 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 				Eventually(cf.Cf(
 					"push", appName,
 					"-p", assets.NewAssets().Binary,
-					"--no-start",
 					"-m", DEFAULT_MEMORY_LIMIT,
 					"-b", "binary_buildpack",
 					"-d", isoSegDomain,
 					"-c", "./app"),
 					Config.CfPushTimeoutDuration()).Should(Exit(0))
-
-				app_helpers.EnableDiego(appName)
-				Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
 
 				resp := v3_helpers.SendRequestWithSpoofedHeader(fmt.Sprintf("%s.%s", appName, isoSegDomain), isoSegDomain)
 				defer resp.Body.Close()
@@ -175,15 +167,11 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 				Eventually(cf.Cf(
 					"push", appName,
 					"-p", assets.NewAssets().Binary,
-					"--no-start",
 					"-m", DEFAULT_MEMORY_LIMIT,
 					"-b", "binary_buildpack",
 					"-d", isoSegDomain,
 					"-c", "./app"),
 					Config.CfPushTimeoutDuration()).Should(Exit(0))
-
-				app_helpers.EnableDiego(appName)
-				Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(1))
 			})
 		})
 	})
@@ -229,15 +217,11 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 				Eventually(cf.Cf(
 					"push", appName,
 					"-p", assets.NewAssets().Binary,
-					"--no-start",
 					"-m", DEFAULT_MEMORY_LIMIT,
 					"-b", "binary_buildpack",
 					"-d", isoSegDomain,
 					"-c", "./app"),
 					Config.CfPushTimeoutDuration()).Should(Exit(0))
-
-				app_helpers.EnableDiego(appName)
-				Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
 
 				resp := v3_helpers.SendRequestWithSpoofedHeader(fmt.Sprintf("%s.%s", appName, isoSegDomain), isoSegDomain)
 				defer resp.Body.Close()

--- a/route_services/route_services.go
+++ b/route_services/route_services.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	logshelper "github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
@@ -23,12 +22,6 @@ import (
 )
 
 var _ = RouteServicesDescribe("Route Services", func() {
-	BeforeEach(func() {
-		if Config.GetBackend() != "diego" {
-			Skip(skip_messages.SkipDiegoMessage)
-		}
-	})
-
 	Context("when a route binds to a service", func() {
 		Context("when service broker returns a route service url", func() {
 			var (

--- a/routing/multiple_app_ports.go
+++ b/routing/multiple_app_ports.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -24,9 +23,6 @@ var _ = RoutingDescribe("Multiple App Ports", func() {
 	)
 
 	BeforeEach(func() {
-		if Config.GetBackend() != "diego" {
-			Skip(skip_messages.SkipDiegoMessage)
-		}
 		app = random_name.CATSRandomName("APP")
 		cmd := fmt.Sprintf("go-online --ports=7777,8888,8080")
 

--- a/routing_isolation_segments/routing_isolation_segments.go
+++ b/routing_isolation_segments/routing_isolation_segments.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers"
@@ -82,15 +81,11 @@ var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
 				Eventually(cf.Cf(
 					"push", appName,
 					"-p", assets.NewAssets().Binary,
-					"--no-start",
 					"-m", DEFAULT_MEMORY_LIMIT,
 					"-b", "binary_buildpack",
 					"-d", appsDomain,
 					"-c", "./app"),
 					Config.CfPushTimeoutDuration()).Should(Exit(0))
-
-				app_helpers.EnableDiego(appName)
-				Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
 			})
 		})
 
@@ -130,15 +125,11 @@ var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
 				Eventually(cf.Cf(
 					"push", appName,
 					"-p", assets.NewAssets().Binary,
-					"--no-start",
 					"-m", DEFAULT_MEMORY_LIMIT,
 					"-b", "binary_buildpack",
 					"-d", isoSegDomain,
 					"-c", "./app"),
 					Config.CfPushTimeoutDuration()).Should(Exit(0))
-
-				app_helpers.EnableDiego(appName)
-				Eventually(cf.Cf("start", appName), Config.CfPushTimeoutDuration()).Should(Exit(0))
 			})
 		})
 

--- a/security_groups/running_security_groups.go
+++ b/security_groups/running_security_groups.go
@@ -56,7 +56,6 @@ func pushApp(appName, buildpack string) {
 		"-p", assets.NewAssets().Catnip,
 		"-c", "./catnip",
 		"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-	app_helpers.SetBackend(appName)
 }
 
 func getAppHostIpAndPort(appName string) (string, string) {

--- a/service_discovery/service_discovery.go
+++ b/service_discovery/service_discovery.go
@@ -53,15 +53,11 @@ var _ = ServiceDiscoveryDescribe("Service Discovery", func() {
 		// push backend app
 		Expect(cf.Cf(
 			"push", appNameBackend,
-			"--no-start",
 			"-b", Config.GetRubyBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().HelloWorld,
 			"-d", Config.GetAppsDomain(),
 		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-
-		app_helpers.SetBackend(appNameBackend)
-		Expect(cf.Cf("start", appNameBackend).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 		// map internal route to backend app
 		Expect(cf.Cf("map-route", appNameBackend, internalDomainName, "--hostname", internalHostName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
@@ -69,16 +65,12 @@ var _ = ServiceDiscoveryDescribe("Service Discovery", func() {
 		// push frontend app
 		Expect(cf.Cf(
 			"push", appNameFrontend,
-			"--no-start",
 			"-b", Config.GetGoBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Proxy,
 			"-d", Config.GetAppsDomain(),
 			"-f", assets.NewAssets().Proxy+"/manifest.yml",
 		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-
-		app_helpers.SetBackend(appNameFrontend)
-		Expect(cf.Cf("start", appNameFrontend).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 	})
 
 	AfterEach(func() {

--- a/services/purge_service_instance.go
+++ b/services/purge_service_instance.go
@@ -51,15 +51,12 @@ var _ = ServicesDescribe("Purging service instances", func() {
 			By("Having a bound service instance")
 			createApp := cf.Cf("push",
 				appName,
-				"--no-start",
 				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Catnip,
 				"-c", "./catnip",
-				"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())
+				"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())
 			Expect(createApp).To(Exit(0), "failed creating app")
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 			broker.CreateServiceInstance(instanceName)
 
@@ -113,15 +110,12 @@ var _ = ServicesDescribe("Purging service instances", func() {
 				By("Having a bound service instance")
 				createApp := cf.Cf("push",
 					appName,
-					"--no-start",
 					"-b", Config.GetBinaryBuildpackName(),
 					"-m", DEFAULT_MEMORY_LIMIT,
 					"-p", assets.NewAssets().Catnip,
 					"-c", "./catnip",
-					"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())
+					"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())
 				Expect(createApp).To(Exit(0), "failed creating app")
-				app_helpers.SetBackend(appName)
-				Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 				broker.CreateServiceInstance(instanceName)
 

--- a/services/purge_service_offering.go
+++ b/services/purge_service_offering.go
@@ -52,15 +52,12 @@ var _ = ServicesDescribe("Purging service offerings", func() {
 			By("Having bound service instances")
 			createApp := cf.Cf("push",
 				appName,
-				"--no-start",
 				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Catnip,
 				"-c", "./catnip",
-				"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())
+				"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())
 			Expect(createApp).To(Exit(0), "failed creating app")
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 			broker.CreateServiceInstance(instanceName)
 
@@ -123,15 +120,12 @@ var _ = ServicesDescribe("Purging service offerings", func() {
 				By("Having bound service instances")
 				createApp := cf.Cf("push",
 					appName,
-					"--no-start",
 					"-b", Config.GetBinaryBuildpackName(),
 					"-m", DEFAULT_MEMORY_LIMIT,
 					"-p", assets.NewAssets().Catnip,
 					"-c", "./catnip",
-					"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())
+					"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())
 				Expect(createApp).To(Exit(0), "failed creating app")
-				app_helpers.SetBackend(appName)
-				Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 				broker.CreateServiceInstance(instanceName)
 

--- a/services/recursive_delete.go
+++ b/services/recursive_delete.go
@@ -55,15 +55,12 @@ var _ = ServicesDescribe("Recursive Delete", func() {
 
 			createApp := cf.Cf("push",
 				appName,
-				"--no-start",
 				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Catnip,
 				"-c", "./catnip",
-				"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())
+				"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())
 			Expect(createApp).To(Exit(0), "failed creating app")
-			app_helpers.SetBackend(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 			createService := cf.Cf("create-service", broker.Service.Name, broker.SyncPlans[0].Name, instanceName).Wait(Config.DefaultTimeoutDuration())
 			Expect(createService).To(Exit(0), "failed creating service")

--- a/services/service_instance_lifecycle.go
+++ b/services/service_instance_lifecycle.go
@@ -223,15 +223,12 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 				appName = random_name.CATSRandomName("APP")
 				createApp := cf.Cf("push",
 					appName,
-					"--no-start",
 					"-b", Config.GetBinaryBuildpackName(),
 					"-m", DEFAULT_MEMORY_LIMIT,
 					"-p", assets.NewAssets().Catnip,
 					"-c", "./catnip",
-					"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())
+					"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())
 				Expect(createApp).To(Exit(0), "failed creating app")
-				app_helpers.SetBackend(appName)
-				Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 				checkForEvents(appName, []string{"audit.app.create"})
 
@@ -403,15 +400,12 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 					appName = random_name.CATSRandomName("APP")
 					createApp := cf.Cf("push",
 						appName,
-						"--no-start",
 						"-b", Config.GetBinaryBuildpackName(),
 						"-m", DEFAULT_MEMORY_LIMIT,
 						"-p", assets.NewAssets().Catnip,
 						"-c", "./catnip",
-						"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())
+						"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())
 					Expect(createApp).To(Exit(0), "failed creating app")
-					app_helpers.SetBackend(appName)
-					Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 				})
 
 				AfterEach(func() {

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 	. "github.com/onsi/ginkgo"
 	ginkgoconfig "github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
@@ -30,9 +29,6 @@ var _ = SshDescribe("SSH", func() {
 	var appName string
 
 	BeforeEach(func() {
-		if Config.GetBackend() != "diego" {
-			Skip(skip_messages.SkipDiegoMessage)
-		}
 		appName = random_name.CATSRandomName("APP")
 		Eventually(cf.Cf(
 			"push", appName,
@@ -45,8 +41,6 @@ var _ = SshDescribe("SSH", func() {
 			"-i", "1"),
 			Config.DefaultTimeoutDuration(),
 		).Should(Exit(0))
-
-		app_helpers.SetBackend(appName)
 
 		enableSSH(appName)
 

--- a/tasks/task.go
+++ b/tasks/task.go
@@ -99,15 +99,12 @@ var _ = TasksDescribe("v3 tasks", func() {
 		BeforeEach(func() {
 			Expect(cf.Cf("push",
 				appName,
-				"--no-start",
 				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Catnip,
 				"-c", "./catnip",
-				"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
+				"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 			appGuid = app_helpers.GetAppGuid(appName)
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, appName)
 			}, Config.DefaultTimeoutDuration()).Should(ContainSubstring("Catnip?"))

--- a/windows/asp_classic.go
+++ b/windows/asp_classic.go
@@ -20,14 +20,11 @@ var _ = WindowsDescribe("ASP classic applications", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().AspClassic,
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 	})
 
 	AfterEach(func() {

--- a/windows/context_paths.go
+++ b/windows/context_paths.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
@@ -37,14 +36,11 @@ var _ = WindowsDescribe("Context Paths", func() {
 		appName1 = random_name.CATSRandomName("APP")
 		Expect(cf.Cf("push",
 			appName1,
-			"--no-start",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora,
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName1)
-		Expect(cf.Cf("start", appName1).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 		appName2 = random_name.CATSRandomName("APP")
 		Expect(cf.Cf("push",
@@ -55,18 +51,15 @@ var _ = WindowsDescribe("Context Paths", func() {
 			"-b", Config.GetHwcBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName2)
 
 		appName3 = random_name.CATSRandomName("APP")
 		Expect(cf.Cf("push",
 			appName3,
-			"--no-start",
 			"--no-route",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName3)
 
 		hostname = appName1
 

--- a/windows/credhub_assist.go
+++ b/windows/credhub_assist.go
@@ -100,8 +100,6 @@ var _ = WindowsCredhubDescribe("CredHub Integration", func() {
 	})
 
 	bindServiceAndStartApp := func(appName string) {
-		app_helpers.SetBackend(appName)
-
 		Expect(chServiceName).ToNot(Equal(""))
 		setServiceName := cf.Cf("set-env", appName, "SERVICE_NAME", chServiceName).Wait(Config.DefaultTimeoutDuration())
 		Expect(setServiceName).To(Exit(0), "failed setting SERVICE_NAME env var on app")
@@ -254,7 +252,6 @@ echo   web: webapp.exe
 						"-m", DEFAULT_MEMORY_LIMIT,
 						"-p", assets.NewAssets().Nora,
 						"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-					app_helpers.SetBackend(appName)
 					bindServiceAndStartApp(appName)
 				})
 

--- a/windows/dynamic_info.go
+++ b/windows/dynamic_info.go
@@ -21,14 +21,11 @@ var _ = WindowsDescribe("A running application", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora,
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hello i am nora"))
 	})
 

--- a/windows/http_healthcheck.go
+++ b/windows/http_healthcheck.go
@@ -31,7 +31,6 @@ var _ = WindowsDescribe("Http Healthcheck", func() {
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora,
 			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
 		logs = cf.Cf("logs", appName)
 	})
 

--- a/windows/instance_reporting.go
+++ b/windows/instance_reporting.go
@@ -26,15 +26,12 @@ var _ = WindowsDescribe("Getting instance information", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetBinaryBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().WindowsWebapp,
 			"-c", ".\\webapp.exe",
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 	})
 
 	AfterEach(func() {

--- a/windows/lifecycle.go
+++ b/windows/lifecycle.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	. "github.com/onsi/ginkgo"
@@ -30,20 +29,14 @@ var _ = WindowsDescribe("Application Lifecycle", func() {
 		By("pushing it", func() {
 			Expect(cf.Cf("push",
 				appName,
-				"--no-start",
 				"-s", Config.GetWindowsStack(),
 				"-b", Config.GetHwcBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Nora,
-				"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			app_helpers.SetBackend(appName)
+				"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		})
 
-		By("staging and running it", func() {
-			Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-		})
-
-		By("generates an app usage 'started' event", func() {
+		By("checking the 'started' event", func() {
 			found, _ := lastAppUsageEvent(appName, "STARTED")
 			Expect(found).To(BeTrue())
 		})

--- a/windows/limits.go
+++ b/windows/limits.go
@@ -20,14 +20,11 @@ var _ = WindowsDescribe("App Limits", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
 			"-m", "256m",
 			"-p", assets.NewAssets().Nora,
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hello i am nora"))
 	})
 

--- a/windows/output_volume.go
+++ b/windows/output_volume.go
@@ -21,14 +21,11 @@ var _ = WindowsDescribe("An application printing a bunch of output", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora,
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hello i am nora"))
 	})
 

--- a/windows/routing.go
+++ b/windows/routing.go
@@ -22,14 +22,11 @@ var _ = WindowsDescribe("Adding and removing routes", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora,
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hello i am nora"))
 	})
 

--- a/windows/running_log.go
+++ b/windows/running_log.go
@@ -25,14 +25,11 @@ var _ = WindowsDescribe("app logs", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora,
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hello i am nora"))
 	})
 

--- a/windows/security_groups.go
+++ b/windows/security_groups.go
@@ -29,14 +29,11 @@ var _ = WindowsDescribe("Security Groups", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora,
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hello i am nora"))
 	})
 

--- a/windows/ssh.go
+++ b/windows/ssh.go
@@ -32,14 +32,11 @@ var _ = WindowsDescribe("SSH", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora,
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hello i am nora"))
 		Expect(cf.Cf("enable-ssh", appName).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 	})

--- a/windows/standalone_webapp.go
+++ b/windows/standalone_webapp.go
@@ -29,15 +29,12 @@ var _ = WindowsDescribe("A standalone webapp", func() {
 	It("stages and runs the app", func() {
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetBinaryBuildpackName(),
 			"-c", ".\\webapp.exe",
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().WindowsWebapp,
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hi i am a standalone webapp"))
 	})
 })

--- a/windows/tasks.go
+++ b/windows/tasks.go
@@ -26,15 +26,12 @@ var _ = WindowsDescribe("Task Lifecycle", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetBinaryBuildpackName(),
 			"-c", ".\\webapp.exe",
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().WindowsWebapp,
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hi i am a standalone webapp"))
 	})
 

--- a/windows/wcf.go
+++ b/windows/wcf.go
@@ -29,15 +29,12 @@ var _ = WindowsDescribe("WCF", func() {
 
 		Expect(cf.Cf("push",
 			appName,
-			"--no-start",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Wcf,
 			"-i", strconv.Itoa(Config.GetNumWindowsCells()+1),
-			"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 	})
 
 	AfterEach(func() {

--- a/windows/worker.go
+++ b/windows/worker.go
@@ -30,14 +30,13 @@ var _ = WindowsDescribe("apps without a port", func() {
 		appName = random_name.CATSRandomName("APP")
 
 		Expect(cf.Cf("push", appName,
-			"--no-start",
 			"--no-route",
+			"--no-start",
 			"-p", filepath.Dir(workerPath),
 			"-c", fmt.Sprintf(".\\%s", filepath.Base(workerPath)),
 			"-u", "none",
 			"-b", Config.GetBinaryBuildpackName(),
 			"-s", Config.GetWindowsStack()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-		app_helpers.SetBackend(appName)
 		logs = cf.Cf("logs", appName)
 		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 	})


### PR DESCRIPTION
DEAs have been EOL'd, and CATs can drop its support for multiple backends and instead support just Diego. 

This PR makes the following changes:

* Remove 'backend' property from the config
* Remove tests that only run against the DEA backend
* Remove skip messages based on the backend property
* No longer call 'helpers.SetBackend' and collapse
  'cf push --no-start' with 'cf start' wherever possible.
* Ensure README no longer mentions backend requirements.