### PR TITLE
fix container metrics regex to accomodate apps with less memory

### DIFF
--- a/apps/lifecycle.go
+++ b/apps/lifecycle.go
@@ -171,7 +171,7 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 
 			It("is able to retrieve container metrics", func() {
 				// #0   running   2015-06-10 02:22:39 PM   0.0%   48.7M of 2G   14M of 1G
-				var metrics = regexp.MustCompile(`running.*(?:[\d\.]+)%\s+([\d\.]+)[MG]? of (?:[\d\.]+)[MG]\s+([\d\.]+)[MG]? of (?:[\d\.]+)[MG]`)
+				var metrics = regexp.MustCompile(`running.*(?:[\d\.]+)%\s+([\d\.]+)[KMG]? of (?:[\d\.]+)[KMG]\s+([\d\.]+)[KMG]? of (?:[\d\.]+)[KMG]`)
 				memdisk := func() (float64, float64) {
 					app := cf.Cf("app", appName)
 					Expect(app.Wait()).To(Exit(0))


### PR DESCRIPTION
Co-authored-by: Connor Braa <cbraa@pivotal.io>
Co-authored-by: Renee Chu <rchu@pivotal.io>

### What is this change about?

sometimes the test app here uses an amount of memory measured in K, not M or G. This causes the test to fail erroneously.

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A


### How should this change be described in cf-acceptance-tests release notes?

fix container metrics regex to accomodate apps with less memory

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@reneighbor @cdutra 