### PR TITLE
Use the same docker image for both v3/app_lifecycle.go and docker/doc…

### DIFF
--- a/v3/app_lifecycle.go
+++ b/v3/app_lifecycle.go
@@ -192,7 +192,7 @@ var _ = V3Describe("v3 docker app lifecycle", func() {
 		spaceGuid = GetSpaceGuidFromName(TestSetup.RegularUserContext().Space)
 		appCreationEnvironmentVariables = `"foo":"bar"`
 		appGuid = CreateDockerApp(appName, spaceGuid, `{"foo":"bar"}`)
-		packageGuid = CreateDockerPackage(appGuid, "cloudfoundry/diego-docker-app:latest")
+		packageGuid = CreateDockerPackage(appGuid, Config.GetPublicDockerAppImage())
 		token = GetAuthToken()
 
 		appUrl := "https://" + appName + "." + Config.GetAppsDomain()


### PR DESCRIPTION
### What is this change about?

make docker image in `v3/app_lifecycle.go` customisable



### Please provide contextual information.

We are running CATs behind the firewall using private docker registry. `docker/docker_lifecycle.go` honours  `public_docker_app_image` for example  `"public_docker_app_image": "my-registry.mycompany.com/cloudfoundry/diego-docker-app-custom:latest"`. But `v3/app_lifecycle.go` is hardcoding `cloudfoundry/diego-docker-app:latest`


### What version of cf-deployment have you run this cf-acceptance-test change against?
we start enable docker in cf-5.1 but this applies to all the newer version and a lot of olders


### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._



### How should this change be described in cf-acceptance-tests release notes?

_Something brief that conveys the change and is written with the component author audience in mind._



### How many more (or fewer) seconds of runtime will this change introduce to CATs?



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
