### PR TITLE
Add `cf push` command to nora README

### DIFF
--- a/assets/nora/README.md
+++ b/assets/nora/README.md
@@ -6,20 +6,13 @@ Nora .NET api app for testing
 A sister app of Dora
 
 
-Install
+Deploy
 =======
-
-To install you will have to get cf 6.10+ and run the following commands:
-
-```sh
-cf add-plugin-repo CF-Community http://plugins.cloudfoundry.org/
-cf install-plugin Diego-Beta -r CF-Community
-```
 
 Run the following command to deploy nora:
 
 ```sh
-./make_a_nora <app_name> <stack_name>
+cf push nora -p NoraPublished -s windows
 ```
 
 Requirements


### PR DESCRIPTION
Looks like ./make_a_nora no longer exists, and this simple command to "cf
push" nora works.


### What is this change about?

We had trouble deploying nora. This should help others avoid that trouble.

### Did you update the README as appropriate for this change?
- [x] YES
- [ ] N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**
- [x] **Not at all urgent... but... why wait?**

### Tag your pair, your PM, and/or team!

@christianang @KauzClay 
