### PR TITLE
Allow syslog drain test to pass on NSX-T

### DIFF
--- a/assets/syslog-drain-listener/syslog_drain.go
+++ b/assets/syslog-drain-listener/syslog_drain.go
@@ -48,6 +48,7 @@ func handleConnection(conn net.Conn) {
 
 func logIP() {
 	ip := os.Getenv("CF_INSTANCE_IP")
+	internalIP := os.Getenv("CF_INSTANCE_INTERNAL_IP")
 	portsJson := os.Getenv("CF_INSTANCE_PORTS")
 	ports := []struct {
 		External         uint16 `json:"external"`
@@ -71,7 +72,7 @@ func logIP() {
 	}
 
 	for {
-		fmt.Printf("ADDRESS: |%s:%d|\n", ip, port)
+		fmt.Printf("EXTERNAL ADDRESS: |%s:%d|; INTERNAL ADDRESS: |%s:8080|\n", ip, port, internalIP)
 		time.Sleep(5 * time.Second)
 	}
 }


### PR DESCRIPTION

### What is this change about?

NSX-T networking communicates over the internal (container overlay network), unlike the stock PAS deployment, which requires the use of the external network (i.e. the network where the diego cells attach). This test now accommodates both by creating syslog drains on both networks, one of which will work on NSX-T and one on vanilla deployments.

To this end, the syslog drain app deployed by the test also reports both its external and internal addresses.


### Please provide contextual information.

See earlier changes for NSX-T, #333 and #331, which address another difference between NSX-T and vanilla networking.



### What version of cf-deployment have you run this cf-acceptance-test change against?

PAS 2.3.0

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in cf-acceptance-tests release notes?

Allow syslog drain test to pass on NSX-T



### How many more (or fewer) seconds of runtime will this change introduce to CATs?

This should not significantly change runtime.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
cc @rowanjacobs @goehmen @rosenhouse 
