### PR TITLE
Better to add to the existing environment than specify it completely.

### DIFF
--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -82,12 +82,10 @@ func TestCATS(t *testing.T) {
 
 		buildCmd := exec.Command("go", "build", "-o", "bin/catnip")
 		buildCmd.Dir = "assets/catnip"
-		buildCmd.Env = []string{
-			fmt.Sprintf("GOPATH=%s", os.Getenv("GOPATH")),
-			fmt.Sprintf("GOROOT=%s", os.Getenv("GOROOT")),
+		buildCmd.Env = append(os.Environ(),
 			"GOOS=linux",
 			"GOARCH=amd64",
-		}
+		)
 		buildCmd.Stdout = GinkgoWriter
 		buildCmd.Stderr = GinkgoWriter
 


### PR DESCRIPTION
* The original code breaks with go 1.12 which requires HOME to be set.
  This method is more future-proof, if later versions of Go require
  other env vars.

Signed-off-by: Seth Boyles <sboyles@pivotal.io>

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Done

### What is this change about?


Go 1.12 now requires the gocache. With the old code, the call to `go build -o bin/catnip`
failed with the error message `build cache is required, but could not be located: GOCACHE is not defined and $HOME is not defined`

### Please provide contextual information.

The cause of the error is straightforward and somewhat generic: it's better to append to
the existing environment than to try to respecify a complete environment for the subprocess.

### What version of cf-deployment have you run this cf-acceptance-test change against?

7.5.0

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

none of the above

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

n/a


### How should this change be described in cf-acceptance-tests release notes?

not needed


### How many more (or fewer) seconds of runtime will this change introduce to CATs?

should be negligible

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

urgent for any teams moving to go 1.12

### Tag your pair, your PM, and/or team!

@ericpromislow @sethboyles @cloudfoundry/cf-capi  PM @ssisil 