### PR TITLE
Raise windows default memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ There are a number of conventions we recommend developers of CF acceptance tests
 adopt:
 
 1. When pushing an app:
-  * set the **memory** requirement, and use the suite's `DEFAULT_MEMORY_LIMIT` unless the test specifically needs to test a different value,
+  * set the **memory** requirement, and use the suite's `DEFAULT_MEMORY_LIMIT` (`DEFAULT_WINDOWS_MEMORY_LIMIT` for tests in the `windows` directory) unless the test specifically needs to test a different value,
   * set the **buildpack** unless the test specifically needs to test the case where a buildpack is unspecified, and use one of `config.RubyBuildpack`, `config.JavaBuildpack`, etc.
 unless the test specifically needs to use a buildpack name or URL specific to the test,
   * set the **domain**, and use the `Config.AppsDomain` unless the test specifically needs to test a different app domain.

--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	CF_JAVA_TIMEOUT      = 10 * time.Minute
-	V3_PROCESS_TIMEOUT   = 45 * time.Second
-	DEFAULT_MEMORY_LIMIT = "256M"
+	CF_JAVA_TIMEOUT              = 10 * time.Minute
+	V3_PROCESS_TIMEOUT           = 45 * time.Second
+	DEFAULT_MEMORY_LIMIT         = "256M"
+	DEFAULT_WINDOWS_MEMORY_LIMIT = "1G"
 )
 
 var (

--- a/windows/asp_classic.go
+++ b/windows/asp_classic.go
@@ -22,7 +22,7 @@ var _ = WindowsDescribe("ASP classic applications", func() {
 			appName,
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().AspClassic,
 			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 	})

--- a/windows/context_paths.go
+++ b/windows/context_paths.go
@@ -38,7 +38,7 @@ var _ = WindowsDescribe("Context Paths", func() {
 			appName1,
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora,
 			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
@@ -50,7 +50,7 @@ var _ = WindowsDescribe("Context Paths", func() {
 			"--no-route",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora).Wait()).To(Exit(0))
 
 		// .NET Apps must be pushed with --no-start --no-route before running cf map-route
@@ -61,7 +61,7 @@ var _ = WindowsDescribe("Context Paths", func() {
 			"--no-route",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora).Wait()).To(Exit(0))
 
 		hostname = appName1

--- a/windows/credhub_assist.go
+++ b/windows/credhub_assist.go
@@ -38,7 +38,7 @@ var _ = WindowsCredhubDescribe("CredHub Integration", func() {
 		Expect(cf.Cf(
 			"push", chBrokerAppName,
 			"-b", Config.GetGoBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().CredHubServiceBroker,
 			"-f", assets.NewAssets().CredHubServiceBroker+"/manifest.yml",
 			"-d", Config.GetAppsDomain(),
@@ -185,7 +185,7 @@ echo   web: webapp.exe
 			Expect(cf.Cf("push", appName,
 				"--no-start",
 				"-b", buildpackName,
-				"-m", DEFAULT_MEMORY_LIMIT,
+				"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 				"-p", assets.NewAssets().WindowsWebapp,
 				"-d", Config.GetAppsDomain(),
 				"-s", Config.GetWindowsStack(),
@@ -248,7 +248,7 @@ echo   web: webapp.exe
 						"--no-start",
 						"-s", Config.GetWindowsStack(),
 						"-b", Config.GetHwcBuildpackName(),
-						"-m", DEFAULT_MEMORY_LIMIT,
+						"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 						"-p", assets.NewAssets().Nora,
 						"-d", Config.GetAppsDomain()).Wait()).To(Exit(0))
 					bindServiceAndStartApp(appName)

--- a/windows/dynamic_info.go
+++ b/windows/dynamic_info.go
@@ -23,7 +23,7 @@ var _ = WindowsDescribe("A running application", func() {
 			appName,
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora,
 			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hello i am nora"))

--- a/windows/http_healthcheck.go
+++ b/windows/http_healthcheck.go
@@ -26,7 +26,7 @@ var _ = WindowsDescribe("Http Healthcheck", func() {
 			"--no-start",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora,
 			"-d", Config.GetAppsDomain()).Wait()).To(Exit(0))
 	})

--- a/windows/instance_reporting.go
+++ b/windows/instance_reporting.go
@@ -28,7 +28,7 @@ var _ = WindowsDescribe("Getting instance information", func() {
 			appName,
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetBinaryBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().WindowsWebapp,
 			"-c", ".\\webapp.exe",
 			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))

--- a/windows/lifecycle.go
+++ b/windows/lifecycle.go
@@ -31,7 +31,7 @@ var _ = WindowsDescribe("Application Lifecycle", func() {
 				appName,
 				"-s", Config.GetWindowsStack(),
 				"-b", Config.GetHwcBuildpackName(),
-				"-m", DEFAULT_MEMORY_LIMIT,
+				"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 				"-p", assets.NewAssets().Nora,
 				"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		})

--- a/windows/metrics.go
+++ b/windows/metrics.go
@@ -36,7 +36,7 @@ var _ = WindowsDescribe("Metrics", func() {
 			appName,
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetBinaryBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().LoggregatorLoadGeneratorGo,
 			"-c", ".\\loggregator-load-generator.exe",
 			"-i", "2",

--- a/windows/output_volume.go
+++ b/windows/output_volume.go
@@ -1,6 +1,8 @@
 package windows
 
 import (
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
@@ -23,7 +25,7 @@ var _ = WindowsDescribe("An application printing a bunch of output", func() {
 			appName,
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora,
 			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hello i am nora"))

--- a/windows/routing.go
+++ b/windows/routing.go
@@ -24,7 +24,7 @@ var _ = WindowsDescribe("Adding and removing routes", func() {
 			appName,
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora,
 			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hello i am nora"))

--- a/windows/running_log.go
+++ b/windows/running_log.go
@@ -28,7 +28,7 @@ var _ = WindowsDescribe("app logs", func() {
 			appName,
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora,
 			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hello i am nora"))

--- a/windows/running_security_groups_win.go
+++ b/windows/running_security_groups_win.go
@@ -46,7 +46,7 @@ func pushApp(appName, buildpack string) {
 		appName,
 		"-s", Config.GetWindowsStack(),
 		"-b", buildpack,
-		"-m", DEFAULT_MEMORY_LIMIT,
+		"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 		"-p", assets.NewAssets().Nora,
 		"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 

--- a/windows/set_start_command.go
+++ b/windows/set_start_command.go
@@ -25,7 +25,7 @@ var _ = WindowsDescribe("Setting an app's start command", func() {
 			"--no-route",
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetBinaryBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-c", "loop.bat Hi there!!!",
 			"-u", "none",
 			"-p", assets.NewAssets().BatchScript).Wait(Config.CfPushTimeoutDuration()),

--- a/windows/ssh.go
+++ b/windows/ssh.go
@@ -37,7 +37,7 @@ var _ = WindowsDescribe("SSH", func() {
 			appName,
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Nora,
 			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hello i am nora"))

--- a/windows/standalone_webapp.go
+++ b/windows/standalone_webapp.go
@@ -32,7 +32,7 @@ var _ = WindowsDescribe("A standalone webapp", func() {
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetBinaryBuildpackName(),
 			"-c", ".\\webapp.exe",
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().WindowsWebapp,
 			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hi i am a standalone webapp"))

--- a/windows/tasks.go
+++ b/windows/tasks.go
@@ -30,7 +30,7 @@ var _ = WindowsDescribe("Task Lifecycle", func() {
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetBinaryBuildpackName(),
 			"-c", ".\\webapp.exe",
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().WindowsWebapp,
 			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("hi i am a standalone webapp"))

--- a/windows/wcf.go
+++ b/windows/wcf.go
@@ -27,7 +27,7 @@ var _ = WindowsDescribe("WCF", func() {
 			appName,
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
+			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Wcf,
 			"-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 	})


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

- [x] Yes

### What is this change about?

This change bumps the `DEFAULT_MEMORY_LIMIT` for .NET apps from 256MB to 1GB. 

While 256MB is enough for most cases, it seems to be just at the edge causing some tests to flake for .NET apps.

### Please provide contextual information.

We noticed some of the Windows CATS were flaking [in our pipelines](https://garden-windows.ci.cf-app.com/teams/main/pipelines/winc/jobs/pesto-cats-2019/builds/247) as well as Rel-Eng's.

Upon inverstigation we discovered that raising the memory limit for the app caused the flakiness to disapear.

See [#165228529](https://www.pivotaltracker.com/story/show/165228529) for the details of our investigation, and [this slack thread](https://pivotal.slack.com/archives/CER7X0FFE/p1553092526119200) for our discussion with Rel-Eng about this issue.

### What version of cf-deployment have you run this cf-acceptance-test change against?

`v7.11.0`

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [x] YES
- [ ] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How should this change be described in cf-acceptance-tests release notes?

Add a DEFAULT_WINDOWS_MEMORY_LIMIT

- .NET apps (like Nora) need to be bigger than 256M to avoid running
into memory-related flakes

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!

@sophiewigmore @greenhouse-ci