### PR TITLE
Attempt to reduce flakiness around broker healthchecks

### DIFF
--- a/helpers/services/broker.go
+++ b/helpers/services/broker.go
@@ -136,7 +136,7 @@ func (b ServiceBroker) Push(config cats_config.CatsConfig) {
 		"-p", b.Path,
 		"-d", config.GetAppsDomain(),
 	).Wait(Config.BrokerStartTimeoutDuration())).To(Exit(0))
-	Expect(cf.Cf("set-health-check", b.Name, "http", "--endpoint", "/v2/catalog").Wait(Config.BrokerStartTimeoutDuration())).To(Exit(0))
+	Expect(cf.Cf("v3-set-health-check", b.Name, "http", "--endpoint", "/v2/catalog", "--invocation-timeout", "10").Wait(Config.BrokerStartTimeoutDuration())).To(Exit(0))
 	Expect(cf.Cf("start", b.Name).Wait(Config.BrokerStartTimeoutDuration())).To(Exit(0))
 }
 
@@ -150,7 +150,7 @@ func (b ServiceBroker) PushWithBuildpackAndManifest(config cats_config.CatsConfi
 		"-f", b.Path+"/manifest.yml",
 		"-d", config.GetAppsDomain(),
 	).Wait(Config.BrokerStartTimeoutDuration())).To(Exit(0))
-	Expect(cf.Cf("set-health-check", b.Name, "http", "--endpoint", "/v2/catalog").Wait(Config.BrokerStartTimeoutDuration())).To(Exit(0))
+	Expect(cf.Cf("v3-set-health-check", b.Name, "http", "--endpoint", "/v2/catalog", "--invocation-timeout", "10").Wait(Config.BrokerStartTimeoutDuration())).To(Exit(0))
 	Expect(cf.Cf("start", b.Name).Wait(Config.BrokerStartTimeoutDuration())).To(Exit(0))
 }
 


### PR DESCRIPTION
We intermittently see CATs which push a service broker fail with:

```
   2018-09-19T01:26:29.43+0000 [APP/PROC/WEB/0] ERR 10.255.21.109 - - [19/Sep/2018:01:26:29 +0000] "GET /v2/catalog HTTP/1.1" 200 2306 1.5427
   2018-09-19T01:26:30.09+0000 [HEALTH/0] ERR Failed to make HTTP request to '/v2/catalog' on port 8080: timed out after 1.00 seconds
   2018-09-19T01:26:30.09+0000 [CELL/0] OUT Container became unhealthy
   2018-09-19T01:26:30.09+0000 [APP/PROC/WEB/0] ERR [2018-09-19 01:26:30] FATAL SignalException: SIGTERM
```

This PR bumps the healthcheck timeout from 1 second to 10 seconds. We
had to switch to `cf v3-set-health-check` as it didn't look like the v2
command supported a timeout

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._



### How should this change be described in cf-acceptance-tests release notes?

_Something brief that conveys the change and is written with the component author audience in mind._



### How many more (or fewer) seconds of runtime will this change introduce to CATs?



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
