### PR TITLE
Avoid race condition when creating iso seg

### DIFF
--- a/helpers/v3_helpers/v3.go
+++ b/helpers/v3_helpers/v3.go
@@ -179,11 +179,11 @@ func CreateIsolationSegment(name string) string {
 }
 
 func CreateOrGetIsolationSegment(name string) string {
-	if IsolationSegmentExists(name) {
-		return GetIsolationSegmentGuid(name)
+	isoSegGUID := CreateIsolationSegment(name)
+	if isoSegGUID == "" {
+		isoSegGUID = GetIsolationSegmentGuid(name)
 	}
-
-	return CreateIsolationSegment(name)
+	return isoSegGUID
 }
 
 func CreatePackage(appGuid string) string {


### PR DESCRIPTION
Our CI pipelines would occasionally fail with:

```
[2018-08-23 04:32:10.48 (UTC)]> cf curl /v3/isolation_segments -X POST -d {"name":"isosegtag"}
{
   "errors": [
      {
         "detail": "Isolation Segment names are case insensitive and must be unique",
         "title": "CF-UnprocessableEntity",
         "code": 10008
      }
   ]
}
```

We think this is due to running this suite in parallel and the Find or
Create pattern is causing this race condition. We switch to always
attempting to create the Iso Seg first, then calling Find only if the
Create fails. This assumes the Create failed due to the unique
constraint shown above.

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to master once they've passed acceptance._



### What is this change about?

_Describe the change and why it's needed._



### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._



### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._



### How should this change be described in cf-acceptance-tests release notes?

_Something brief that conveys the change and is written with the component author audience in mind._



### How many more (or fewer) seconds of runtime will this change introduce to CATs?



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
