### PR TITLE
Fix failing ASG/C2C CAT on newer rootfs

### DIFF
--- a/assets/catnip/linux/linux.go
+++ b/assets/catnip/linux/linux.go
@@ -19,7 +19,9 @@ func ReleaseHandler(res http.ResponseWriter, req *http.Request) {
 }
 
 func MyIPHandler(res http.ResponseWriter, req *http.Request) {
-	cmd := exec.Command("bash", "-c", "ip route get 1 | awk '{print $NF;exit}'")
+	// example output from `ip`: `1.0.0.0 via 169.254.0.1 dev eth0 src 10.255.97.224 uid 2000`,
+	// in older rootfs the `uid 2000` is omitted
+	cmd := exec.Command("bash", "-c", `ip route get 1 | sed -n -e 's/^.*src \([^ ]\+\).*$/\1/p'`)
 	outBytes, _ := cmd.Output()
 
 	res.Write(outBytes)


### PR DESCRIPTION


### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yep

### What is this change about?

Failing `[security_groups] App Instance Networking Using container-networking and running security-groups [It] correctly configures asgs and c2c policy independent of each other`

With a newer rootfs, the `ip` command now includes a `uid 2000` at the
end which breaks the `/myip` endpoint on the test app. This updated
command should be compatible with both the old and new `ip` output.

### Please provide contextual information.

Might only happen on `cflinuxfs3` apps but not positive

### What version of cf-deployment have you run this cf-acceptance-test change against?

Not using cf-deployment

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How should this change be described in cf-acceptance-tests release notes?

Fixes failing ASG/C2C test with newer rootfs

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!


