### PR TITLE
Fix `GET /sigterm` endpoint for Dora

### DIFF
--- a/assets/dora/dora.rb
+++ b/assets/dora/dora.rb
@@ -51,7 +51,7 @@ class Dora < Sinatra::Base
   end
 
   get '/sigterm' do
-    "Available sigterms #{`man -k signal | grep list`}"
+    "Available sigterms #{Signal.list.keys}"
   end
 
   get '/dpkg/:package' do


### PR DESCRIPTION
- Implementation used to rely on `man` being installed
  - It is not installed on default CF buildpack
- Alternative implementation uses Ruby `Signal.list`

Pair with @blgm 