### PR TITLE
Fix `use_windows_context_path` config

### DIFF
--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -102,7 +102,7 @@ type config struct {
 	IncludeWindows        *bool   `json:"include_windows"`
 	NumWindowsCells       *int    `json:"num_windows_cells"`
 	UseWindowsTestTask    *bool   `json:"use_windows_test_task"`
-	UseWindowsContextPath *bool   `json:"windows_context_path"`
+	UseWindowsContextPath *bool   `json:"use_windows_context_path"`
 	WindowsStack          *string `json:"windows_stack"`
 
 	PrivateDockerRegistryImage    *string `json:"private_docker_registry_image"`

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -522,6 +522,19 @@ var _ = Describe("Config", func() {
 			})
 		})
 
+		Context("when use_windows_context_path is set", func() {
+			BeforeEach(func() {
+				testCfg.UseWindowsContextPath = ptrToBool(true)
+				testCfg.NumWindowsCells = ptrToInt(1)
+			})
+
+			It("is loaded into the config", func() {
+				config, err := cfg.NewCatsConfig(tmpFilePath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.GetUseWindowsContextPath()).To(BeTrue())
+			})
+		})
+
 		Context("when the # of windows cells is < 1", func() {
 			BeforeEach(func() {
 				testCfg.WindowsStack = ptrToString("windows2016")


### PR DESCRIPTION
It was documented as `use_windows_context_path`, but the config struct
was actually parsing `windows_context_path`. So anyone with
`use_windows_context_path` set in their config was silently and
unexpectedly skipping this test

Signed-off-by: Amin Jamali <ajamali@pivotal.io>