### PR TITLE
Update admin_buildpack_lifecycle.go

### DIFF
--- a/apps/admin_buildpack_lifecycle.go
+++ b/apps/admin_buildpack_lifecycle.go
@@ -273,7 +273,7 @@ exit 1
 		start := cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())
 		Expect(start).To(Exit(0))
 		appOutput := cf.Cf("app", appName).Wait(Config.DefaultTimeoutDuration())
-		Expect(appOutput).To(Say("buildpack:\\s+Simple"))
+		Expect(appOutput).To(Say("buildpacks?:\\s+Simple"))
 	}
 
 	itDoesNotDetectForEmptyApp := func() {
@@ -365,7 +365,7 @@ exit 1
 			Expect(start).To(Exit(0))
 
 			appOutput := cf.Cf("app", appName).Wait(Config.DefaultTimeoutDuration())
-			Expect(appOutput).To(Say("buildpack:\\s+" + buildpackName))
+			Expect(appOutput).To(Say("buildpacks?:\\s+" + buildpackName))
 		})
 
 		It("fails if the specified buildpack is disabled", func() {


### PR DESCRIPTION
cf-cli v6.38.0 now outputs buildpacks: with an s, on the 'app' command
Updating the regex matcher to accommodate this change

https://github.com/cloudfoundry/cli/releases/tag/v6.38.0

### What version of cf-deployment have you run this cf-acceptance-test change against?

cf-cli: v6.38.0
cf-acceptance-tests@ea989ef2b4c4ede09eb8dd037686008017ad843a

### Please check all that apply for this PR:
- [ ] introduces a new test --- are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### How should this change be described in cf-acceptance-tests release notes?

Add support cf-cli v6.38.0

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**