### PR TITLE
Add CATs for asynchronous binding create feature

### DIFF
--- a/assets/service_broker/cats.json
+++ b/assets/service_broker/cats.json
@@ -104,6 +104,20 @@
                     }
                   ]
                 }
+              },
+              {
+                "name": "<fake-async-plan-3>",
+                "id": "<fake-async-plan-3-guid>",
+                "description": "Shared fake Server, 5tb persistent disk, 40 max concurrent connections. 100 async",
+                "max_storage_tb": 5,
+                "metadata": {
+                  "cost": 0,
+                  "bullets": [
+                    {
+                      "content": "40 concurrent connections"
+                    }
+                  ]
+                }
               }
             ]
           }
@@ -118,6 +132,12 @@
         }
       },
       "<fake-async-plan-2-guid>": {
+        "sleep_seconds": 0,
+        "status": 202,
+        "body": {
+        }
+      },
+      "<fake-async-plan-3-guid>": {
         "sleep_seconds": 0,
         "status": 202,
         "body": {
@@ -191,6 +211,12 @@
       }
     },
     "bind": {
+      "<fake-async-plan-3-guid>": {
+        "sleep_seconds": 0,
+        "async_only": true,
+        "status": 202,
+        "body": {}
+      },
       "default": {
         "sleep_seconds": 0,
         "status": 201,
@@ -211,6 +237,22 @@
         "sleep_seconds": 0,
         "status": 200,
         "body": {}
+      }
+    },
+    "fetch_service_binding": {
+      "default": {
+        "sleep_seconds": 0,
+        "status": 200,
+        "body": {
+          "credentials": {
+            "uri": "fake-service://fake-user:fake-password@fake-host:3306/fake-dbname",
+            "username": "fake-user",
+            "password": "fake-password",
+            "host": "fake-host",
+            "port": 3306,
+            "database": "fake-dbname"
+          }
+        }
       }
     }
   },

--- a/assets/service_broker/service_broker.rb
+++ b/assets/service_broker/service_broker.rb
@@ -233,6 +233,15 @@ class ServiceBroker < Sinatra::Base
     end
   end
 
+  # fetch service binding
+  get '/v2/service_instances/:instance_id/service_bindings/:binding_id/last_operation/?' do |instance_id, binding_id|
+    status 200
+    log_response(status, {
+      state: 'succeeded',
+      description: '100%',
+    }.to_json)
+  end
+
   # update service instance
   patch '/v2/service_instances/:id/?' do |id|
     json_body = JSON.parse(request.body.read)
@@ -264,7 +273,7 @@ class ServiceBroker < Sinatra::Base
     json_body = JSON.parse(request.body.read)
 
     service_binding = $datasource.create_service_binding(instance_id, binding_id, json_body)
-    respond_with_behavior($datasource.behavior_for_type(:bind, service_binding['binding_data']['plan_id']))
+    respond_with_behavior($datasource.behavior_for_type(:bind, service_binding['binding_data']['plan_id']), params[:accepts_incomplete])
   end
 
   # delete service binding
@@ -273,9 +282,9 @@ class ServiceBroker < Sinatra::Base
 
     service_binding = $datasource.delete_service_binding(binding_id)
     if service_binding
-      respond_with_behavior($datasource.behavior_for_type(:unbind, service_binding['binding_data']['plan_id']))
+      respond_with_behavior($datasource.behavior_for_type(:unbind, service_binding['binding_data']['plan_id']), params[:accepts_incomplete])
     else
-      respond_with_behavior($datasource.behavior_for_type(:unbind, nil))
+      respond_with_behavior($datasource.behavior_for_type(:unbind, nil), params[:accepts_incomplete])
     end
   end
 
@@ -285,8 +294,10 @@ class ServiceBroker < Sinatra::Base
   end
 
   get '/v2/service_instances/:instance_id/service_bindings/:id' do |instance_id, binding_id|
-    status 200
-    log_response(status, JSON.pretty_generate($datasource.data['service_instances'][binding_id]['binding_data']))
+    binding_data = $datasource.data['service_instances'][binding_id]['binding_data']
+    response_body = $datasource.behavior_for_type(:fetch_service_binding, binding_data['plan_id'])
+    response_body['body'].merge!(binding_data)
+    respond_with_behavior(response_body)
   end
 
   get '/config/all/?' do

