### PR TITLE
Allow security groups to pass on NSX-T

### DIFF
--- a/security_groups/running_security_groups.go
+++ b/security_groups/running_security_groups.go
@@ -232,7 +232,7 @@ var _ = SecurityGroupsDescribe("App Instance Networking", func() {
 
 			By("Testing that external connectivity to a private ip is not refused (but may be unreachable for other reasons)")
 			catnipCurlResponse = testAppConnectivity(clientAppName, privateAddress, 80)
-			Expect(catnipCurlResponse.Stderr).To(ContainSubstring("Connection timed out after"), "wide-open ASG configured but app is still refused by private ip")
+			Expect(catnipCurlResponse.Stderr).To(MatchRegexp("Connection timed out after|No route to host"), "wide-open ASG configured but app is still refused by private ip")
 
 			By("adding policy")
 			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
@@ -263,7 +263,7 @@ var _ = SecurityGroupsDescribe("App Instance Networking", func() {
 
 			By("Testing that external connectivity to a private ip is refused")
 			catnipCurlResponse = testAppConnectivity(clientAppName, privateAddress, 80)
-			Expect(catnipCurlResponse.Stderr).To(ContainSubstring("refused"))
+			Expect(catnipCurlResponse.Stderr).To(MatchRegexp("refused|No route to host"))
 
 			By("deleting policy")
 			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {


### PR DESCRIPTION
### What is this change about?

This commit enables CF foundations using the NSX-T container plugin (NCP) to pass the security groups test. NCP's mechanism to deny egress is to drop packets, resulting in timeouts, whereas Silk refuses packets. The test now accommodates `Connection timed out` failures as well as `connection refused`.


### Please provide contextual information.

See https://github.com/cloudfoundry/cf-networking-release/pull/49 for a similar change made to the networking acceptance test suite.



### What version of cf-deployment have you run this cf-acceptance-test change against?

This has been run against PAS 2.2.4 and 2.3.0-beta.2.


### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### How should this change be described in cf-acceptance-tests release notes?

This commit enables CF foundations using the NSX-T container plugin (NCP) to pass the security groups test. [NCP's mechanism to deny egress is to drop packets, resulting in timeouts, while Silk's is to refuse packets (i.e., to send a TCP reset)]. The test now accommodates `Connection timed out` (`ETIMEDOUT`) errors as well as `connection refused` (`ECONNREFUSED`).

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

There should be no change in runtime on non-NSX-T environments.

NSX-T environments will take 3 seconds for the security group check to time out and pass.

(NSX-T environments already take 3 seconds for the security group check to time out and *fail*.)


### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

Specifically, this will unblock current work in getting CATS to pass on NSX-T environments.

### Tag your pair, your PM, and/or team!

@cunnie @goehmen
