### PR TITLE
Volume services test uses a cf-pushed nfs server

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,16 +195,9 @@ include_capi_no_bridge
 * `include_service_discovery`: Flag to include test for the service discovery. These tests use `apps.internal` domain, which is the default in `cf-networking-release`. The internal domain is currently not configurable.
 * `stacks`: An array of stacks to test against. Currently only `cflinuxfs3` stack is supported. Default is `[cflinuxfs3]`.
 
-* `include_volume_services`: Flag to include the tests for volume services. Diego must be deployed for these tests to pass and volume service broker should be registered in platform.
+* `include_volume_services`: Flag to include the tests for volume services. The following requirements must be met to run this suite: Diego must be deployed. Docker support must be enabled. tcp-routing must be deployed. 
 * `volume_service_name`: The name of the volume service provided by the volume service broker.
 * `volume_service_plan_name`: The name of the plan of the service provided by the volume service broker.
-* `volume_service_create_config`: The JSON configuration that is used when volume service is created.
-* `volume_service_bind_config`: The JSON configuration that is used when volume service is bound to the test application.
-
-* `include_volume_services`: Flag to include the tests for volume services. Diego must be deployed for these tests to pass and volume service broker should be registered in platform.
-* `volume_service_name`: The name of the volume service provided by the volume service broker.
-* `volume_service_plan_name`: The name of the plan of the service provided by the volume service broker.
-* `volume_service_create_config`: The JSON configuration that is used when volume service is created.
 * `volume_service_bind_config`: The JSON configuration that is used when volume service is bound to the test application.
 
 #### Buildpack Names

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -84,8 +84,6 @@ type CatsConfig interface {
 
 	GetVolumeServiceName() string
 	GetVolumeServicePlanName() string
-	GetVolumeServiceCreateConfig() string
-	GetVolumeServiceBindConfig() string
 
 	GetReporterConfig() reporterConfig
 

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -64,8 +64,6 @@ type config struct {
 
 	VolumeServiceName         *string `json:"volume_service_name"`
 	VolumeServicePlanName     *string `json:"volume_service_plan_name"`
-	VolumeServiceCreateConfig *string `json:"volume_service_create_config"`
-	VolumeServiceBindConfig   *string `json:"volume_service_bind_config"`
 
 	IncludeApps                     *bool `json:"include_apps"`
 	IncludeBackendCompatiblity      *bool `json:"include_backend_compatibility"`
@@ -200,8 +198,6 @@ func getDefaults() config {
 
 	defaults.VolumeServiceName = ptrToString("")
 	defaults.VolumeServicePlanName = ptrToString("")
-	defaults.VolumeServiceCreateConfig = ptrToString("")
-	defaults.VolumeServiceBindConfig = ptrToString("")
 
 	defaults.ReporterConfig = &reporterConfig{}
 
@@ -681,12 +677,6 @@ func validateVolumeServices(config *config) error {
 	if config.GetVolumeServicePlanName() == "" {
 		return fmt.Errorf("* Invalid configuration: 'volume_service_plan_name' must be provided if 'include_volume_services' is true")
 	}
-	if config.GetVolumeServiceCreateConfig() == "" {
-		return fmt.Errorf("* Invalid configuration: 'volume_service_create_config' must be provided if 'include_volume_services' is true")
-	}
-	if config.GetVolumeServiceBindConfig() == "" {
-		return fmt.Errorf("* Invalid configuration: 'volume_service_bind_config' must be provided if 'include_volume_services' is true")
-	}
 
 	return nil
 }
@@ -1076,14 +1066,6 @@ func (c *config) GetVolumeServiceName() string {
 
 func (c *config) GetVolumeServicePlanName() string {
 	return *c.VolumeServicePlanName
-}
-
-func (c *config) GetVolumeServiceCreateConfig() string {
-	return *c.VolumeServiceCreateConfig
-}
-
-func (c *config) GetVolumeServiceBindConfig() string {
-	return *c.VolumeServiceBindConfig
 }
 
 func (c *config) GetAdminClient() string {

--- a/volume_services/volume_services.go
+++ b/volume_services/volume_services.go
@@ -1,26 +1,31 @@
 package volume_services
 
 import (
-	"path/filepath"
-
-	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
-
+	"encoding/json"
+	"fmt"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
+	"path/filepath"
+	"time"
 )
 
 var _ = VolumeServicesDescribe("Volume Services", func() {
+
 	var (
 		serviceName         string
 		serviceInstanceName string
 		appName             string
 		poraAsset           = assets.NewAssets().Pora
+		routerGroupGuid string
+		reservablePorts string
+		nfsPort = "2049"
 	)
 
 	BeforeEach(func() {
@@ -29,8 +34,45 @@ var _ = VolumeServicesDescribe("Volume Services", func() {
 		appName = random_name.CATSRandomName("APP")
 
 		workflowhelpers.AsUser(TestSetup.AdminUserContext(), TestSetup.ShortTimeout(), func() {
+			session := cf.Cf("curl", "/routing/v1/router_groups").Wait()
+			Expect(session).To(Exit(0), "cannot retrieve current router groups")
+
+			routerGroupGuid, reservablePorts = routerGroupIdAndPorts(session.Out.Contents())
+
+			payload := `{ "reservable_ports":"1024-2049", "name":"default-tcp", "type": "tcp"}`
+			session = cf.Cf("curl", fmt.Sprintf("/routing/v1/router_groups/%s", routerGroupGuid), "-X", "PUT", "-d", payload).Wait()
+			Expect(session).To(Exit(0), "cannot update tcp router group to allow nfs traffic")
+		})
+
+		By("pushing an nfs server")
+		Expect(cf.Cf("push", "nfs", "--docker-image", "cfpersi/nfs-cats", "--health-check-type", "none", "--no-start").
+			Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+		tcpDomain := fmt.Sprintf("tcp.%s", Config.GetAppsDomain())
+		session := cf.Cf("create-route", TestSetup.RegularUserContext().Space, tcpDomain, "--port", nfsPort).Wait()
+		Expect(session).To(Exit(0))
+
+		nfsGuid := GuidForAppName("nfs")
+		workflowhelpers.AsUser(TestSetup.AdminUserContext(), TestSetup.ShortTimeout(), func() {
+			session := cf.Cf("curl", "/v2/routes").Wait()
+			Expect(session).To(Exit(0), "cannot retrieve current routes")
+
+			routes := &Routes{}
+			err := json.Unmarshal(session.Out.Contents(), routes)
+			Expect(err).NotTo(HaveOccurred())
+
+			routeId := nfsRouteGuid(routes)
+
+			session = cf.Cf("curl", "/v2/route_mappings", "-X", "POST", "-d", fmt.Sprintf(`{"app_guid": "%s", "route_guid": "%s", "app_port": %s}`, nfsGuid, routeId, nfsPort)).Wait()
+			Expect(session).To(Exit(0), "cannot create a tcp route mapping to the nfs server app")
+		})
+
+		session = cf.Cf("start", "nfs").Wait()
+		Expect(session).To(Exit(0))
+
+		workflowhelpers.AsUser(TestSetup.AdminUserContext(), TestSetup.ShortTimeout(), func() {
 			session := cf.Cf("enable-service-access", serviceName, "-o", TestSetup.RegularUserContext().Org).Wait()
-			Expect(session).To(Exit(0))
+			Expect(session).To(Exit(0), "cannot enable service access")
 		})
 
 		By("pushing an app")
@@ -45,11 +87,11 @@ var _ = VolumeServicesDescribe("Volume Services", func() {
 		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 		By("creating a service")
-		createServiceSession := cf.Cf("create-service", serviceName, Config.GetVolumeServicePlanName(), serviceInstanceName, "-c", Config.GetVolumeServiceCreateConfig())
-		Expect(createServiceSession.Wait(TestSetup.ShortTimeout())).To(Exit(0))
+		createServiceSession := cf.Cf("create-service", serviceName, Config.GetVolumeServicePlanName(), serviceInstanceName, "-c", fmt.Sprintf(`{"share": "%s/"}`, tcpDomain))
+		Expect(createServiceSession.Wait(TestSetup.ShortTimeout())).To(Exit(0), "cannot create nfs service")
 
 		By("binding the service")
-		bindSession := cf.Cf("bind-service", appName, serviceInstanceName, "-c", Config.GetVolumeServiceBindConfig())
+		bindSession := cf.Cf("bind-service", appName, serviceInstanceName, "-c", `{"uid": "2000", "gid": "2000"}`, "cannot bind nfs service to app")
 		Expect(bindSession.Wait(TestSetup.ShortTimeout())).To(Exit(0))
 
 		By("starting the app")
@@ -62,7 +104,15 @@ var _ = VolumeServicesDescribe("Volume Services", func() {
 
 		workflowhelpers.AsUser(TestSetup.AdminUserContext(), TestSetup.ShortTimeout(), func() {
 			session := cf.Cf("disable-service-access", serviceName, "-o", TestSetup.RegularUserContext().Org).Wait()
-			Expect(session).To(Exit(0))
+			Expect(session).To(Exit(0), "cannot disable service access")
+		})
+
+		Eventually(cf.Cf("delete", "nfs", "-f")).Should(Exit(0))
+
+		workflowhelpers.AsUser(TestSetup.AdminUserContext(), TestSetup.ShortTimeout(), func() {
+			payload := fmt.Sprintf(`{ "reservable_ports":"%s", "name":"default-tcp", "type": "tcp"}`, reservablePorts)
+			session := cf.Cf("curl", fmt.Sprintf("/routing/v1/router_groups/%s", routerGroupGuid), "-X", "PUT", "-d", payload).Wait()
+			Expect(session).To(Exit(0), "cannot retrieve current router groups")
 		})
 	})
 
@@ -70,3 +120,60 @@ var _ = VolumeServicesDescribe("Volume Services", func() {
 		Expect(helpers.CurlApp(Config, appName, "/write")).To(ContainSubstring("Hello Persistent World"))
 	})
 })
+
+func nfsRouteGuid(routes *Routes) string {
+	for _, resource := range routes.Resources {
+		if resource.Entity.Port != nil && resource.Entity.Port.(float64) == 2049 {
+			return resource.Metadata.GUID
+		}
+	}
+	Fail("Unable to find a valid tcp route for port 2049")
+	return ""
+}
+
+func routerGroupIdAndPorts(routerGroupOutput []byte) (guid, ports string) {
+	routerGroups := &[]RouterGroup{}
+	err := json.Unmarshal(routerGroupOutput, routerGroups)
+	Expect(err).NotTo(HaveOccurred())
+	for _, routerGroup := range *routerGroups {
+		if routerGroup.Name == "default-tcp" {
+			return routerGroup.GUID, routerGroup.ReservablePorts
+		}
+	}
+	Fail("Unable to find routergroup 'default-tcp'")
+	return "", ""
+}
+
+type RouterGroup struct {
+	GUID            string `json:"guid"`
+	Name            string `json:"name"`
+	Type            string `json:"type"`
+	ReservablePorts string `json:"reservable_ports"`
+}
+
+type Routes struct {
+	TotalResults int         `json:"total_results"`
+	TotalPages   int         `json:"total_pages"`
+	PrevURL      interface{} `json:"prev_url"`
+	NextURL      interface{} `json:"next_url"`
+	Resources    []struct {
+		Metadata struct {
+			GUID      string    `json:"guid"`
+			URL       string    `json:"url"`
+			CreatedAt time.Time `json:"created_at"`
+			UpdatedAt time.Time `json:"updated_at"`
+		} `json:"metadata"`
+		Entity struct {
+			Host                string      `json:"host"`
+			Path                string      `json:"path"`
+			DomainGUID          string      `json:"domain_guid"`
+			SpaceGUID           string      `json:"space_guid"`
+			ServiceInstanceGUID interface{} `json:"service_instance_guid"`
+			Port                interface{} `json:"port"`
+			DomainURL           string      `json:"domain_url"`
+			SpaceURL            string      `json:"space_url"`
+			AppsURL             string      `json:"apps_url"`
+			RouteMappingsURL    string      `json:"route_mappings_url"`
+		} `json:"entity"`
+	} `json:"resources"`
+}


### PR DESCRIPTION
[#167932835](https://www.pivotaltracker.com/story/show/167932835)

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

> Yes


### What is this change about?

> Having the ability to run volume-services suite without any external nfs server running. Instead the suite 'creates' a nfs server to run tests against.


### Please provide contextual information.

> We would like it to be easier to run the volume services suite


### What version of cf-deployment have you run this cf-acceptance-test change against?
 
> https://github.com/cloudfoundry/cf-deployment/commits/29bd9ac01754398587623435403437da894f6684


### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ X ] changes an existing test
- [ X ] requires an update to a CATs integration-config

> We removed an unused configuration property `volume_service_create_config`



### Did you update the README as appropriate for this change?
- [ X ] YES
- [ ] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

n/a


### How should this change be described in cf-acceptance-tests release notes?

Volume services test now uses a cf-pushed "in-memory" nfs server


### How many more (or fewer) seconds of runtime will this change introduce to CATs?

~1 minute


### What is the level of urgency for publishing this change?

- [ X ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
cc/ @DennisDenuto @julian-hj