### PR TITLE
Change multi-instance WCF test to single-instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,6 @@ include_capi_no_bridge
 * `binary_buildpack_name` [See below](#buildpack-names).
 
 * `include_windows`: Flag to include the tests that run against Windows cells.
-* `num_windows_cells`: Number of Windows cells. Must be greater than 0 if `include_windows` is set to `true`.
 * `use_windows_test_task`: Flag to include the tasks tests on Windows cells. Default is `false`.
 * `use_windows_context_path`: Flag to include the Windows context path routing tests. Default is `false`.
 * `windows_stack`: Windows stack to run tests against. Must be either `windows2012R2` or `windows2016`. Defaults to `windows2012R2`.

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -71,7 +71,6 @@ type CatsConfig interface {
 	GetUnallocatedIPForSecurityGroup() string
 	Protocol() string
 
-	GetNumWindowsCells() int
 	GetUseWindowsTestTask() bool
 	GetUseWindowsContextPath() bool
 	GetWindowsStack() string

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -100,7 +100,6 @@ type config struct {
 	CredhubClientSecret *string `json:"credhub_secret"`
 
 	IncludeWindows        *bool   `json:"include_windows"`
-	NumWindowsCells       *int    `json:"num_windows_cells"`
 	UseWindowsTestTask    *bool   `json:"use_windows_test_task"`
 	UseWindowsContextPath *bool   `json:"use_windows_context_path"`
 	WindowsStack          *string `json:"windows_stack"`
@@ -194,7 +193,6 @@ func getDefaults() config {
 	defaults.UseLogCache = ptrToBool(false)
 
 	defaults.IncludeWindows = ptrToBool(false)
-	defaults.NumWindowsCells = ptrToInt(0)
 	defaults.UseWindowsContextPath = ptrToBool(false)
 	defaults.WindowsStack = ptrToString("windows2012R2")
 	defaults.UseWindowsTestTask = ptrToBool(false)
@@ -658,10 +656,6 @@ func validateWindows(config *config) error {
 		return fmt.Errorf("* Invalid configuration: unknown Windows stack %s", config.GetWindowsStack())
 	}
 
-	if config.GetNumWindowsCells() < 1 {
-		return fmt.Errorf("* Invalid configuration: must have >= 1 Windows cell")
-	}
-
 	return nil
 }
 
@@ -988,10 +982,6 @@ func (c *config) GetPublicDockerAppImage() string {
 
 func (c *config) GetUnallocatedIPForSecurityGroup() string {
 	return *c.UnallocatedIPForSecurityGroup
-}
-
-func (c *config) GetNumWindowsCells() int {
-	return *c.NumWindowsCells
 }
 
 func (c *config) GetUseWindowsTestTask() bool {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -58,7 +58,6 @@ type testConfig struct {
 	UnallocatedIPForSecurityGroup   *string `json:"unallocated_ip_for_security_group"`
 
 	IncludeWindows        *bool   `json:"include_windows,omitempty"`
-	NumWindowsCells       *int    `json:"num_windows_cells,omitempty"`
 	UseWindowsTestTask    *bool   `json:"use_windows_test_task,omitempty"`
 	UseWindowsContextPath *bool   `json:"use_windows_context_path,omitempty"`
 	WindowsStack          *string `json:"windows_stack,omitempty"`
@@ -531,7 +530,6 @@ var _ = Describe("Config", func() {
 			Context("when the windows stack is not specified", func() {
 				BeforeEach(func() {
 					testCfg.WindowsStack = nil
-					testCfg.NumWindowsCells = ptrToInt(1)
 				})
 
 				It("defaults to windows2012R2", func() {
@@ -545,7 +543,6 @@ var _ = Describe("Config", func() {
 		Context("when use_windows_context_path is set", func() {
 			BeforeEach(func() {
 				testCfg.UseWindowsContextPath = ptrToBool(true)
-				testCfg.NumWindowsCells = ptrToInt(1)
 			})
 
 			It("is loaded into the config", func() {
@@ -554,20 +551,6 @@ var _ = Describe("Config", func() {
 				Expect(config.GetUseWindowsContextPath()).To(BeTrue())
 			})
 		})
-
-		Context("when the # of windows cells is < 1", func() {
-			BeforeEach(func() {
-				testCfg.WindowsStack = ptrToString("windows2016")
-				testCfg.NumWindowsCells = ptrToInt(0)
-			})
-
-			It("errors", func() {
-				config, err := cfg.NewCatsConfig(tmpFilePath)
-				Expect(config).To(BeNil())
-				Expect(err).To(MatchError("* Invalid configuration: must have >= 1 Windows cell"))
-			})
-		})
-
 	})
 
 	Context("when including routing isolation segment tests", func() {


### PR DESCRIPTION
We were testing that multiple WCF apps could be colocated on the same
cell. This is a better fit for our Windows regression tests:

https://github.com/cloudfoundry/windows-regression-tests

So we now will only push one instance and test that it works.

This should remove any flakiness caused by this test.