### PR TITLE
Fix go1.11 vet issues

### DIFF
--- a/capi_experimental/process_commands.go
+++ b/capi_experimental/process_commands.go
@@ -26,7 +26,6 @@ var _ = CapiExperimentalDescribe("setting_process_commands", func() {
 		packageGUID         string
 		spaceGUID           string
 		spaceName           string
-		orgName             string
 		token               string
 		dropletGuid         string
 	)
@@ -34,7 +33,6 @@ var _ = CapiExperimentalDescribe("setting_process_commands", func() {
 	BeforeEach(func() {
 		appName = random_name.CATSRandomName("APP")
 		spaceName = TestSetup.RegularUserContext().Space
-		orgName = TestSetup.RegularUserContext().Org
 		spaceGUID = GetSpaceGuidFromName(spaceName)
 		By("Creating an App")
 		appGUID = CreateApp(appName, spaceGUID, `{"foo":"bar"}`)

--- a/docker/credhub_enabled.go
+++ b/docker/credhub_enabled.go
@@ -84,11 +84,10 @@ var _ = DockerDescribe("Docker App Lifecycle CredHub Integration", func() {
 		})
 
 		Describe("service bindings", func() {
-			var appName, appURL, dockerImage string
+			var appName, dockerImage string
 
 			JustBeforeEach(func() {
 				appName = random_name.CATSRandomName("APP-CH")
-				appURL = "https://" + appName + "." + Config.GetAppsDomain()
 				Eventually(cf.Cf(
 					"push", appName,
 					"--no-start",


### PR DESCRIPTION
Signed-off-by: Steve Hiehn <shiehn@pivotal.io>

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?
Yes

### What is this change about?
Unable to run tests on go1.11, due to automatic `go vet` issues

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in cf-acceptance-tests release notes?
Support golang 1.11

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
0 seconds.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@xtreme-stevehiehn 
