### PR TITLE
Allow volume service create config to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ include_capi_no_bridge
 * `include_volume_services`: Flag to include the tests for volume services. The following requirements must be met to run this suite: Diego must be deployed. Docker support must be enabled. tcp-routing must be deployed. 
 * `volume_service_name`: The name of the volume service provided by the volume service broker.
 * `volume_service_plan_name`: The name of the plan of the service provided by the volume service broker.
+* `volume_service_create_config`: The JSON configuration that is used when volume service is created.
 
 #### Buildpack Names
 Many tests specify a buildpack when pushing an app, so that on diego the app staging process completes in less time. The default names for the buildpacks are as follows; if you have buildpacks with different names, you can override them by setting different names:

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -84,6 +84,7 @@ type CatsConfig interface {
 
 	GetVolumeServiceName() string
 	GetVolumeServicePlanName() string
+	GetVolumeServiceCreateConfig() string
 
 	GetReporterConfig() reporterConfig
 

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -64,6 +64,7 @@ type config struct {
 
 	VolumeServiceName         *string `json:"volume_service_name"`
 	VolumeServicePlanName     *string `json:"volume_service_plan_name"`
+	VolumeServiceCreateConfig *string `json:"volume_service_create_config"`
 
 	IncludeApps                     *bool `json:"include_apps"`
 	IncludeBackendCompatiblity      *bool `json:"include_backend_compatibility"`
@@ -198,6 +199,7 @@ func getDefaults() config {
 
 	defaults.VolumeServiceName = ptrToString("")
 	defaults.VolumeServicePlanName = ptrToString("")
+	defaults.VolumeServiceCreateConfig = ptrToString("")
 
 	defaults.ReporterConfig = &reporterConfig{}
 
@@ -1066,6 +1068,10 @@ func (c *config) GetVolumeServiceName() string {
 
 func (c *config) GetVolumeServicePlanName() string {
 	return *c.VolumeServicePlanName
+}
+
+func (c *config) GetVolumeServiceCreateConfig() string {
+	return *c.VolumeServiceCreateConfig
 }
 
 func (c *config) GetAdminClient() string {


### PR DESCRIPTION
### What is this change about?
Allow volume service create config to be specified so that we can support testing against external volume services such as SMB

### Please provide contextual information.
[#167082052](https://www.pivotaltracker.com/story/show/167082052)


### What version of cf-deployment have you run this cf-acceptance-test change against?
v12 release candidate

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [X] YES
- [ ] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

n/a


### How should this change be described in cf-acceptance-tests release notes?
Allow volume service create config to be specified to support testing against external volume services such as SMB

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
n/a


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
cc /@julian-hj @DennisDenuto 
