### PR TITLE
Update python app to Python 3.x

### DIFF
--- a/assets/python/runtime.txt
+++ b/assets/python/runtime.txt
@@ -1,1 +1,1 @@
-\r\r\n\npython-2.7.x\n\n\r\r
+python-3.x

--- a/assets/python/server.py
+++ b/assets/python/server.py
@@ -1,5 +1,5 @@
-from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
-from SocketServer import ThreadingMixIn
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from socketserver import ThreadingMixIn
 import os
 
 class Handler(BaseHTTPRequestHandler):
@@ -7,8 +7,8 @@ class Handler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.end_headers()
         message =  "Hello python, world!"
-        self.wfile.write(message)
-        self.wfile.write('\n')
+        self.wfile.write(message.encode('utf-8'))
+        self.wfile.write('\n'.encode('utf-8'))
         return
 
 class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
@@ -17,7 +17,7 @@ class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', '8080'))
     host = os.environ.get('VCAP_APP_HOST', '127.0.0.1')
-    print "Goin to start sever on %s:%s" % (host, port)
+    print("Going to start server on %s:%s" % (host, port))
     server = ThreadedHTTPServer((host, port), Handler)
-    print 'Starting server, use <Ctrl-C> to stop'
+    print('Starting server, use <Ctrl-C> to stop')
     server.serve_forever()


### PR DESCRIPTION
Updates the python app asset to use Python 3.x. Newer versions of the python-buildpack do not support Python 2.x anymore.
See reported issue: https://github.com/cloudfoundry/cf-acceptance-tests/issues/407

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in cf-acceptance-tests release notes?
The python app asset has been updated to use Python 3.

### What is the level of urgency for publishing this change?
- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

Signed-off-by: Fabio Berchtold <fabio.berchtold@swisscom.com>