### PR TITLE
Add internetless test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ cat > integration_config.json <<EOF
   "include_detect": true,
   "include_docker": false,
   "include_internet_dependent": false,
+  "include_internetless": false,
   "include_isolation_segments": false,
   "include_private_docker_registry": false,
   "include_route_services": false,
@@ -171,6 +172,7 @@ include_capi_no_bridge
 * `include_detect`: Flag to include tests in the detect group.
 * `include_docker`: Flag to include tests related to running Docker apps on Diego. Diego must be deployed and the CC API docker_diego feature flag must be enabled for these tests to pass.
 * `include_internet_dependent`: Flag to include tests that require the deployment to have internet access.
+* `include_internetless`: Flag to include tests that require the deployment to not have internet access.
 * `include_isolation_segments`: Flag to include isolation segment tests.
 * `include_private_docker_registry`: Flag to run tests that rely on a private docker image. [See below](#private-docker).
 * `include_route_services`: Flag to include the route services tests. Diego must be deployed for these tests to pass.
@@ -368,6 +370,7 @@ Test Group Name| Description
 `detect` | Tests the ability of the platform to detect the correct buildpack for compiling an application if no buildpack is explicitly specified.
 `docker`| Tests our ability to run docker containers on Diego and that we handle docker metadata correctly.
 `internet_dependent`| Tests the feature of being able to specify a buildpack via a Github URL.  As such, this depends on your Cloud Foundry application containers having access to the Internet.  You should take into account the configuration of the network into which you've deployed your Cloud Foundry, as well as any security group settings applied to application containers.
+`internetless`| Tests that your Cloud Foundry application containers do not have access to the Internet.  You should take into account the configuration of the network into which you've deployed your Cloud Foundry, as well as any security group settings applied to application containers.
 `isolation_segments` | This test group requires that Diego be deployed with a minimum of 2 cells. One of those cells must have been deployed with a `placement_tag`. If the deployment has been deployed with a routing isolation segment, `isolation_segment_domain` must also be set. For more information, please refer to the [Isolation Segments documentation](https://docs.cloudfoundry.org/adminguide/isolation-segments.html).
 `route_services` | Tests the [Route Services](https://docs.cloudfoundry.org/services/route-services.html) feature of Cloud Foundry.
 `routing`| This package contains routing specific acceptance tests (context paths, wildcards, SSL termination, sticky sessions, and zipkin tracing).

--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	CF_JAVA_TIMEOUT      = 10 * time.Minute
-	V3_PROCESS_TIMEOUT = 45 * time.Second
+	V3_PROCESS_TIMEOUT   = 45 * time.Second
 	DEFAULT_MEMORY_LIMIT = "256M"
 )
 
@@ -87,6 +87,17 @@ func InternetDependentDescribe(description string, callback func()) bool {
 		BeforeEach(func() {
 			if !Config.GetIncludeInternetDependent() {
 				Skip(skip_messages.SkipInternetDependentMessage)
+			}
+		})
+		Describe(description, callback)
+	})
+}
+
+func InternetlessDescribe(description string, callback func()) bool {
+	return Describe("[internetless]", func() {
+		BeforeEach(func() {
+			if !Config.GetIncludeInternetless() {
+				Skip(skip_messages.SkipInternetlessMessage)
 			}
 		})
 		Describe(description, callback)

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -15,6 +15,7 @@ type CatsConfig interface {
 	GetIncludeDetect() bool
 	GetIncludeDocker() bool
 	GetIncludeInternetDependent() bool
+	GetIncludeInternetless() bool
 	GetIncludePrivateDockerRegistry() bool
 	GetIncludeRouteServices() bool
 	GetIncludeRouting() bool

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -70,6 +70,7 @@ type config struct {
 	IncludeDetect                   *bool `json:"include_detect"`
 	IncludeDocker                   *bool `json:"include_docker"`
 	IncludeInternetDependent        *bool `json:"include_internet_dependent"`
+	IncludeInternetless             *bool `json:"include_internetless"`
 	IncludePrivateDockerRegistry    *bool `json:"include_private_docker_registry"`
 	IncludeRouteServices            *bool `json:"include_route_services"`
 	IncludeRouting                  *bool `json:"include_routing"`
@@ -164,6 +165,7 @@ func getDefaults() config {
 	defaults.CredhubClientSecret = ptrToString("")
 	defaults.IncludeDocker = ptrToBool(false)
 	defaults.IncludeInternetDependent = ptrToBool(false)
+	defaults.IncludeInternetless = ptrToBool(false)
 	defaults.IncludeIsolationSegments = ptrToBool(false)
 	defaults.IncludePrivateDockerRegistry = ptrToBool(false)
 	defaults.IncludeRouteServices = ptrToBool(false)
@@ -184,7 +186,6 @@ func getDefaults() config {
 	defaults.UseWindowsContextPath = ptrToBool(false)
 	defaults.WindowsStack = ptrToString("windows2012R2")
 	defaults.UseWindowsTestTask = ptrToBool(false)
-
 
 	defaults.ReporterConfig = &reporterConfig{}
 
@@ -386,6 +387,9 @@ func validateConfig(config *config) Errors {
 	}
 	if config.IncludeInternetDependent == nil {
 		errs.Add(fmt.Errorf("* 'include_internet_dependent' must not be null"))
+	}
+	if config.IncludeInternetless == nil {
+		errs.Add(fmt.Errorf("* 'include_internetless' must not be null"))
 	}
 	if config.IncludePrivateDockerRegistry == nil {
 		errs.Add(fmt.Errorf("* 'include_private_docker_registry' must not be null"))
@@ -804,6 +808,10 @@ func (c *config) GetIncludeDocker() bool {
 
 func (c *config) GetIncludeInternetDependent() bool {
 	return *c.IncludeInternetDependent
+}
+
+func (c *config) GetIncludeInternetless() bool {
+	return *c.IncludeInternetless
 }
 
 func (c *config) GetIncludeRouteServices() bool {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -126,6 +126,7 @@ type allConfig struct {
 	IncludeDetect                 *bool `json:"include_detect"`
 	IncludeDocker                 *bool `json:"include_docker"`
 	IncludeInternetDependent      *bool `json:"include_internet_dependent"`
+	IncludeInternetless           *bool `json:"include_internetless"`
 	IncludePrivateDockerRegistry  *bool `json:"include_private_docker_registry"`
 	IncludeRouteServices          *bool `json:"include_route_services"`
 	IncludeRouting                *bool `json:"include_routing"`
@@ -245,6 +246,7 @@ var _ = Describe("Config", func() {
 		Expect(config.GetIncludeCapiNoBridge()).To(BeTrue())
 		Expect(config.GetIncludeDocker()).To(BeFalse())
 		Expect(config.GetIncludeInternetDependent()).To(BeFalse())
+		Expect(config.GetIncludeInternetless()).To(BeFalse())
 		Expect(config.GetIncludeRouteServices()).To(BeFalse())
 		Expect(config.GetIncludeContainerNetworking()).To(BeFalse())
 		Expect(config.GetIncludeSecurityGroups()).To(BeFalse())

--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -8,6 +8,8 @@ const SkipDockerMessage = `Skipping this test because config.IncludeDocker is se
 NOTE: Ensure Docker containers are enabled on your platform before enabling this test.`
 const SkipInternetDependentMessage = `Skipping this test because config.IncludeInternetDependent is set to 'false'.
 NOTE: Ensure that your platform has access to the internet before running this test.`
+const SkipInternetlessMessage = `Skipping this test because config.IncludeInternetless is set to 'false'.
+NOTE: Ensure that your platform does not have access to the internet before running this test.`
 const SkipPrivateDockerRegistryMessage = `Skipping this test because config.IncludePrivateDockerRegistry is set to 'false'.
 NOTE: Ensure that you've provided values for config.PrivateDockerRegistryImage, config.PrivateDockerRegistryUsername,
 and config.PrivateDockerRegistryPassword before running this test.`

--- a/internetless/app_dns_resolution.go
+++ b/internetless/app_dns_resolution.go
@@ -1,0 +1,68 @@
+package internetless_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
+)
+
+type CatnipCurlResponse struct {
+	Stdout     string
+	Stderr     string
+	ReturnCode int `json:"return_code"`
+}
+
+func pushApp(appName, buildpack string) {
+	Expect(cf.Cf("push",
+		appName,
+		"-b", buildpack,
+		"-m", DEFAULT_MEMORY_LIMIT,
+		"-p", assets.NewAssets().Catnip,
+		"-c", "./catnip",
+		"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+}
+
+func testAppConnectivity(clientAppName string, privateHost string, privatePort int) CatnipCurlResponse {
+	var catnipCurlResponse CatnipCurlResponse
+	curlResponse := helpers.CurlApp(Config, clientAppName, fmt.Sprintf("/curl/%s/%d", privateHost, privatePort))
+	json.Unmarshal([]byte(curlResponse), &catnipCurlResponse)
+	return catnipCurlResponse
+}
+
+var _ = InternetlessDescribe("App container DNS behavior", func() {
+	var clientAppName string
+	var catnipCurlResponse CatnipCurlResponse
+
+	BeforeEach(func() {
+		if !Config.GetIncludeInternetless() {
+			Skip(skip_messages.SkipInternetlessMessage)
+		}
+	})
+
+	AfterEach(func() {
+		app_helpers.AppReport(clientAppName)
+		Expect(cf.Cf("delete", clientAppName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+	})
+
+	It("denies external traffic from app containers", func() {
+		clientAppName = random_name.CATSRandomName("APP")
+		pushApp(clientAppName, Config.GetBinaryBuildpackName())
+
+		By("Connecting from running container to an external destination")
+		catnipCurlResponse = testAppConnectivity(clientAppName, "www.google.com", 80)
+		Expect(catnipCurlResponse.ReturnCode).ToNot(Equal(0), "Expected external traffic to be denied from app containers to external addresses.")
+	})
+})

--- a/internetless/app_external_traffic_denied.go
+++ b/internetless/app_external_traffic_denied.go
@@ -41,7 +41,7 @@ func testAppConnectivity(clientAppName string, privateHost string, privatePort i
 	return catnipCurlResponse
 }
 
-var _ = InternetlessDescribe("App container DNS behavior", func() {
+var _ = InternetlessDescribe("App external traffic denied", func() {
 	var clientAppName string
 	var catnipCurlResponse CatnipCurlResponse
 
@@ -63,6 +63,6 @@ var _ = InternetlessDescribe("App container DNS behavior", func() {
 
 		By("Connecting from running container to an external destination")
 		catnipCurlResponse = testAppConnectivity(clientAppName, "www.google.com", 80)
-		Expect(catnipCurlResponse.ReturnCode).ToNot(Equal(0), "Expected external traffic to be denied from app containers to external addresses.")
+		Expect(catnipCurlResponse.ReturnCode).ToNot(Equal(0), "Expected traffic to be denied from app containers to external addresses.")
 	})
 })


### PR DESCRIPTION
### What is this change about?

Adding a test suite that verifies a deployment does not allow external traffic from app containers.



### Please provide contextual information.

Slack: https://pivotal.slack.com/archives/C3LUD2L04/p1538515665000100
Story: https://www.pivotaltracker.com/story/show/160211045


### What version of cf-deployment have you run this cf-acceptance-test change against?

Not cf-deployment...

### Please check all that apply for this PR:
- [x] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

Technically, there is a new config option for the new test, so if the user wants to run that test, they would need to update their CATs integration-config but otherwise, it defaults to false.


### Did you update the README as appropriate for this change?
- [x] YES
- [ ] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

See slack conversation.


### How should this change be described in cf-acceptance-tests release notes?

Adds a test that verifies a deployment does not allow external traffic from app containers.


### How many more (or fewer) seconds of runtime will this change introduce to CATs?

0s if not enabled.


### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**


### Tag your pair, your PM, and/or team!
@acrmp @mcwumbly 
