### PR TITLE
App env vars are different when unproxied communication is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ include_capi_no_bridge
 * `private_docker_registry_password`: Password to access the private docker repository. [See below](#private-docker)
 * `unallocated_ip_for_security_group`: An unused IP address in the private network used by CF. Defaults to 10.0.244.255. [See below](#container-networking-and-application-security-groups)
 
+* `disallow_unproxied_app_traffic`: Set this to `true` if Diego was configured to disallow unproxied port mappings, i.e. if `containers.proxy.enable_unproxied_port_mappings` is set to `false`.  Note that this also requires using the [cf-syslog-skip-cert-verify](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/cf-syslog-skip-cert-verify.yml).
+
 * `staticfile_buildpack_name` [See below](#buildpack-names).
 * `java_buildpack_name` [See below](#buildpack-names).
 * `ruby_buildpack_name` [See below](#buildpack-names).

--- a/apps/lifecycle.go
+++ b/apps/lifecycle.go
@@ -194,17 +194,25 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 			Expect(envValues.Index).To(Equal("0"))
 			Expect(envValues.IP).To(MatchRegexp(`[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+`))
 			Expect(envValues.InternalIP).To(MatchRegexp(`[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+`))
-			Expect(envValues.Port).To(MatchRegexp(`[0-9]+`))
-			Expect(envValues.Addr).To(MatchRegexp(`[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+`))
 			var ports []struct {
-				External int `json:"external"`
-				Internal int `json:"internal"`
+				External *int `json:"external"`
+				Internal int  `json:"internal"`
 			}
 			err = json.Unmarshal([]byte(envValues.Ports), &ports)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(ports)).NotTo(BeZero())
 			Expect(ports[0].Internal).NotTo(BeZero())
-			Expect(ports[0].External).NotTo(BeZero())
+
+			if Config.GetDisallowUnproxiedAppTraffic() {
+				Expect(ports[0].External).To(BeNil())
+				Expect(envValues.Port).To(BeZero())
+				Expect(envValues.Addr).To(BeZero())
+			} else {
+				Expect(ports[0].External).NotTo(BeNil())
+				Expect(*ports[0].External).NotTo(BeZero())
+				Expect(envValues.Port).To(MatchRegexp(`[0-9]+`))
+				Expect(envValues.Addr).To(MatchRegexp(`[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+`))
+			}
 		})
 
 		It("generates an app usage 'started' event", func() {

--- a/assets/syslog-drain-listener/syslog_drain.go
+++ b/assets/syslog-drain-listener/syslog_drain.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -47,9 +48,30 @@ func handleConnection(conn net.Conn) {
 
 func logIP() {
 	ip := os.Getenv("CF_INSTANCE_IP")
-	port := os.Getenv("CF_INSTANCE_PORT")
+	portsJson := os.Getenv("CF_INSTANCE_PORTS")
+	ports := []struct {
+		External         uint16 `json:"external"`
+		ExternalTLSProxy uint16 `json:"external_tls_proxy"`
+	}{}
+
+	err := json.Unmarshal([]byte(portsJson), &ports)
+	if err != nil {
+		fmt.Printf("Cannot unmarshal CF_INSTANCE_PORTS: %s", err)
+		os.Exit(1)
+	}
+
+	if len(ports) <= 0 {
+		fmt.Printf("CF_INSTANCE_PORTS is empty")
+		os.Exit(1)
+	}
+
+	port := ports[0].External
+	if port == 0 {
+		port = ports[0].ExternalTLSProxy
+	}
+
 	for {
-		fmt.Printf("ADDRESS: |%s:%s|\n", ip, port)
+		fmt.Printf("ADDRESS: |%s:%d|\n", ip, port)
 		time.Sleep(5 * time.Second)
 	}
 }

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -65,6 +65,7 @@ type CatsConfig interface {
 	GetPrivateDockerRegistryPassword() string
 	GetRubyBuildpackName() string
 	GetUnallocatedIPForSecurityGroup() string
+	GetDisallowUnproxiedAppTraffic() bool
 	Protocol() string
 
 	GetUseWindowsTestTask() bool

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -104,6 +104,7 @@ type config struct {
 	PublicDockerAppImage          *string `json:"public_docker_app_image"`
 
 	UnallocatedIPForSecurityGroup *string `json:"unallocated_ip_for_security_group"`
+	DisallowUnproxiedAppTraffic   *bool   `json:"disallow_unproxied_app_traffic"`
 
 	NamePrefix *string `json:"name_prefix"`
 
@@ -213,6 +214,7 @@ func getDefaults() config {
 	defaults.PublicDockerAppImage = ptrToString("cloudfoundry/diego-docker-app-custom:latest")
 
 	defaults.UnallocatedIPForSecurityGroup = ptrToString("10.0.244.255")
+	defaults.DisallowUnproxiedAppTraffic = ptrToBool(false)
 
 	defaults.NamePrefix = ptrToString("CATS")
 	return defaults
@@ -940,6 +942,10 @@ func (c *config) GetPublicDockerAppImage() string {
 
 func (c *config) GetUnallocatedIPForSecurityGroup() string {
 	return *c.UnallocatedIPForSecurityGroup
+}
+
+func (c *config) GetDisallowUnproxiedAppTraffic() bool {
+	return *c.DisallowUnproxiedAppTraffic
 }
 
 func (c *config) GetUseWindowsTestTask() bool {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -57,6 +57,7 @@ type testConfig struct {
 	IsolationSegmentDomain          *string `json:"isolation_segment_domain,omitempty"`
 
 	UnallocatedIPForSecurityGroup *string `json:"unallocated_ip_for_security_group"`
+	DisallowUnproxiedAppTraffic   *bool   `json:"disallow_unproxied_app_traffic"`
 
 	IncludeWindows        *bool   `json:"include_windows,omitempty"`
 	UseWindowsTestTask    *bool   `json:"use_windows_test_task,omitempty"`
@@ -297,6 +298,7 @@ var _ = Describe("Config", func() {
 
 		Expect(config.GetPublicDockerAppImage()).To(Equal("cloudfoundry/diego-docker-app-custom:latest"))
 		Expect(config.GetUnallocatedIPForSecurityGroup()).To(Equal("10.0.244.255"))
+		Expect(config.GetDisallowUnproxiedAppTraffic()).To(BeFalse())
 	})
 
 	Context("when all values are null", func() {
@@ -387,6 +389,7 @@ var _ = Describe("Config", func() {
 			testCfg.SleepTimeout = ptrToInt(101)
 			testCfg.TimeoutScale = ptrToFloat(1.0)
 			testCfg.UnallocatedIPForSecurityGroup = ptrToString("192.168.0.1")
+			testCfg.DisallowUnproxiedAppTraffic = ptrToBool(true)
 		})
 
 		It("respects the overriden values", func() {
@@ -402,6 +405,7 @@ var _ = Describe("Config", func() {
 			Expect(config.SleepTimeoutDuration()).To(Equal(101 * time.Second))
 			Expect(config.SleepTimeoutDuration()).To(Equal(101 * time.Second))
 			Expect(config.GetUnallocatedIPForSecurityGroup()).To(Equal("192.168.0.1"))
+			Expect(config.GetDisallowUnproxiedAppTraffic()).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
### What is this change about?

As part of [#157675252](https://www.pivotaltracker.com/story/show/157675252), operators can now configure Diego to require that all traffic to app containers go through the Envoy proxy.  In that scenario  `CF_INSTANCE_PORTS` & `CF_INSTANCE_PORT` environment variable will no longer be set.  Furthermore, `CF_INSTANCE_ADDR` won't have the 'external' field set. This commit introduces the following changes:

- New parameter 'disallow_unproxied_app_traffic'.
- Change the relevant tests to use the previously mentioned parameter.

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/157675252. Also chatted with @njbennett @ytulsiani about the change, so they should have some context as well.

### What version of cf-deployment have you run this cf-acceptance-test change against?

cloudfoundry/cf-deployment@030626013a80c9bc78f33561add4f3cc4e2485fd. Note that Running CATs with the new flag `disallow_unproxied_app_traffic` set to `true` requires using the latest [diego-release](https://github.com/cloudfoundry/diego-release/tree/develop) with `containers.proxy.enable_unproxied_port_mappings` set to `true` on the `Rep` job.

### Please check all that apply for this PR:
- [ ] introduces a new test --- are you sure everyone should be running this test?
- [X] changes an existing test
- [X] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [X] YES
- [ ] N/A

### How should this change be described in cf-acceptance-tests release notes?

Add a new config parameter to change the behavior of the tests when unproxied port mapping is disallowed in Diego.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

This change shouldn't affect the runtime of CATs. It only replaces existing assertions with more appropriate assertions if `disallow_unproxied_app_traffic` was set to `true`.

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

This is currently blocking Diego from merging this feature and testing it in CI.

### Tag your pair, your PM, and/or team!

@cloudfoundry/cf-diego
