### PR TITLE
Allow 10 redirects in download.WithRedirect, this time also working with HTTP/2

### DIFF
--- a/helpers/download/download.go
+++ b/helpers/download/download.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
+	"strconv"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/config"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers"
 )
+
+const maxNumRedirects = 10 // This is the same default Go uses with in its http library: https://godoc.org/net/http#Get
 
 func WithRedirect(url, path string, config config.CatsConfig) error {
 	oauthToken := v3_helpers.GetAuthToken()
@@ -22,26 +25,52 @@ func WithRedirect(url, path string, config config.CatsConfig) error {
 		return fmt.Errorf("curl exited with code: %d", downloadCurl.ExitCode())
 	}
 
-	locationHeaderRegex, err := regexp.Compile("(?i)Location: (.*)\r\n")
+	isRedirect, redirectURI, err := CheckRedirect(string(downloadCurl.Err.Contents()))
 	if err != nil {
 		return err
 	}
-
-	matches := locationHeaderRegex.FindStringSubmatch(string(downloadCurl.Err.Contents()))
-	if len(matches) < 2 {
+	if !isRedirect {
 		ioutil.WriteFile(path, downloadCurl.Out.Contents(), 0644)
 		return nil
 	}
+	for i := 0; i < maxNumRedirects; i++ {
+		downloadCurl := helpers.Curl(
+			config,
+			"-v", redirectURI,
+			"-f",
+		).Wait()
+		if downloadCurl.ExitCode() != 0 {
+			return fmt.Errorf("curl exited with code: %d", downloadCurl.ExitCode())
+		}
 
-	redirectURI := matches[1]
-	downloadCurl = helpers.Curl(
-		config,
-		"-v", redirectURI,
-		"--output", path,
-		"-f",
-	).Wait()
-	if downloadCurl.ExitCode() != 0 {
-		return fmt.Errorf("curl exited with code: %d", downloadCurl.ExitCode())
+		isRedirect, redirectURI, err = CheckRedirect(string(downloadCurl.Err.Contents()))
+		if err != nil {
+			return err
+		}
+		if !isRedirect {
+			ioutil.WriteFile(path, downloadCurl.Out.Contents(), 0644)
+			return nil
+		}
 	}
-	return nil
+	return fmt.Errorf("Only %v redirects allowed", maxNumRedirects)
+}
+
+func CheckRedirect(curlOutput string) (bool, string, error) {
+	statusCodePattern := `HTTP/\d(?:\.\d)? (\d{3}) [A-Za-z \-]+`
+	statusCodeMatches := regexp.MustCompile(statusCodePattern).FindStringSubmatch(curlOutput)
+	if len(statusCodeMatches) != 2 {
+		return false, "", fmt.Errorf("Unexpected output from curl. Was expecting %v in the output", statusCodePattern)
+	}
+	statusCode, e := strconv.Atoi(statusCodeMatches[1])
+	if e != nil {
+		return false, "", fmt.Errorf("Unexpected status code from curl: %v", e.Error())
+	}
+	if statusCode > 300 && statusCode < 400 {
+		matches := regexp.MustCompile("(?i)Location: (.*)\r\n").FindStringSubmatch(curlOutput)
+		if len(matches) != 2 {
+			return false, "", fmt.Errorf("Got redirect status code %v, but found no Location in curl output  %v", statusCode, len(matches))
+		}
+		return true, matches[1], nil
+	}
+	return false, "", nil
 }

--- a/helpers/download/download_suite_test.go
+++ b/helpers/download/download_suite_test.go
@@ -1,0 +1,13 @@
+package download_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestDownload(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Download Suite")
+}

--- a/helpers/download/download_test.go
+++ b/helpers/download/download_test.go
@@ -1,0 +1,77 @@
+package download_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/download"
+)
+
+var _ = Describe("CheckRedirect", func() {
+	Context("Response is a redirect", func() {
+		const moreHeaderInfoIncludingLocation = "< Content-Type: text/html; charset=utf-8\r\n" +
+			"< Date: Fri, 25 Jan 2019 14:51:35 GMT\r\n" +
+			"< Location: https://example.com\r\n" +
+			"< Referrer-Policy: strict-origin-when-cross-origin\r\n" +
+			"< Server: nginx"
+
+		Context("HTTP version 1.1", func() {
+			It("returns true and the redirect location ", func() {
+				isRedirect, location, err := download.CheckRedirect("< HTTP/1.1 302 Found\r\n" + moreHeaderInfoIncludingLocation)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isRedirect).To(BeTrue())
+				Expect(location).To(Equal("https://example.com"))
+			})
+
+		})
+
+		Context("HTTP version 2", func() {
+			It("returns true and the redirect location ", func() {
+				isRedirect, location, err := download.CheckRedirect("< HTTP/2 302 Found\r\n" + moreHeaderInfoIncludingLocation)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isRedirect).To(BeTrue())
+				Expect(location).To(Equal("https://example.com"))
+			})
+		})
+
+		Context("Location is missing", func() {
+			It("returns an error", func() {
+				_, _, err := download.CheckRedirect("< HTTP/1.1 302 Found\r\n" +
+					"< Content-Type: text/html; charset=utf-8\r\n" +
+					"< Date: Fri, 25 Jan 2019 14:51:35 GMT\r\n" +
+					"< Referrer-Policy: strict-origin-when-cross-origin\r\n" +
+					"< Server: nginx")
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("Response is not a redirect", func() {
+		const moreHeaderInfo = "< Content-Type: text/html; charset=utf-8\r\n" +
+			"< Date: Fri, 25 Jan 2019 14:51:35 GMT\r\n" +
+			"< Server: nginx"
+
+		Context("HTTP version 1.1", func() {
+			It("returns false and empty redirect location ", func() {
+				isRedirect, location, err := download.CheckRedirect("< HTTP/1.1 200 OK\r\n" + moreHeaderInfo)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isRedirect).To(BeFalse())
+				Expect(location).To(BeEmpty())
+			})
+		})
+
+		Context("HTTP version 2", func() {
+			It("returns false and empty redirect location ", func() {
+				isRedirect, location, err := download.CheckRedirect("< HTTP/2 200 OK\r\n" + moreHeaderInfo)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isRedirect).To(BeFalse())
+				Expect(location).To(BeEmpty())
+			})
+		})
+	})
+})


### PR DESCRIPTION
This is exactly the same as https://github.com/cloudfoundry/cf-acceptance-tests/pull/354, but correctly handling HTTP/2 (including additional tests), for which the previous one was reverted in https://github.com/cloudfoundry/cf-acceptance-tests/commit/1200e986bed44040c253eb2fb6c7b4bb10133cd4.

For your convenience, the text from the original PR:

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

yes


### What is this change about?

'can copy package bits to another app and download the package' in `v3/package.go` fails with a confusing unzip error, when api redirects multiple times, because it tries to unzip the body of a redirect. This change stops on the second redirect with an error message emulating what the cf CLI would do.

### Please provide contextual information.

I've started a [conversation on the cf CLI Slack](https://cloudfoundry.slack.com/archives/C032824SM/p1548426413059900) and it seems like it is not on purpose that the CLI doesn't follow more than 1 redirect. Once it's changed in the cf CLI, it would be preferable in the code that I've refactored here, to actually just follow all redirects just as the CLI does to be in parity. Then the improved error reporting introduced here might not be needed anymore, unless of course you decided to still stop redirecting after 10 redirects or so. Would still be nicer to get an error about redirecting instead of a failed unzip.

### What version of cf-deployment have you run this cf-acceptance-test change against?

master

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A


### How should this change be described in cf-acceptance-tests release notes?

> Improve error message when API redirects multiple times.


### How many more (or fewer) seconds of runtime will this change introduce to CATs?
About the same.


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@idev4u