### PR TITLE
Skip security-group c2c tests when not using container-networking.

### DIFF
--- a/security_groups/running_security_groups.go
+++ b/security_groups/running_security_groups.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 )
 
 type AppsResponse struct {
@@ -188,6 +189,10 @@ var _ = SecurityGroupsDescribe("App Instance Networking", func() {
 		var privatePort int
 
 		BeforeEach(func() {
+			if !Config.GetIncludeContainerNetworking() {
+				Skip(skip_messages.SkipContainerNetworkingMessage)
+			}
+
 			orgName = TestSetup.RegularUserContext().Org
 			spaceName = TestSetup.RegularUserContext().Space
 


### PR DESCRIPTION
Running the CATs in a setup without container-networking broke the security-group test case `[It] correctly configures asgs and c2c policy independent of each other`. Inspection showed that while the failed test depends on c2c, its section is not conditional on it, causing execution even when c2c is not present/disabled.

This commit fixes the issue in the `cf.135` branch where it was found.
