### PR TITLE
Add windows stack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ include_capi_no_bridge
 * `include_windows`: Flag to include the tests that run against Windows cells.
 * `use_windows_test_task`: Flag to include the tasks tests on Windows cells. Default is `false`.
 * `use_windows_context_path`: Flag to include the Windows context path routing tests. Default is `false`.
-* `windows_stack`: Windows stack to run tests against. Must be either `windows2012R2` or `windows2016`. Defaults to `windows2012R2`.
+* `windows_stack`: Windows stack to run tests against. Must be either `windows2012R2`, `windows2016`, or `windows`. Defaults to `windows2012R2`.
 
 * `include_service_discovery`: Flag to include test for the service discovery. These tests use `apps.internal` domain, which is the default in `cf-networking-release`. The internal domain is currently not configurable.
 

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -627,7 +627,7 @@ func validateWindows(config *config) error {
 	}
 
 	switch config.GetWindowsStack() {
-	case "windows2012R2", "windows2016":
+	case "windows2012R2", "windows2016", "windows":
 	default:
 		return fmt.Errorf("* Invalid configuration: unknown Windows stack %s", config.GetWindowsStack())
 	}

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -514,7 +514,7 @@ var _ = Describe("Config", func() {
 			testCfg.IncludeWindows = ptrToBool(true)
 		})
 
-		Context("when the windows stack is not windows2016 or windows2012R2", func() {
+		Context("when the windows stack is not windows2016, windows2012R2, or windows", func() {
 			BeforeEach(func() {
 				testCfg.WindowsStack = ptrToString("windows98")
 			})

--- a/windows/running_security_groups_win.go
+++ b/windows/running_security_groups_win.go
@@ -162,7 +162,7 @@ var _ = WindowsDescribe("WINDOWS: App Instance Networking", func() {
 			serverAppName, privateHost, privatePort = pushServerApp()
 			clientAppName = pushClientApp()
 
-			if Config.GetWindowsStack() == "windows2016" {
+			if Config.GetWindowsStack() == "windows2016" || Config.GetWindowsStack() == "windows" {
 				assertNetworkingPreconditions(clientAppName, privateHost, privatePort)
 			}
 		})


### PR DESCRIPTION
[#161817037]

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Add support for `-s windows` in CATS

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/161817037

### What version of cf-deployment have you run this cf-acceptance-test change against?

release-candidate

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [X] requires an update to a CATs integration-config


### Did you update the README as appropriate for this change?
- [X] YES
- [ ] N/A


### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

No new test

### How should this change be described in cf-acceptance-tests release notes?

Add windows stack `-s windows` for CATs

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**
