### PR TITLE
Respect Config.Protocol when testing iso segs

### DIFF
--- a/isolation_segments/isolation_segments.go
+++ b/isolation_segments/isolation_segments.go
@@ -124,10 +124,8 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 					"-c", "./app"),
 					Config.CfPushTimeoutDuration()).Should(Exit(0))
 
-				hostHeader := fmt.Sprintf("Host: %s.%s", appName, isoSegDomain)
-				host := fmt.Sprintf("http://wildcard-path.%s", isoSegDomain)
-
-				curlSession := helpers.CurlSkipSSL(Config.GetSkipSSLValidation(), host, "-H", hostHeader)
+				curlArgs := Config.Protocol() + appName + "." + isoSegDomain
+				curlSession := helpers.Curl(Config, curlArgs)
 				Eventually(curlSession).Should(Exit(0))
 				Expect(curlSession.Out).To(Say(binaryHi))
 			})
@@ -220,10 +218,8 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 					"-c", "./app"),
 					Config.CfPushTimeoutDuration()).Should(Exit(0))
 
-				hostHeader := fmt.Sprintf("Host: %s.%s", appName, isoSegDomain)
-				host := fmt.Sprintf("http://wildcard-path.%s", isoSegDomain)
-
-				curlSession := helpers.CurlSkipSSL(Config.GetSkipSSLValidation(), host, "-H", hostHeader)
+				curlArgs := Config.Protocol() + appName + "." + isoSegDomain
+				curlSession := helpers.Curl(Config, curlArgs)
 				Eventually(curlSession).Should(Exit(0))
 				Expect(curlSession.Out).To(Say(binaryHi))
 			})


### PR DESCRIPTION
### What is this change about?

@schmie and I recently enabled the isolation segment acceptance tests in our environments, and they were failing.

They were failing because the tests made assumptions about:

- the configured protocol which should be used to test the applications
- the hostname under which the applications were accessible

We have made the protocol use the configurable protocol, which assumes that the isolation segment will be routable via gorouter, on the apps domain (which I think is a reasonable assumption).

We have changed the hostname to be the name of the application, which is consistent with the other tests.

### What version of cf-deployment have you run this cf-acceptance-test change against?

We have used cf-acceptance-tests branch `cf12.19` against a fairly heavily modified cf-deployment `12.19`, the details of which can be found in [alphagov/paas-cf/wip-tlwr](https://github.com/alphagov/paas-cf/tree/wip-tlwr)

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A


### How should this change be described in cf-acceptance-tests release notes?

The isolation segments acceptance tests now respect the protocol configuration option, and use the hostname of the application, rather than a statically defined wildcard.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

This should not change the runtime

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@tlwr and @schmie paired on this on behalf of [GOV.UK PaaS](https://www.cloud.service.gov.uk/)