### PR TITLE
Remove `include_assisted_credhub` from ex. config

### DIFF
--- a/example-cats-config.json
+++ b/example-cats-config.json
@@ -36,7 +36,6 @@ IN DEVELOPMENT
   "include_tasks": true,
   "include_v3": true,
   "include_zipkin": true,
-  "include_assisted_credhub": true,
   "include_credhub": true,
   "include_tcp_routing": true,
   "include_volume_services": false,


### PR DESCRIPTION
It doesn't appear to be a real thing.