### PR TITLE
Make cats run with Go 1.12

### DIFF
--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -85,6 +85,9 @@ func TestCATS(t *testing.T) {
 		buildCmd.Env = []string{
 			fmt.Sprintf("GOPATH=%s", os.Getenv("GOPATH")),
 			fmt.Sprintf("GOROOT=%s", os.Getenv("GOROOT")),
+			fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
+			fmt.Sprintf("XDG_CACHE_HOME=%s", os.Getenv("XDG_CACHE_HOME")),
+			fmt.Sprintf("GOCACHE=%s", os.Getenv("GOCACHE")),
 			"GOOS=linux",
 			"GOARCH=amd64",
 		}


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)? Yes


### What is this change about?

Make CATS run with Go 1.12
GOCACHE is now required but it can be calculated using 
HOME or XDG_CACHE_HOME, so we are passing it from environment

### Please provide contextual information.

https://golang.org/doc/go1.12#gocache

### What version of cf-deployment have you run this cf-acceptance-test change against?

SUSE CF 2.14.5

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

No new tests introduced.

### How should this change be described in cf-acceptance-tests release notes?

Doesn't need to be described in release notes.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

0s

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@alex-slynko 
