### PR TITLE
assert different "routing transparency" behavior for Istio Proxy

### DIFF
--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -51,3 +51,4 @@ const SkipVolumeServicesMessage = `Skipping this test because config.IncludeVolu
 NOTE: Ensure that volume services are enabled on your platform and volume service broker is registered before running this test.`
 const SkipVolumeServicesDockerEnabledMessage = `Skipping this test because config.IncludeDocker is set to 'true'`
 const SkipK8sMessage = `Skipping this test because config.Infrastructure is set to 'kubernetes': %s`
+const SkipVMsMessage = `Skipping this test because config.Infrastructure is set to 'vms': %s`


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Ya 👍 

### What is this change about?
Istio performs some URL normalization so it does not have _complete_ route transparency like the Gorouters do. For various reasons this is desired behavior on the Istio side and they will not be changing it. We think that based on the history of this CAT (https://github.com/cloudfoundry/gorouter/issues/46) that this behavior is fine to differ between Gorouter and Istio-Proxy.

This change does the following:
- adds a new config property, `UseKubernetesIstioProxy` to use as a flag
for asserting on behavior differences between Gorouter and Istio Proxy. This property defaults to `false` to maintain the current CATS behavior.
- modifies the routing transparency CATS to allow for Istio Proxy's URL
normalization

Story: https://www.pivotaltracker.com/story/show/169404143

We've run the existing Gorouter-specific tests against an environment using `release-candidate` of cf-deployment. We ran the Istio-Proxy specific CATS against an Eirini environment.

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [x] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [x] YES
- [ ] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

This is an existing test that applies differently in the Istio-Proxy/CF on k8s world. We are introducing change this to CATS so that we can continue to run CATS against environments that do not use Gorouters.

### How should this change be described in cf-acceptance-tests release notes?

* assert different "routing transparency" behavior for Istio Proxy


### How many more (or fewer) seconds of runtime will this change introduce to CATs?
It will not affect CATS runtime. Same amount of tests, just different assertions.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@ndhanushkodi @mike1808 @rosenhouse @rodolfo2488 
