### PR TITLE
Run tests faster with mod=vendor

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -27,4 +27,4 @@ go build -v -o bin/ginkgo github.com/cloudfoundry/cf-acceptance-tests/vendor/git
 export PATH=$PWD/bin:$PATH
 
 echo "Using $(ginkgo version)" > /dev/null
-ginkgo "$@"
+ginkgo -mod=vendor "$@"


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)? 

Yes

### What is this change about?

As all of the dependencies are vendored, we should leverage that. This saves about a minute in our (Eirini team's) CI.

### Please provide contextual information.

N/A

### What version of cf-deployment have you run this cf-acceptance-test change against?

SCF + Eirini

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How should this change be described in cf-acceptance-tests release notes?

cf-acceptance-tests will leverage vendored modules using `-mod=vendor`. This means go versions less than 1.11 will not be supported.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

This change cuts down 55 seconds.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!

@alex-slynko 