### PR TITLE
Add restart-app-instance test to app lifecycle

### DIFF
--- a/apps/lifecycle.go
+++ b/apps/lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 
@@ -187,6 +188,15 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 				}
 				Eventually(func() float64 { m, _ := memdisk(); return m }, Config.CfPushTimeoutDuration()).Should(BeNumerically(">", 0.0))
 				Eventually(func() float64 { _, d := memdisk(); return d }, Config.CfPushTimeoutDuration()).Should(BeNumerically(">", 0.0))
+			})
+
+			It("is able to restart an instance", func() {
+				idsBefore := app_helpers.ReportedIDs(2, appName)
+				Expect(len(idsBefore)).To(Equal(2))
+				Expect(cf.Cf("restart-app-instance", appName, "1").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				Eventually(func() []string {
+					return app_helpers.DifferentIDsFrom(idsBefore, appName)
+				}, Config.CfPushTimeoutDuration(), 2*time.Second).Should(HaveLen(1))
 			})
 		})
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Adds a test for `cf restart-app-instance`. The test is the same as in the windows tests.

### Please provide contextual information.

[Link to story in Eirini tracker](https://www.pivotaltracker.com/story/show/164894822)

### What version of cf-deployment have you run this cf-acceptance-test change against?
Test were ran against [SCF v2.15.2.1](https://github.com/SUSE/scf/tree/2.15.2.1)

### Please check all that apply for this PR:
- [X] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

This test is already present in the windows suite and should also be a part of the default apps tests.

### How should this change be described in cf-acceptance-tests release notes?

Add test to verify `cf restart-app-instance`. Extract functions for gathering instance ids to `app_helpers`

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Our tests ran between 60-80s.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@cloudfoundry/eirini