### PR TITLE
Enable fetching of logs through log-cache by default

### DIFF
--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -177,7 +177,7 @@ func getDefaults() config {
 	defaults.IncludeServiceInstanceSharing = ptrToBool(false)
 	defaults.IncludeTCPRouting = ptrToBool(false)
 
-	defaults.UseLogCache = ptrToBool(false)
+	defaults.UseLogCache = ptrToBool(true)
 
 	defaults.IncludeWindows = ptrToBool(false)
 	defaults.UseWindowsContextPath = ptrToBool(false)


### PR DESCRIPTION
Signed-off-by: Jesse Weaver <jeweaver@pivotal.io>

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes, thank you for asking.

### What is this change about?

Since Log Cache is now GA in cf-d, this turns on testing of Log Cache by default.

### Please provide contextual information.

Talked to @staylor14 about flipping this default on 8/22. This seems to make sense to all parties involved since Log Cache is now GA in cf-d.

### What version of cf-deployment have you run this cf-acceptance-test change against?

This was run against cf-d 3.4.0 in our own pipeline.

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How should this change be described in cf-acceptance-tests release notes?

Testing log tailing with Log Cache is now enabled by default.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

This should speed up CATs since tailing previously used to be somewhat slow.

### What is the level of urgency for publishing this change?

- [ ] **Urgent**
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

/cc @pianohacker @colins @hdub2 