### PR TITLE
Increase timeout in loggregator firehose test.

### DIFF
--- a/apps/loggregator.go
+++ b/apps/loggregator.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"fmt"
+
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 
 	. "github.com/onsi/ginkgo"
@@ -103,7 +104,7 @@ var _ = AppsDescribe("loggregator", func() {
 				return helpers.CurlApp(Config, appName, fmt.Sprintf("/log/sleep/%d", hundredthOfOneSecond))
 			}).Should(ContainSubstring("Muahaha"))
 
-			Eventually(msgChan, Config.DefaultTimeoutDuration(), time.Millisecond).Should(Receive(EnvelopeContainingMessageLike("Muahaha")), "To enable the logging & metrics firehose feature, please ask your CF administrator to add the 'doppler.firehose' scope to your CF admin user.")
+			Eventually(msgChan, 2*Config.DefaultTimeoutDuration(), time.Millisecond).Should(Receive(EnvelopeContainingMessageLike("Muahaha")), "To enable the logging & metrics firehose feature, please ask your CF administrator to add the 'doppler.firehose' scope to your CF admin user.")
 		})
 
 		It("shows container metrics", func() {


### PR DESCRIPTION
We've seen this test failing intermittently. Increasing the timeout here
seems to resolve this. This also changes it to match the container
metrics test below which also uses 2*config.DefaultTimeoutDuration which
was increased in story 1995884 to fix a similar issue.

In my testing, I often saw this failing against an AWS deployment,
whereas with this increased timeout, it didn't file after 20 rounds
using `ginkgo -untilItFails`. With some tracing added, I often saw it
taking a little over a minute for the messages to appear.

/cc @alext original author.