### PR TITLE
Remove windows2016 stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ include_capi_no_bridge
 * `include_windows`: Flag to include the tests that run against Windows cells.
 * `use_windows_test_task`: Flag to include the tasks tests on Windows cells. Default is `false`.
 * `use_windows_context_path`: Flag to include the Windows context path routing tests. Default is `false`.
-* `windows_stack`: Windows stack to run tests against. Must be either `windows2012R2`, `windows2016`, or `windows`. Defaults to `windows2012R2`.
+* `windows_stack`: Windows stack to run tests against. Must be either `windows2012R2`, or `windows`. Defaults to `windows2012R2`.
 
 * `include_service_discovery`: Flag to include test for the service discovery. These tests use `apps.internal` domain, which is the default in `cf-networking-release`. The internal domain is currently not configurable.
 * `stacks`: An array of stacks to test against. Currently only `cflinuxfs3` stack is supported. Default is `[cflinuxfs3]`.

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -701,7 +701,7 @@ func validateWindows(config *config) error {
 	}
 
 	switch config.GetWindowsStack() {
-	case "windows2012R2", "windows2016", "windows":
+	case "windows2012R2", "windows":
 	default:
 		return fmt.Errorf("* Invalid configuration: unknown Windows stack %s", config.GetWindowsStack())
 	}

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -558,7 +558,7 @@ var _ = Describe("Config", func() {
 			testCfg.IncludeWindows = ptrToBool(true)
 		})
 
-		Context("when the windows stack is not windows2016, windows2012R2, or windows", func() {
+		Context("when the windows stack is not windows2012R2, or windows", func() {
 			BeforeEach(func() {
 				testCfg.WindowsStack = ptrToString("windows98")
 			})

--- a/windows/running_security_groups_win.go
+++ b/windows/running_security_groups_win.go
@@ -158,7 +158,7 @@ var _ = WindowsDescribe("WINDOWS: App Instance Networking", func() {
 			serverAppName, privateHost, privatePort = pushServerApp()
 			clientAppName = pushClientApp()
 
-			if Config.GetWindowsStack() == "windows2016" || Config.GetWindowsStack() == "windows" {
+			if Config.GetWindowsStack() == "windows" {
 				assertNetworkingPreconditions(clientAppName, privateHost, privatePort)
 			}
 		})


### PR DESCRIPTION
The legacy "windows2016" stack is deprecated and not supported
anymore by CF that uses windows cells.

Use of apps with "windows2016" stack is no more part of
the acceptance criteria for windows.

See https://docs.cloudfoundry.org/devguide/deploy-apps/windows-stacks.html
> The windows2016 stack is not supported on Cloud Foundry.

### How should this change be described in cf-acceptance-tests release notes?
Removed the `windows2016` stack.