### PR TITLE
Use logs.Tail for windows logs assertions

### DIFF
--- a/windows/running_log.go
+++ b/windows/running_log.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -49,10 +50,8 @@ var _ = WindowsDescribe("app logs", func() {
 		message = "message-from-stdout"
 		helpers.CurlApp(Config, appName, fmt.Sprintf("/print/%s", url.QueryEscape(message)))
 
-		Eventually(func() *Session {
-			appLogsSession := cf.Cf("logs", "--recent", appName)
-			Expect(appLogsSession.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			return appLogsSession
+		Eventually(func() *Buffer {
+			return logs.Tail(Config.GetUseLogCache(), appName).Wait(Config.DefaultTimeoutDuration()).Out
 		}, Config.DefaultTimeoutDuration()).Should(Say(fmt.Sprintf("\\[APP(.*)/0\\]\\s*OUT %s", message)))
 	})
 
@@ -63,10 +62,8 @@ var _ = WindowsDescribe("app logs", func() {
 		message = "message-from-stderr"
 		helpers.CurlApp(Config, appName, fmt.Sprintf("/print_err/%s", url.QueryEscape(message)))
 
-		Eventually(func() *Session {
-			appLogsSession := cf.Cf("logs", "--recent", appName)
-			Expect(appLogsSession.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-			return appLogsSession
+		Eventually(func() *Buffer {
+			return logs.Tail(Config.GetUseLogCache(), appName).Wait(Config.DefaultTimeoutDuration()).Out
 		}, Config.DefaultTimeoutDuration()).Should(Say(fmt.Sprintf("\\[APP(.*)/0\\]\\s*ERR %s", message)))
 	})
 })

--- a/windows/set_start_command.go
+++ b/windows/set_start_command.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -38,12 +39,9 @@ var _ = WindowsDescribe("Setting an app's start command", func() {
 	})
 
 	It("uses the given start command", func() {
-		getRecentLogs := func() *Buffer {
-			session := cf.Cf("logs", appName, "--recent").Wait(Config.DefaultTimeoutDuration())
-			return session.Out
-		}
-
 		// OUT... to make sure we don't match the Launcher line: Running `loop.bat Hi there!!!'
-		Eventually(getRecentLogs, Config.DefaultTimeoutDuration()).Should(Say("OUT Hi there!!!"))
+		Eventually(func() *Buffer {
+			return logs.Tail(Config.GetUseLogCache(), appName).Wait(Config.DefaultTimeoutDuration()).Out
+		}, Config.DefaultTimeoutDuration()).Should(Say("OUT Hi there!!!"))
 	})
 })

--- a/windows/ssh.go
+++ b/windows/ssh.go
@@ -14,9 +14,11 @@ import (
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
 )
 
@@ -72,11 +74,9 @@ var _ = WindowsDescribe("SSH", func() {
 				Expect(string(stdErr)).To(MatchRegexp(fmt.Sprintf(`VCAP_APPLICATION=.*"application_name":"%s"`, appName)))
 				Expect(string(stdErr)).To(MatchRegexp("INSTANCE_INDEX=1"))
 
-				Eventually(func() string {
-					appLogsSession := cf.Cf("logs", "--recent", appName)
-					Expect(appLogsSession.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-					return string(appLogsSession.Out.Contents())
-				}).Should(ContainSubstring("Successful remote access"))
+				Eventually(func() *gbytes.Buffer {
+					return logs.Tail(Config.GetUseLogCache(), appName).Wait(Config.DefaultTimeoutDuration()).Out
+				}, Config.DefaultTimeoutDuration()).Should(gbytes.Say("Successful remote access"))
 
 				eventsCmd := cf.Cf("events", appName).Wait(Config.CfPushTimeoutDuration())
 				Expect(eventsCmd.Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
@@ -98,11 +98,9 @@ var _ = WindowsDescribe("SSH", func() {
 			Expect(string(stdErr)).To(MatchRegexp(fmt.Sprintf(`VCAP_APPLICATION=.*"application_name":"%s"`, appName)))
 			Expect(string(stdErr)).To(MatchRegexp("INSTANCE_INDEX=0"))
 
-			Eventually(func() string {
-				appLogsSession := cf.Cf("logs", "--recent", appName)
-				Expect(appLogsSession.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-				return string(appLogsSession.Out.Contents())
-			}).Should(ContainSubstring("Successful remote access"))
+			Eventually(func() *gbytes.Buffer {
+				return logs.Tail(Config.GetUseLogCache(), appName).Wait(Config.DefaultTimeoutDuration()).Out
+			}, Config.DefaultTimeoutDuration()).Should(gbytes.Say("Successful remote access"))
 
 			eventsCmd := cf.Cf("events", appName).Wait(Config.CfPushTimeoutDuration())
 			Expect(eventsCmd.Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
@@ -137,11 +135,9 @@ var _ = WindowsDescribe("SSH", func() {
 			Expect(string(output)).To(MatchRegexp(fmt.Sprintf(`VCAP_APPLICATION=.*"application_name":"%s"`, appName)))
 			Expect(string(output)).To(MatchRegexp("INSTANCE_INDEX=0"))
 
-			Eventually(func() string {
-				appLogsSession := cf.Cf("logs", "--recent", appName)
-				Expect(appLogsSession.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-				return string(appLogsSession.Out.Contents())
-			}).Should(ContainSubstring("Successful remote access"))
+			Eventually(func() *gbytes.Buffer {
+				return logs.Tail(Config.GetUseLogCache(), appName).Wait(Config.DefaultTimeoutDuration()).Out
+			}, Config.DefaultTimeoutDuration()).Should(gbytes.Say("Successful remote access"))
 
 			eventsCmd := cf.Cf("events", appName).Wait(Config.CfPushTimeoutDuration())
 			Expect(eventsCmd.Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
@@ -190,11 +186,9 @@ var _ = WindowsDescribe("SSH", func() {
 			Expect(string(output)).To(MatchRegexp(fmt.Sprintf(`VCAP_APPLICATION=.*"application_name":"%s"`, appName)))
 			Expect(string(output)).To(MatchRegexp("INSTANCE_INDEX=0"))
 
-			Eventually(func() string {
-				appLogsSession := cf.Cf("logs", "--recent", appName)
-				Expect(appLogsSession.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
-				return string(appLogsSession.Out.Contents())
-			}).Should(ContainSubstring("Successful remote access"))
+			Eventually(func() *gbytes.Buffer {
+				return logs.Tail(Config.GetUseLogCache(), appName).Wait(Config.DefaultTimeoutDuration()).Out
+			}, Config.DefaultTimeoutDuration()).Should(gbytes.Say("Successful remote access"))
 
 			eventsCmd := cf.Cf("events", appName).Wait(Config.CfPushTimeoutDuration())
 			Expect(eventsCmd.Wait(Config.CfPushTimeoutDuration())).To(Exit(0))

--- a/windows/wcf.go
+++ b/windows/wcf.go
@@ -49,7 +49,7 @@ var _ = WindowsDescribe("WCF", func() {
 	It("can have multiple routable instances on the same cell", func() {
 		Eventually(allInstancesRunning(appName, Config.GetNumWindowsCells()+1), Config.CfPushTimeoutDuration()).Should(Succeed())
 
-		Eventually(wcfRequest(appName).Msg).Should(Equal("WATS!!!"))
+		Expect(wcfRequest(appName).Msg).To(Equal("WATS!!!"))
 
 		Eventually(isServiceRunningOnTheSameCell(appName), Config.CfPushTimeoutDuration()).Should(BeTrue())
 	})


### PR DESCRIPTION
Use logs.Tail for windows logs assertions and add the missing `DefaultTimeoutDuration` for windows ssh tests.

The windows tests now use the same log fetching pattern as the linux tests