### PR TITLE
cf tail doesn't expect header

### DIFF
--- a/apps/loggregator.go
+++ b/apps/loggregator.go
@@ -67,7 +67,12 @@ var _ = AppsDescribe("loggregator", func() {
 		})
 
 		It("exercises basic loggregator behavior", func() {
-			Eventually(logs, (Config.DefaultTimeoutDuration() + time.Minute)).Should(Say("(Connected, tailing|Retrieving) logs for app"))
+			if Config.GetUseLogCache() {
+				// log cache cli will not emit header unless being run in terminal
+				Consistently(logs, (Config.DefaultTimeoutDuration() + time.Minute)).ShouldNot(Say("(Connected, tailing|Retrieving) logs for app"))
+			} else {
+				Eventually(logs, (Config.DefaultTimeoutDuration() + time.Minute)).Should(Say("(Connected, tailing|Retrieving) logs for app"))
+			}
 
 			Eventually(func() string {
 				return helpers.CurlApp(Config, appName, fmt.Sprintf("/log/sleep/%d", hundredthOfOneSecond))

--- a/apps/loggregator.go
+++ b/apps/loggregator.go
@@ -67,10 +67,8 @@ var _ = AppsDescribe("loggregator", func() {
 		})
 
 		It("exercises basic loggregator behavior", func() {
-			if Config.GetUseLogCache() {
+			if !Config.GetUseLogCache() {
 				// log cache cli will not emit header unless being run in terminal
-				Consistently(logs, (Config.DefaultTimeoutDuration() + time.Minute)).ShouldNot(Say("(Connected, tailing|Retrieving) logs for app"))
-			} else {
 				Eventually(logs, (Config.DefaultTimeoutDuration() + time.Minute)).Should(Say("(Connected, tailing|Retrieving) logs for app"))
 			}
 


### PR DESCRIPTION
If running with tail, header will not be emitted
- CATs will never run as a terminal

[#157710932]

Signed-off-by: Todd Persen <tpersen@pivotal.io>

/cc @toddboom 