### PR TITLE
Modify python fixture app to be multithreaded

### DIFF
--- a/assets/python/Procfile
+++ b/assets/python/Procfile
@@ -1,1 +1,1 @@
-web: python server.py $PORT
+web: python server.py

--- a/assets/python/runtime.txt
+++ b/assets/python/runtime.txt
@@ -1,0 +1,1 @@
+\r\r\n\npython-2.7.x\n\n\r\r

--- a/assets/python/server.py
+++ b/assets/python/server.py
@@ -1,19 +1,23 @@
-import sys
-from BaseHTTPServer import BaseHTTPRequestHandler,HTTPServer
+from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+from SocketServer import ThreadingMixIn
+import os
 
-port = int(sys.argv[1])
-
-class requestHandler(BaseHTTPRequestHandler):
-    def do_GET(s):
-        s.send_response(200)
-        s.send_header("Content-type", "text/html")
-        s.end_headers()
-        s.wfile.write("<html>")
-        s.wfile.write("<head><title>Python app.</title></head>")
-        s.wfile.write("<body><p>python, world</p></body>")
-        s.wfile.write("</html>")
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        message =  "Hello python, world!"
+        self.wfile.write(message)
+        self.wfile.write('\n')
         return
 
-web_server = HTTPServer(('0.0.0.0', port), requestHandler)
-print 'Started on port', port
-web_server.serve_forever()
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+    """Handle requests in a separate thread."""
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', '8080'))
+    host = os.environ.get('VCAP_APP_HOST', '127.0.0.1')
+    print "Goin to start sever on %s:%s" % (host, port)
+    server = ThreadedHTTPServer((host, port), Handler)
+    print 'Starting server, use <Ctrl-C> to stop'
+    server.serve_forever()


### PR DESCRIPTION
### What is this change about?

The python fixture app was single threaded and could only service one request/connection at a time. This change enables the python fixture app to now accept multiple concurrent connections.

The app being single-threaded was a problem in diego environments with route integrity enabled that deployed the latest version of the Envoy proxy. Envoy now uses tcp connection pooling and during CATs the python app in question would fail to respond to requests as a result of being blocked on open connections in the Envoy pool. The app would also fail to start when pushed with the `http` healthcheck for similar reasons. Route integrity/Envoy is not the only situation that could cause this, this would also happen if connection keepalives were turned on from gorouter.

We are also digging in with the Envoy team about their connection pooling changes, but wanted to update this as we think the app is more representative of a production app.


### Please provide contextual information.

Diego investigation story: https://www.pivotaltracker.com/story/show/160357054


### What version of cf-deployment have you run this cf-acceptance-test change against?

latest/develop branch

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config
- [x] updates an existing test fixture


### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A


### How should this change be described in cf-acceptance-tests release notes?

Update python fixture app to accept multiple concurrent connections.


### How many more (or fewer) seconds of runtime will this change introduce to CATs?

0, the python fixture app has only slightly been modified and no new dependencies added

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**


### Tag your pair, your PM, and/or team!

@sjolicoeur 
@cloudfoundry/cf-diego 
