### PR TITLE
Check env variables in tasks when they are enabled

### DIFF
--- a/apps/default_environment_variables.go
+++ b/apps/default_environment_variables.go
@@ -153,34 +153,36 @@ exit 1
 				)
 			}
 
-			taskName := "get-env"
+			if Config.GetIncludeTasks() {
+				taskName := "get-env"
 
-			Eventually(cf.Cf("run-task", appName, "env", "--name", taskName)).Should(Exit(0))
+				Eventually(cf.Cf("run-task", appName, "env", "--name", taskName)).Should(Exit(0))
 
-			Eventually(func() string {
-				return getTaskState(appName)
-			}).Should(Equal("SUCCEEDED"))
+				Eventually(func() string {
+					return getTaskState(appName)
+				}).Should(Equal("SUCCEEDED"))
 
-			var taskStdout string
-			Eventually(func() string {
-				appLogsSession := logs.Tail(Config.GetUseLogCache(), appName)
-				appLogsSession.Wait()
+				var taskStdout string
+				Eventually(func() string {
+					appLogsSession := logs.Tail(Config.GetUseLogCache(), appName)
+					appLogsSession.Wait()
 
-				taskStdout = string(appLogsSession.Out.Contents())
+					taskStdout = string(appLogsSession.Out.Contents())
 
-				return taskStdout
-			}).Should(MatchRegexp("TASK.*VCAP_SERVICES=.*"))
+					return taskStdout
+				}).Should(MatchRegexp("TASK.*VCAP_SERVICES=.*"))
 
-			Expect(taskStdout).To(MatchRegexp("TASK.*LANG=en_US\\.UTF-8"))
-			Expect(taskStdout).To(MatchRegexp("TASK.*CF_INSTANCE_INTERNAL_IP=.*"))
-			Expect(taskStdout).To(MatchRegexp("TASK.*CF_INSTANCE_IP=.*"))
-			Expect(taskStdout).To(MatchRegexp("TASK.*CF_INSTANCE_PORTS=.*"))
-			Expect(taskStdout).To(MatchRegexp("TASK.*VCAP_APPLICATION=.*"))
-			Expect(taskStdout).To(MatchRegexp("TASK.*VCAP_SERVICES=.*"))
+				Expect(taskStdout).To(MatchRegexp("TASK.*LANG=en_US\\.UTF-8"))
+				Expect(taskStdout).To(MatchRegexp("TASK.*CF_INSTANCE_INTERNAL_IP=.*"))
+				Expect(taskStdout).To(MatchRegexp("TASK.*CF_INSTANCE_IP=.*"))
+				Expect(taskStdout).To(MatchRegexp("TASK.*CF_INSTANCE_PORTS=.*"))
+				Expect(taskStdout).To(MatchRegexp("TASK.*VCAP_APPLICATION=.*"))
+				Expect(taskStdout).To(MatchRegexp("TASK.*VCAP_SERVICES=.*"))
 
-			// these vars are set to the empty string (use m flag to make $ match eol)
-			Expect(taskStdout).To(MatchRegexp("(?m)TASK.*CF_INSTANCE_ADDR=$"))
-			Expect(taskStdout).To(MatchRegexp("(?m)TASK.*CF_INSTANCE_PORT=$"))
+				// these vars are set to the empty string (use m flag to make $ match eol)
+				Expect(taskStdout).To(MatchRegexp("(?m)TASK.*CF_INSTANCE_ADDR=$"))
+				Expect(taskStdout).To(MatchRegexp("(?m)TASK.*CF_INSTANCE_PORT=$"))
+			}
 		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: Akshay Mankar <amankar@pivotal.io>

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

When tasks are disabled in the config, the environment variable test still runs the task 

### What version of cf-deployment have you run this cf-acceptance-test change against?

SCF + Eirini

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config


### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A


### How should this change be described in cf-acceptance-tests release notes?

* FIX: Stop running tasks in the environment variable test when tasks are disabled


### How many more (or fewer) seconds of runtime will this change introduce to CATs?

up to 1 minute less when tasks are disabled

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!

With 💚 from @cloudfoundry/eirini 
