### PR TITLE
Revert "Randomize the shared domain created by this spec"

### DIFF
--- a/volume_services/volume_services.go
+++ b/volume_services/volume_services.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
@@ -46,9 +45,7 @@ var _ = VolumeServicesDescribe("Volume Services", func() {
 			session = cf.Cf("curl", fmt.Sprintf("/routing/v1/router_groups/%s", routerGroupGuid), "-X", "PUT", "-d", payload).Wait()
 			Expect(session).To(Exit(0), "cannot update tcp router group to allow nfs traffic")
 
-			randomDomain := strings.ReplaceAll(random_name.CATSRandomName("SHARED_DOMAIN"), "_", "-")
-
-			tcpDomain = fmt.Sprintf("%s.%s", randomDomain, Config.GetAppsDomain())
+			tcpDomain = fmt.Sprintf("tcp.%s", Config.GetAppsDomain())
 
 			session = cf.Cf("create-shared-domain", tcpDomain, "--router-group", "default-tcp").Wait()
 			Expect(session).To(Exit(0), "can not create shared tcp domain")

--- a/volume_services/volume_services.go
+++ b/volume_services/volume_services.go
@@ -118,7 +118,12 @@ var _ = VolumeServicesDescribe("Volume Services", func() {
 		Expect(bindSession.Wait(TestSetup.ShortTimeout())).To(Exit(0), "cannot bind the nfs service instance to the test app")
 
 		By("starting the app")
-		Expect(cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "cannot start the test app")
+		session = cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())
+		Eventually(session).Should(Exit())
+		if session.ExitCode() != 0 {
+			cf.Cf("logs", appName, "--recent")
+		}
+		Expect(session.ExitCode()).To(Equal(0))
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
## What is this change about?
The volume services test suite is a little flakey. I attempted to randomize the tcpDomain in the last PR (see below) but this caused other issues (app would flakily fail to start sometimes but not clear why).
Propose reverting randomizing the  part to timebox this chore
https://github.com/cloudfoundry/cf-acceptance-tests/pull/391

## Please provide contextual information.
#169354687

##What version of cf-deployment have you run this cf-acceptance-test change against?
Release candidate

## Please check all that apply for this PR:
 introduces a new test --- Are you sure everyone should be running this test?
 changes an existing test
 requires an update to a CATs integration-config
Did you update the README as appropriate for this change?
 YES
 N/A
##How should this change be described in cf-acceptance-tests release notes?
Improve the repeatability of the volume services test in CATs by adding the correct timeouts and randomizing the shared domain that it creates.

## How many more (or fewer) seconds of runtime will this change introduce to CATs?
The time difference is negligable

## What is the level of urgency for publishing this change?
 Urgent - unblocks current or future work
 Slightly Less than Urgent
Tag your pair, your PM, and/or team!
cc/@julian-hj, @DennisDenuto, @lcho @paulcwarren 