### PR TITLE
Add protocol to service discovery app url.

### DIFF
--- a/service_discovery/service_discovery.go
+++ b/service_discovery/service_discovery.go
@@ -89,7 +89,7 @@ var _ = ServiceDiscoveryDescribe("Service Discovery", func() {
 
 	Describe("Adding an internal route on an app", func() {
 		It("successfully creates a policy", func() {
-			curlArgs := appNameFrontend + "." + Config.GetAppsDomain() + "/proxy/" + internalHostName + "." + internalDomainName + ":8080"
+			curlArgs := Config.Protocol() + appNameFrontend + "." + Config.GetAppsDomain() + "/proxy/" + internalHostName + "." + internalDomainName + ":8080"
 			Eventually(func() string {
 				curl := helpers.Curl(Config, curlArgs).Wait()
 				return string(curl.Out.Contents())


### PR DESCRIPTION
We run a proxy in front of the gorouter that redirects http to https, so this test fails without adding the protocol to the url.