### PR TITLE
Add syslog v3 drain tests

### DIFF
--- a/apps/syslog_drain.go
+++ b/apps/syslog_drain.go
@@ -13,6 +13,7 @@ import (
 	logshelper "github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
@@ -88,7 +89,7 @@ var _ = AppsDescribe("Logging", func() {
 			Eventually(cf.Cf("delete-orphaned-routes", "-f"), Config.CfPushTimeoutDuration()).Should(Exit(0), "Failed to delete orphaned routes")
 		})
 
-		It("forwards app messages to registered syslog drains", func() {
+		DescribeTable("Forwards app messages to registered syslog drains", func(protoSuffix string) {
 			// The syslog drains return two IP addresses: external & internal.
 			// On a vanilla environment, apps can connect through the syslog service
 			// to the external IP (Diego cell address and external port) of the drain
@@ -98,9 +99,9 @@ var _ = AppsDescribe("Logging", func() {
 			for i, address := range getSyslogDrainAddresses(listenerAppName) {
 				var syslogDrainURL string
 				if Config.GetRequireProxiedAppTraffic() {
-					syslogDrainURL = "syslog-tls://" + address
+					syslogDrainURL = "syslog-tls" + protoSuffix + "://" + address
 				} else {
-					syslogDrainURL = "syslog://" + address
+					syslogDrainURL = "syslog" + protoSuffix + "://" + address
 				}
 
 				Eventually(cf.Cf("cups", serviceNames[i], "-l", syslogDrainURL)).Should(Exit(0), "Failed to create syslog drain service")
@@ -119,7 +120,10 @@ var _ = AppsDescribe("Logging", func() {
 
 			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(randomMessage1))
 			Consistently(logs, 10).ShouldNot(Say(randomMessage2))
-		})
+		},
+			Entry("V2 Drain", ""),
+			Entry("V3 Drain", "-v3"),
+		)
 	})
 })
 


### PR DESCRIPTION
[#164224800]

Signed-off-by: Tom Chen <tochen@pivotal.io>

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?
We added tests for the V3 of syslog drain



### Please provide contextual information.
https://www.pivotaltracker.com/story/show/164224800


### What version of cf-deployment have you run this cf-acceptance-test change against?
v7.6.0


### Please check all that apply for this PR:
- [X] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

This functionality is only complete in the context of a cf deployment. Also, there was already a test in CATS for the V2 syslog drain.


### How should this change be described in cf-acceptance-tests release notes?
Test added to verify syslog drains V3



### How many more (or fewer) seconds of runtime will this change introduce to CATs?
The test should add at most 30s

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@jtuchscherer, @chentom88  