--- a/helpers/services/broker.go
+++ b/helpers/services/broker.go
@@ -118,6 +118,7 @@ func NewServiceBroker(name string, path string, TestSetup *workflowhelpers.Repro
 	b.AsyncPlans = []Plan{
 		{Name: random_name.CATSRandomName("SVC-PLAN"), ID: random_name.CATSRandomName("SVC-PLAN-ID")},
 		{Name: random_name.CATSRandomName("SVC-PLAN"), ID: random_name.CATSRandomName("SVC-PLAN-ID")},
+		{Name: random_name.CATSRandomName("SVC-PLAN"), ID: random_name.CATSRandomName("SVC-PLAN-ID")},
 	}
 	b.Service.DashboardClient.ID = random_name.CATSRandomName("DASHBOARD-ID")
 	b.Service.DashboardClient.Secret = random_name.CATSRandomName("DASHBOARD-SECRET")
@@ -220,6 +221,8 @@ func (b ServiceBroker) ToJSON() string {
 		"<fake-async-plan-guid>", b.AsyncPlans[0].ID,
 		"<fake-async-plan-2>", b.AsyncPlans[1].Name,
 		"<fake-async-plan-2-guid>", b.AsyncPlans[1].ID,
+		"<fake-async-plan-3>", b.AsyncPlans[2].Name,
+		"<fake-async-plan-3-guid>", b.AsyncPlans[2].ID,
 		"\"<fake-plan-schema>\"", string(planSchema),
 	)
 

--- a/services/service_instance_lifecycle.go
+++ b/services/service_instance_lifecycle.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
@@ -24,22 +25,27 @@ type LastOperation struct {
 	State string `json:"state"`
 }
 
-type Service struct {
+type Entity struct {
 	Name          string        `json:"name"`
 	LastOperation LastOperation `json:"last_operation"`
 }
 
-type ServiceMetadata struct {
-	URL string `json:"url"`
+type Metadata struct {
+	URL  string
+	GUID string
 }
 
 type Resource struct {
-	Entity   Service         `json:"entity"`
-	Metadata ServiceMetadata `json:"metadata"`
+	Entity   Entity   `json:"entity"`
+	Metadata Metadata `json:"metadata"`
 }
 
 type Response struct {
 	Resources []Resource `json:"resources"`
+}
+
+type ErrorResponse struct {
+	ErrorCode string `json:"error_code"`
 }
 
 var _ = ServicesDescribe("Service Instance Lifecycle", func() {
@@ -62,7 +68,7 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 		}, Config.AsyncServiceOperationTimeoutDuration(), ASYNC_OPERATION_POLL_INTERVAL).Should(Say("succeeded"))
 	}
 
-	Context("Synchronous operations", func() {
+	Describe("Synchronous operations", func() {
 		BeforeEach(func() {
 			broker = NewServiceBroker(
 				random_name.CATSRandomName("BRKR"),
@@ -81,7 +87,7 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 			broker.Destroy()
 		})
 
-		Context("just service instances", func() {
+		Describe("just service instances", func() {
 			var instanceName string
 			AfterEach(func() {
 				if instanceName != "" {
@@ -111,7 +117,7 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 				})
 
 				It("fetch the configuration parameters", func() {
-					instanceGUID := getServiceInstanceGuid(instanceName)
+					instanceGUID := getGuidFor("service", instanceName)
 					configParams := cf.Cf("curl", fmt.Sprintf("/v2/service_instances/%s/parameters", instanceGUID)).Wait(Config.DefaultTimeoutDuration())
 					Expect(configParams).To(Exit(0), "failed to curl fetch binding parameters")
 					Expect(configParams).To(Say("\"param1\": \"value\""))
@@ -214,12 +220,12 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 						})
 
 						It("can retrieve parameters", func() {
-							serviceKeyGUID := getServiceKeyGUID(instanceName, keyName)
+							serviceKeyGUID := getGuidFor("service-key", instanceName, keyName)
 							paramsEndpoint := fmt.Sprintf("/v2/service_keys/%s/parameters", serviceKeyGUID)
 
 							fetchServiceKeyParameters := cf.Cf("curl", paramsEndpoint).Wait(Config.DefaultTimeoutDuration())
 							Expect(fetchServiceKeyParameters).To(Say(`"param1": "value"`))
-							Expect(fetchServiceKeyParameters).To(Exit(0), "failed to curl fetch binding parameters")
+							Expect(fetchServiceKeyParameters).To(Exit(0), "failed to fetch service key parameters")
 						})
 
 						It("can delete the key", func() {
@@ -236,7 +242,6 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 
 		Context("when there is an app", func() {
 			var instanceName, appName string
-			params := "{\"param1\": \"value\"}"
 
 			BeforeEach(func() {
 				appName = random_name.CATSRandomName("APP")
@@ -249,7 +254,7 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 					"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())
 				Expect(createApp).To(Exit(0), "failed creating app")
 
-				checkForEvents(appName, []string{"audit.app.create"})
+				checkForAppEvents(appName, []string{"audit.app.create"})
 
 				instanceName = random_name.CATSRandomName("SVIN")
 				createService := cf.Cf("create-service", broker.Service.Name, broker.SyncPlans[0].Name, instanceName).Wait(Config.DefaultTimeoutDuration())
@@ -267,55 +272,60 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 					bindService := cf.Cf("bind-service", appName, instanceName).Wait(Config.DefaultTimeoutDuration())
 					Expect(bindService).To(Exit(0), "failed binding app to service")
 
-					checkForEvents(appName, []string{"audit.app.update"})
-
-					restageApp := cf.Cf("restage", appName).Wait(Config.CfPushTimeoutDuration())
-					Expect(restageApp).To(Exit(0), "failed restaging app")
-
-					checkForEvents(appName, []string{"audit.app.restage"})
+					checkForAppEvents(appName, []string{"audit.app.update"})
 
 					appEnv := cf.Cf("env", appName).Wait(Config.DefaultTimeoutDuration())
 					Expect(appEnv).To(Exit(0), "failed get env for app")
 					Expect(appEnv).To(Say(fmt.Sprintf("credentials")))
+
+					restartApp := cf.Cf("restart", appName).Wait(Config.CfPushTimeoutDuration())
+					Expect(restartApp).To(Exit(0), "failed restarting app")
+
+					Expect(helpers.CurlApp(Config, appName, "/env/VCAP_SERVICES")).Should(ContainSubstring("fake-service://fake-user:fake-password@fake-host:3306/fake-dbname"))
 				})
 
 				It("can bind service to app and send arbitrary params", func() {
-					bindService := cf.Cf("bind-service", appName, instanceName, "-c", params).Wait(Config.DefaultTimeoutDuration())
+					bindService := cf.Cf("bind-service", appName, instanceName, "-c", `{"param1": "value"}`).Wait(Config.DefaultTimeoutDuration())
 					Expect(bindService).To(Exit(0), "failed binding app to service")
 				})
 
 				Context("when there is an existing binding", func() {
 					BeforeEach(func() {
-						bindService := cf.Cf("bind-service", appName, instanceName, "-c", "{\"max_clients\": 5}").Wait(Config.DefaultTimeoutDuration())
+						bindService := cf.Cf("bind-service", appName, instanceName, "-c", `{"max_clients": 5}`).Wait(Config.DefaultTimeoutDuration())
 						Expect(bindService).To(Exit(0), "failed binding app to service")
 					})
 
 					It("can retrieve parameters", func() {
 						appGUID := app_helpers.GetAppGuid(appName)
-						serviceInstanceGUID := getServiceInstanceGuid(instanceName)
+						serviceInstanceGUID := getGuidFor("service", instanceName)
 						paramsEndpoint := getBindingParamsEndpoint(appGUID, serviceInstanceGUID)
 
 						fetchBindingParameters := cf.Cf("curl", paramsEndpoint).Wait(Config.DefaultTimeoutDuration())
-						Expect(fetchBindingParameters).To(Say("\"max_clients\": 5"))
-						Expect(fetchBindingParameters).To(Exit(0), "failed to curl fetch binding parameters")
+						Expect(fetchBindingParameters).To(Say(`"max_clients": 5`))
+						Expect(fetchBindingParameters).To(Exit(0), "failed to fetch binding parameters")
 					})
 
 					It("can unbind service to app and check app env and events", func() {
 						unbindService := cf.Cf("unbind-service", appName, instanceName).Wait(Config.DefaultTimeoutDuration())
 						Expect(unbindService).To(Exit(0), "failed unbinding app to service")
 
-						checkForEvents(appName, []string{"audit.app.update"})
+						checkForAppEvents(appName, []string{"audit.app.update"})
 
 						appEnv := cf.Cf("env", appName).Wait(Config.DefaultTimeoutDuration())
 						Expect(appEnv).To(Exit(0), "failed get env for app")
 						Expect(appEnv).ToNot(Say(fmt.Sprintf("credentials")))
+
+						restartApp := cf.Cf("restart", appName).Wait(Config.CfPushTimeoutDuration())
+						Expect(restartApp).To(Exit(0), "failed restarting app")
+
+						Expect(helpers.CurlApp(Config, appName, "/env/VCAP_SERVICES")).ShouldNot(ContainSubstring("fake-service://fake-user:fake-password@fake-host:3306/fake-dbname"))
 					})
 				})
 			})
 		})
 	})
 
-	Context("Asynchronous operations", func() {
+	Describe("Asynchronous operations", func() {
 		var instanceName string
 
 		BeforeEach(func() {
@@ -339,167 +349,232 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 			broker.Destroy()
 		})
 
-		It("can create a service instance", func() {
-			tags := "['tag1', 'tag2']"
-			params := "{\"param1\": \"value\"}"
+		Describe("for a service instance", func() {
+			It("can create a service instance", func() {
+				tags := "['tag1', 'tag2']"
+				params := "{\"param1\": \"value\"}"
 
-			instanceName = random_name.CATSRandomName("SVIN")
-			createService := cf.Cf("create-service", broker.Service.Name, broker.AsyncPlans[0].Name, instanceName, "-t", tags, "-c", params).Wait(Config.DefaultTimeoutDuration())
-			Expect(createService).To(Exit(0))
-			Expect(createService).To(Say("Create in progress."))
-
-			waitForAsyncOperationToComplete(broker, instanceName)
-
-			serviceInfo := cf.Cf("-v", "service", instanceName).Wait(Config.DefaultTimeoutDuration())
-			Expect(serviceInfo).To(Say("[P|p]lan:\\s+%s", broker.AsyncPlans[0].Name))
-			Expect(serviceInfo).To(Say("[S|s]tatus:\\s+create succeeded"))
-			Expect(serviceInfo).To(Say("[M|m]essage:\\s+100 percent done"))
-			Expect(serviceInfo.Out.Contents()).To(MatchRegexp(`"tags":\s*\[\n.*tag1.*\n.*tag2.*\n.*\]`))
-		})
-
-		Context("when there is an existing service instance", func() {
-			tags := "['tag1', 'tag2']"
-			params := "{\"param1\": \"value2\"}"
-
-			BeforeEach(func() {
-				instanceName = random_name.CATSRandomName("SVC")
-				createService := cf.Cf("create-service", broker.Service.Name, broker.AsyncPlans[0].Name, instanceName).Wait(Config.DefaultTimeoutDuration())
+				instanceName = random_name.CATSRandomName("SVIN")
+				createService := cf.Cf("create-service", broker.Service.Name, broker.AsyncPlans[0].Name, instanceName, "-t", tags, "-c", params).Wait(Config.DefaultTimeoutDuration())
 				Expect(createService).To(Exit(0))
 				Expect(createService).To(Say("Create in progress."))
 
 				waitForAsyncOperationToComplete(broker, instanceName)
-			})
-
-			It("can update a service plan", func() {
-				updateService := cf.Cf("update-service", instanceName, "-p", broker.AsyncPlans[1].Name).Wait(Config.DefaultTimeoutDuration())
-				Expect(updateService).To(Exit(0))
-				Expect(updateService).To(Say("Update in progress."))
-
-				serviceInfo := cf.Cf("service", instanceName).Wait(Config.DefaultTimeoutDuration())
-				Expect(serviceInfo).To(Exit(0), "failed getting service instance details")
-				Expect(serviceInfo).To(Say("[P|p]lan:\\s+%s", broker.AsyncPlans[0].Name))
-
-				waitForAsyncOperationToComplete(broker, instanceName)
-
-				serviceInfo = cf.Cf("service", instanceName).Wait(Config.DefaultTimeoutDuration())
-				Expect(serviceInfo).To(Exit(0), "failed getting service instance details")
-				Expect(serviceInfo).To(Say("[P|p]lan:\\s+%s", broker.AsyncPlans[1].Name))
-			})
-
-			It("can update the arbitrary params", func() {
-				updateService := cf.Cf("update-service", instanceName, "-c", params).Wait(Config.DefaultTimeoutDuration())
-				Expect(updateService).To(Exit(0))
-				Expect(updateService).To(Say("Update in progress."))
-
-				waitForAsyncOperationToComplete(broker, instanceName)
-			})
-
-			It("can update all of the possible parameters at once", func() {
-				updateService := cf.Cf(
-					"update-service", instanceName,
-					"-t", tags,
-					"-c", params,
-					"-p", broker.AsyncPlans[1].Name).Wait(Config.DefaultTimeoutDuration())
-				Expect(updateService).To(Exit(0))
-				Expect(updateService).To(Say("Update in progress."))
-
-				waitForAsyncOperationToComplete(broker, instanceName)
 
 				serviceInfo := cf.Cf("-v", "service", instanceName).Wait(Config.DefaultTimeoutDuration())
-				Expect(serviceInfo).To(Exit(0), "failed getting service instance details")
-				Expect(serviceInfo).To(Say("[P|p]lan:\\s+%s", broker.AsyncPlans[1].Name))
+				Expect(serviceInfo).To(Say("[P|p]lan:\\s+%s", broker.AsyncPlans[0].Name))
+				Expect(serviceInfo).To(Say("[S|s]tatus:\\s+create succeeded"))
+				Expect(serviceInfo).To(Say("[M|m]essage:\\s+100 percent done"))
 				Expect(serviceInfo.Out.Contents()).To(MatchRegexp(`"tags":\s*\[\n.*tag1.*\n.*tag2.*\n.*\]`))
 			})
 
-			It("can delete a service instance", func() {
-				deleteService := cf.Cf("delete-service", instanceName, "-f").Wait(Config.DefaultTimeoutDuration())
-				Expect(deleteService).To(Exit(0), "failed making delete request")
-				Expect(deleteService).To(Say("Delete in progress."))
+			Context("when there is an existing service instance", func() {
+				tags := "['tag1', 'tag2']"
+				params := "{\"param1\": \"value2\"}"
 
-				waitForAsyncDeletionToComplete(broker, instanceName)
-			})
-
-			Context("when there is an app", func() {
-				var appName string
 				BeforeEach(func() {
-					appName = random_name.CATSRandomName("APP")
-					createApp := cf.Cf("push",
-						appName,
-						"-b", Config.GetBinaryBuildpackName(),
-						"-m", DEFAULT_MEMORY_LIMIT,
-						"-p", assets.NewAssets().Catnip,
-						"-c", "./catnip",
-						"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())
-					Expect(createApp).To(Exit(0), "failed creating app")
+					instanceName = random_name.CATSRandomName("SVC")
+					createService := cf.Cf("create-service", broker.Service.Name, broker.AsyncPlans[0].Name, instanceName).Wait(Config.DefaultTimeoutDuration())
+					Expect(createService).To(Exit(0))
+					Expect(createService).To(Say("Create in progress."))
+
+					waitForAsyncOperationToComplete(broker, instanceName)
 				})
 
-				AfterEach(func() {
-					app_helpers.AppReport(appName, Config.DefaultTimeoutDuration())
-					Expect(cf.Cf("delete", appName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				It("can update a service plan", func() {
+					updateService := cf.Cf("update-service", instanceName, "-p", broker.AsyncPlans[1].Name).Wait(Config.DefaultTimeoutDuration())
+					Expect(updateService).To(Exit(0))
+					Expect(updateService).To(Say("Update in progress."))
+
+					serviceInfo := cf.Cf("service", instanceName).Wait(Config.DefaultTimeoutDuration())
+					Expect(serviceInfo).To(Exit(0), "failed getting service instance details")
+					Expect(serviceInfo).To(Say("[P|p]lan:\\s+%s", broker.AsyncPlans[0].Name))
+
+					waitForAsyncOperationToComplete(broker, instanceName)
+
+					serviceInfo = cf.Cf("service", instanceName).Wait(Config.DefaultTimeoutDuration())
+					Expect(serviceInfo).To(Exit(0), "failed getting service instance details")
+					Expect(serviceInfo).To(Say("[P|p]lan:\\s+%s", broker.AsyncPlans[1].Name))
 				})
 
-				It("can bind a service instance", func() {
-					bindService := cf.Cf("bind-service", appName, instanceName).Wait(Config.DefaultTimeoutDuration())
-					Expect(bindService).To(Exit(0), "failed binding app to service")
+				It("can update the arbitrary params", func() {
+					updateService := cf.Cf("update-service", instanceName, "-c", params).Wait(Config.DefaultTimeoutDuration())
+					Expect(updateService).To(Exit(0))
+					Expect(updateService).To(Say("Update in progress."))
 
-					checkForEvents(appName, []string{"audit.app.update"})
-
-					restageApp := cf.Cf("restage", appName).Wait(Config.CfPushTimeoutDuration())
-					Expect(restageApp).To(Exit(0), "failed restaging app")
-
-					checkForEvents(appName, []string{"audit.app.restage"})
-
-					appEnv := cf.Cf("env", appName).Wait(Config.DefaultTimeoutDuration())
-					Expect(appEnv).To(Exit(0), "failed get env for app")
-					Expect(appEnv).To(Say(fmt.Sprintf("credentials")))
+					waitForAsyncOperationToComplete(broker, instanceName)
 				})
 
-				It("can bind service to app and send arbitrary params", func() {
-					bindService := cf.Cf("bind-service", appName, instanceName, "-c", params).Wait(Config.DefaultTimeoutDuration())
-					Expect(bindService).To(Exit(0), "failed binding app to service")
+				It("can update all of the possible parameters at once", func() {
+					updateService := cf.Cf(
+						"update-service", instanceName,
+						"-t", tags,
+						"-c", params,
+						"-p", broker.AsyncPlans[1].Name).Wait(Config.DefaultTimeoutDuration())
+					Expect(updateService).To(Exit(0))
+					Expect(updateService).To(Say("Update in progress."))
 
-					checkForEvents(appName, []string{"audit.app.update"})
+					waitForAsyncOperationToComplete(broker, instanceName)
+
+					serviceInfo := cf.Cf("-v", "service", instanceName).Wait(Config.DefaultTimeoutDuration())
+					Expect(serviceInfo).To(Exit(0), "failed getting service instance details")
+					Expect(serviceInfo).To(Say("[P|p]lan:\\s+%s", broker.AsyncPlans[1].Name))
+					Expect(serviceInfo.Out.Contents()).To(MatchRegexp(`"tags":\s*\[\n.*tag1.*\n.*tag2.*\n.*\]`))
 				})
 
-				Context("when there is an existing binding", func() {
+				It("can delete a service instance", func() {
+					deleteService := cf.Cf("delete-service", instanceName, "-f").Wait(Config.DefaultTimeoutDuration())
+					Expect(deleteService).To(Exit(0), "failed making delete request")
+					Expect(deleteService).To(Say("Delete in progress."))
+
+					waitForAsyncDeletionToComplete(broker, instanceName)
+				})
+
+				Context("when there is an app", func() {
+					var appName string
 					BeforeEach(func() {
-						bindService := cf.Cf("bind-service", appName, instanceName).Wait(Config.DefaultTimeoutDuration())
-						Expect(bindService).To(Exit(0), "failed binding app to service")
+						appName = random_name.CATSRandomName("APP")
+						createApp := cf.Cf("push",
+							appName,
+							"-b", Config.GetBinaryBuildpackName(),
+							"-m", DEFAULT_MEMORY_LIMIT,
+							"-p", assets.NewAssets().Catnip,
+							"-c", "./catnip",
+							"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())
+						Expect(createApp).To(Exit(0), "failed creating app")
 					})
 
-					It("can unbind a service instance", func() {
-						unbindService := cf.Cf("unbind-service", appName, instanceName).Wait(Config.DefaultTimeoutDuration())
-						Expect(unbindService).To(Exit(0), "failed unbinding app to service")
+					AfterEach(func() {
+						app_helpers.AppReport(appName, Config.DefaultTimeoutDuration())
+						Expect(cf.Cf("delete", appName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+					})
 
-						checkForEvents(appName, []string{"audit.app.update"})
+					It("can bind a service instance", func() {
+						bindService := cf.Cf("bind-service", appName, instanceName).Wait(Config.DefaultTimeoutDuration())
+						Expect(bindService).To(Exit(0), "failed binding app to service")
+
+						checkForAppEvents(appName, []string{"audit.app.update"})
+
+						restageApp := cf.Cf("restage", appName).Wait(Config.CfPushTimeoutDuration())
+						Expect(restageApp).To(Exit(0), "failed restaging app")
+
+						checkForAppEvents(appName, []string{"audit.app.restage"})
 
 						appEnv := cf.Cf("env", appName).Wait(Config.DefaultTimeoutDuration())
 						Expect(appEnv).To(Exit(0), "failed get env for app")
-						Expect(appEnv).ToNot(Say(fmt.Sprintf("credentials")))
+						Expect(appEnv).To(Say(fmt.Sprintf("credentials")))
+					})
+
+					It("can bind service to app and send arbitrary params", func() {
+						bindService := cf.Cf("bind-service", appName, instanceName, "-c", params).Wait(Config.DefaultTimeoutDuration())
+						Expect(bindService).To(Exit(0), "failed binding app to service")
+
+						checkForAppEvents(appName, []string{"audit.app.update"})
+					})
+
+					Context("when there is an existing binding", func() {
+						BeforeEach(func() {
+							bindService := cf.Cf("bind-service", appName, instanceName).Wait(Config.DefaultTimeoutDuration())
+							Expect(bindService).To(Exit(0), "failed binding app to service")
+						})
+
+						It("can unbind a service instance", func() {
+							unbindService := cf.Cf("unbind-service", appName, instanceName).Wait(Config.DefaultTimeoutDuration())
+							Expect(unbindService).To(Exit(0), "failed unbinding app to service")
+
+							checkForAppEvents(appName, []string{"audit.app.update"})
+
+							appEnv := cf.Cf("env", appName).Wait(Config.DefaultTimeoutDuration())
+							Expect(appEnv).To(Exit(0), "failed get env for app")
+							Expect(appEnv).ToNot(Say(fmt.Sprintf("credentials")))
+						})
 					})
 				})
+			})
+		})
+
+		Describe("for a service binding", func() {
+			var (
+				appName     string
+				appGUID     string
+				serviceGUID string
+			)
+
+			BeforeEach(func() {
+				instanceName = random_name.CATSRandomName("SVC")
+				createService := cf.Cf("create-service", broker.Service.Name, broker.AsyncPlans[2].Name, instanceName).Wait(Config.DefaultTimeoutDuration())
+				Expect(createService).To(Exit(0))
+				Expect(createService).To(Say("Create in progress."))
+
+				waitForAsyncOperationToComplete(broker, instanceName)
+
+				appName = random_name.CATSRandomName("APP")
+				createApp := cf.Cf("push",
+					appName,
+					"--no-start",
+					"-b", Config.GetBinaryBuildpackName(),
+					"-m", DEFAULT_MEMORY_LIMIT,
+					"-p", assets.NewAssets().Catnip,
+					"-c", "./catnip",
+					"-d", Config.GetAppsDomain()).Wait(Config.DefaultTimeoutDuration())
+				Expect(createApp).To(Exit(0), "failed creating app")
+				Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+				appGUID = getGuidFor("app", appName)
+				serviceGUID = getGuidFor("service", instanceName)
+			})
+
+			AfterEach(func() {
+				app_helpers.AppReport(appName, Config.DefaultTimeoutDuration())
+				Expect(cf.Cf("delete", appName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			})
+
+			It("can bind and unbind asynchronously", func() {
+				By("creating a binding asynchronously")
+				bindService := cf.Cf(
+					"curl", "/v2/service_bindings?accepts_incomplete=true", "-X", "POST",
+					"-d", fmt.Sprintf(`'{ "app_guid": "%s", "service_instance_guid": "%s" }'`, appGUID, serviceGUID)).
+					Wait(Config.DefaultTimeoutDuration())
+
+				Expect(bindService).To(Exit(0), "failed to asynchronously bind service")
+
+				var bindingResource Resource
+				err := json.Unmarshal(bindService.Out.Contents(), &bindingResource)
+				Expect(err).NotTo(HaveOccurred())
+				bindingMetadata := bindingResource.Metadata
+
+				By("waiting for binding to be created")
+				Eventually(func() string {
+					bindingDetails := cf.Cf("curl", bindingMetadata.URL).Wait(Config.DefaultTimeoutDuration())
+					Expect(bindingDetails).To(Exit(0), "failed getting service binding details")
+
+					var binding Resource
+					err := json.Unmarshal(bindingDetails.Out.Contents(), &binding)
+					Expect(err).NotTo(HaveOccurred())
+
+					return binding.Entity.LastOperation.State
+				}, Config.AsyncServiceOperationTimeoutDuration(), ASYNC_OPERATION_POLL_INTERVAL).Should(Equal("succeeded"))
+
+				appEnv := cf.Cf("env", appName).Wait(Config.DefaultTimeoutDuration())
+				Expect(appEnv).To(Exit(0), "failed get env for app")
+				Expect(appEnv).To(Say(fmt.Sprintf("credentials")))
+
+				restartApp := cf.Cf("restart", appName).Wait(Config.CfPushTimeoutDuration())
+				Expect(restartApp).To(Exit(0), "failed restarting app")
+
+				Expect(helpers.CurlApp(Config, appName, "/env/VCAP_SERVICES")).Should(ContainSubstring("fake-service://fake-user:fake-password@fake-host:3306/fake-dbname"))
 			})
 		})
 	})
 })
 
-func checkForEvents(name string, eventNames []string) {
+func checkForAppEvents(name string, eventNames []string) {
 	events := cf.Cf("events", name).Wait(Config.DefaultTimeoutDuration())
 	Expect(events).To(Exit(0), fmt.Sprintf("failed getting events for %s", name))
 
 	for _, eventName := range eventNames {
 		Expect(events).To(Say(eventName), "failed to find event")
 	}
-}
-
-func getServiceInstanceGuid(instanceName string) string {
-	getServiceInstanceGuid := cf.Cf("service", instanceName, "--guid")
-	Eventually(getServiceInstanceGuid, Config.DefaultTimeoutDuration()).Should(Exit(0))
-
-	serviceInstanceGuid := strings.TrimSpace(string(getServiceInstanceGuid.Out.Contents()))
-	Expect(serviceInstanceGuid).NotTo(Equal(""))
-
-	return serviceInstanceGuid
 }
 
 func getBindingParamsEndpoint(appGUID string, instanceGUID string) string {
@@ -513,12 +588,10 @@ func getBindingParamsEndpoint(appGUID string, instanceGUID string) string {
 	return fmt.Sprintf("%s/parameters", jsonResults.Resources[0].Metadata.URL)
 }
 
-func getServiceKeyGUID(instanceName, keyName string) string {
-	getServiceKeyGUID := cf.Cf("service-key", instanceName, keyName, "--guid")
-	Eventually(getServiceKeyGUID, Config.DefaultTimeoutDuration()).Should(Exit(0))
+func getGuidFor(args ...string) string {
+	args = append(args, "--guid")
+	session := cf.Cf(args...).Wait(Config.DefaultTimeoutDuration())
 
-	serviceKeyGUID := strings.TrimSpace(string(getServiceKeyGUID.Out.Contents()))
-	Expect(serviceKeyGUID).NotTo(Equal(""))
-
-	return serviceKeyGUID
+	out := string(session.Out.Contents())
+	return strings.TrimSpace(out)
 }


### PR DESCRIPTION
This PR adds tests for the new asynchronous binding create feature. It allows users to create bindings asynchronously by providing `accepts_incomplete` flag. The flow is very similar to asynchronous service instance provisioning.

List of the changes:
* add new async bind response behavior to the fake broker
* add new last_operation endpoint for the binding to the fake broker
* add async binding create test
* minor refactoring

These tests pass on cf-deployment (v1.37.0) with capi-release (1.59.0)