### PR TITLE
Add more verbose logging around SSH test

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -109,6 +109,9 @@ var _ = SshDescribe("SSH", func() {
 			stdout, err := envCmd.StdoutPipe()
 			Expect(err).NotTo(HaveOccurred())
 
+			stderr, err := envCmd.StderrPipe()
+			Expect(err).NotTo(HaveOccurred())
+
 			err = envCmd.Start()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -118,11 +121,15 @@ var _ = SshDescribe("SSH", func() {
 			err = stdin.Close()
 			Expect(err).NotTo(HaveOccurred())
 
+			exitErr := envCmd.Wait()
+
 			output, err := ioutil.ReadAll(stdout)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = envCmd.Wait()
+			errOutput, err := ioutil.ReadAll(stderr)
 			Expect(err).NotTo(HaveOccurred())
+
+			Expect(exitErr).NotTo(HaveOccurred(), "Failed to run SSH command: %s, %s", output, errOutput)
 
 			Expect(string(output)).To(MatchRegexp(fmt.Sprintf(`VCAP_APPLICATION=.*"application_name":"%s"`, appName)))
 			Expect(string(output)).To(MatchRegexp("INSTANCE_INDEX=0"))


### PR DESCRIPTION
Seeing the following failure periodically on GCP:

```
• Failure [17.473 seconds]
[ssh] SSH ssh [It] runs an interactive session when no command is provided
/tmp/build/33ac16d1/go/src/github.com/cloudfoundry/cf-acceptance-tests/ssh/ssh.go:93

  Expected error:
      <*exec.ExitError | 0xc4204c0120>: {
          ProcessState: {
              pid: 28056,
              status: 256,
              rusage: {
                  Utime: {Sec: 0, Usec: 190025},
                  Stime: {Sec: 0, Usec: 57833},
                  Maxrss: 25804,
                  Ixrss: 0,
                  Idrss: 0,
                  Isrss: 0,
                  Minflt: 3099,
                  Majflt: 0,
                  Nswap: 0,
                  Inblock: 0,
                  Oublock: 200,
                  Msgsnd: 0,
                  Msgrcv: 0,
                  Nsignals: 0,
                  Nvcsw: 2803,
                  Nivcsw: 28,
              },
          },
          Stderr: nil,
      }
      exit status 1
  not to have occurred

  /tmp/build/33ac16d1/go/src/github.com/cloudfoundry/cf-acceptance-tests/ssh/ssh.go:115
```

This PR tries to add more logging to help diagnose the underlying issue

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to master once they've passed acceptance._



### What is this change about?

_Describe the change and why it's needed._



### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._



### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [ ] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._



### How should this change be described in cf-acceptance-tests release notes?

_Something brief that conveys the change and is written with the component author audience in mind._



### How many more (or fewer) seconds of runtime will this change introduce to CATs?



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
