### PR TITLE
`bin/test` requires Go 1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,22 +39,12 @@ in such a way as to impact other tests.
 
 ## Test Setup
 ### Prerequisites for running CATS
-- Install golang >= `1.7`. Set up your golang development environment, per
+- Install golang >= `1.11`. Set up your golang development environment, per
   [golang.org](http://golang.org/doc/install).
 - Install the [`cf CLI`](https://github.com/cloudfoundry/cli).
   Make sure that it is accessible in your `$PATH`.
 - Install [curl](http://curl.haxx.se/)
-- Check out a copy of `cf-acceptance-tests`
-  and make sure that it is added to your `$GOPATH`.
-  The recommended way to do this is to run:
-
-  ```bash
-  go get -d github.com/cloudfoundry/cf-acceptance-tests
-  ```
-
-  You will receive a warning:
-  `no buildable Go source files`.
-  This can be ignored, as there is only test code in the package.
+- Check out a copy of `cf-acceptance-tests`. It uses Go modules, so there is no need to put it in `$GOPATH`.
 - Ensure all submodules are checked out to the correct SHA.
   The easiest way to do this is by running:
 


### PR DESCRIPTION
See also https://github.com/cloudfoundry/cf-acceptance-tests/pull/386

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

https://github.com/cloudfoundry/cf-acceptance-tests/pull/386 introduces a flag that has been added in Go 1.11. Also, it most probably won't work in GOPATH

### Please provide contextual information.

https://github.com/cloudfoundry/cf-acceptance-tests/pull/386

### What version of cf-deployment have you run this cf-acceptance-test change against?

N/A

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [X] YES
- [ ] N/A

Should have done it in previous PR :(

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How should this change be described in cf-acceptance-tests release notes?

cf-acceptance-tests should run outside of GOPATH

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**


