### PR TITLE
Fix go1.11 vet issues

### DIFF
--- a/docker/credhub_enabled.go
+++ b/docker/credhub_enabled.go
@@ -39,7 +39,7 @@ var _ = DockerDescribe("Docker App Lifecycle CredHub Integration", func() {
 
 			existingEnvVar := string(cf.Cf("running-environment-variable-group").Wait(Config.DefaultTimeoutDuration()).Out.Contents())
 
-			if (!strings.Contains(existingEnvVar, "CREDHUB_API")){
+			if !strings.Contains(existingEnvVar, "CREDHUB_API") {
 				Expect(cf.Cf(
 					"set-env", chBrokerName,
 					"CREDHUB_API", Config.GetCredHubLocation(),
@@ -55,7 +55,6 @@ var _ = DockerDescribe("Docker App Lifecycle CredHub Integration", func() {
 				"set-env", chBrokerName,
 				"CREDHUB_SECRET", Config.GetCredHubBrokerClientSecret(),
 			).Wait(Config.DefaultTimeoutDuration())).To(Exit(0), "failed setting CREDHUB_SECRET env var on credhub-enabled service broker")
-
 
 			chServiceName = random_name.CATSRandomName("SERVICE-NAME")
 			setServiceName := cf.Cf("set-env", chBrokerName, "SERVICE_NAME", chServiceName).Wait(Config.DefaultTimeoutDuration())
@@ -90,11 +89,10 @@ var _ = DockerDescribe("Docker App Lifecycle CredHub Integration", func() {
 		})
 
 		Describe("service bindings", func() {
-			var appName, appURL, dockerImage string
+			var appName, dockerImage string
 
 			JustBeforeEach(func() {
 				appName = random_name.CATSRandomName("APP-CH")
-				appURL = "https://" + appName + "." + Config.GetAppsDomain()
 				Eventually(cf.Cf(
 					"push", appName,
 					"--no-start",

--- a/service_discovery/service_discovery.go
+++ b/service_discovery/service_discovery.go
@@ -21,13 +21,11 @@ var _ = ServiceDiscoveryDescribe("Service Discovery", func() {
 	var appNameBackend string
 	var domainName string
 	var orgName string
-	var spaceName string
 	var internalDomainName string
 	var internalHostName string
 
 	BeforeEach(func() {
 		orgName = TestSetup.RegularUserContext().Org
-		spaceName = TestSetup.RegularUserContext().Space
 		domainName = random_name.CATSRandomName("DOMAIN") + "." + Config.GetAppsDomain()
 		workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
 			Expect(cf.Cf("create-shared-domain", domainName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?
No, we need this PR for an older version of CF and thus an older version of the cf-acceptance-tests

### What is this change about?
Unable to run tests on go1.11, due to automatic `go vet` issues

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in cf-acceptance-tests release notes?
Support golang 1.11

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
0 seconds.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

