### PR TITLE
Remove duplicate entry from example config

### DIFF
--- a/example-cats-config.json
+++ b/example-cats-config.json
@@ -35,7 +35,6 @@ IN DEVELOPMENT
   "include_v3": true,
   "include_zipkin": true,
   "include_credhub": true,
-  "include_tcp_routing": true,
   "include_volume_services": false,
   "stacks": [
     "cflinuxfs3"


### PR DESCRIPTION
### What is this change about?

The example config has a duplicated entry, which can make the behaviour of the suite very confusing if they have different values!

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**