### PR TITLE
Add script to build and push multi app.

### DIFF
--- a/assets/multi-port-app/build-and-push-windows.sh
+++ b/assets/multi-port-app/build-and-push-windows.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+echo "Building the binary."
+GOOS=windows go build
+
+echo "Pushing the app to the windows stack."
+cf push multi -s windows -b binary_buildpack -c "./multi-port-app.exe --ports=8080,8081"
+
+echo "Capturing the app guid."
+export MULTI_APP_GUID=$(cf app multi --guid)
+
+echo "Configuring CF with the ports the app is listening on."
+cf curl /v2/apps/$MULTI_APP_GUID -X PUT -d '{"ports": [8080, 8081]}'
+
+echo "Capturing the route guid."
+export MULTI_ROUTE_GUID=$(cf curl /v2/routes?q=host:multi | jq -r .resources[0].metadata.guid)
+
+echo "Updating the route mapping for the app."
+cf curl /v2/route_mappings -X POST -d '{"app_guid": "'"$MULTI_APP_GUID"'", "route_guid": "'"$MULTI_ROUTE_GUID"'", "app_port": 8081}'


### PR DESCRIPTION
cc @sophiewigmore 

### What is this change about?

The multi-port app should be built for windows and pushed to the windows stack. Additionally, users will need to configure the app with the cf cli to open up the new ports it's running on.


### Please provide contextual information.

This is related to supporting route integrity & tls on windows by using nginx in place of envoy. https://www.pivotaltracker.com/story/show/165793495

### What version of cf-deployment have you run this cf-acceptance-test change against?
Does not acceptance the test itself.


### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A
