### PR TITLE
Use cf tail --envelope-class flag to only get logs in logs helper

### DIFF
--- a/helpers/logs/logs_helper.go
+++ b/helpers/logs/logs_helper.go
@@ -7,7 +7,7 @@ import (
 
 func Tail(useLogCache bool, appName string) *gexec.Session {
 	if useLogCache {
-		return cf.Cf("tail", appName, "--lines", "125")
+		return cf.Cf("tail", "--envelope-class=logs", appName, "--lines", "125")
 	}
 
 	return cf.Cf("logs", "--recent", appName)
@@ -15,7 +15,7 @@ func Tail(useLogCache bool, appName string) *gexec.Session {
 
 func TailFollow(useLogCache bool, appName string) *gexec.Session {
 	if useLogCache {
-		return cf.Cf("tail", "--follow", appName)
+		return cf.Cf("tail", "--envelope-class=logs", "--follow", appName)
 	}
 
 	return cf.Cf("logs", appName)


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes


### What is this change about?

This removes the application metric envelopes that often pollute the generic `cf tail` output and make test failure output harder to read.


### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config


### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A


### How should this change be described in cf-acceptance-tests release notes?

Use `cf tail` `--envelope-class` flag to reduce test failure output pollution by metric envelopes


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

