### PR TITLE
Enable docker before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ include_capi_no_bridge
 * `include_service_discovery`: Flag to include test for the service discovery. These tests use `apps.internal` domain, which is the default in `cf-networking-release`. The internal domain is currently not configurable.
 * `stacks`: An array of stacks to test against. Currently only `cflinuxfs3` stack is supported. Default is `[cflinuxfs3]`.
 
-* `include_volume_services`: Flag to include the tests for volume services. The following requirements must be met to run this suite: Diego must be deployed. Docker support must be enabled. tcp-routing must be deployed. 
+* `include_volume_services`: Flag to include the tests for volume services. The following requirements must be met to run this suite: tcp-routing must be deployed. 
 * `volume_service_name`: The name of the volume service provided by the volume service broker.
 * `volume_service_plan_name`: The name of the plan of the service provided by the volume service broker.
 * `volume_service_create_config`: The JSON configuration that is used when volume service is created.

--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -336,6 +336,9 @@ func VolumeServicesDescribe(description string, callback func()) bool {
 			if !Config.GetIncludeVolumeServices() {
 				Skip(skip_messages.SkipVolumeServicesMessage)
 			}
+			if Config.GetIncludeDocker() {
+				Skip(skip_messages.SkipVolumeServicesDockerEnabledMessage)
+			}
 		})
 		Describe(description, callback)
 	})

--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -52,3 +52,4 @@ const SkipWindowsTasksMessage = `Skipping Windows tasks tests (requires diego-re
 const SkipNoAlternateStacksMessage = `Skipping this test because config.Stacks is empty.`
 const SkipVolumeServicesMessage = `Skipping this test because config.IncludeVolumeServices is set to 'false'.
 NOTE: Ensure that volume services are enabled on your platform and volume service broker is registered before running this test.`
+const SkipVolumeServicesDockerEnabledMessage = `Skipping this test because config.IncludeDocker is set to 'true'`

--- a/volume_services/volume_services.go
+++ b/volume_services/volume_services.go
@@ -36,7 +36,10 @@ var _ = VolumeServicesDescribe("Volume Services", func() {
 		appName = random_name.CATSRandomName("APP")
 
 		workflowhelpers.AsUser(TestSetup.AdminUserContext(), TestSetup.ShortTimeout(), func() {
-			session := cf.Cf("curl", "/routing/v1/router_groups").Wait()
+			session := cf.Cf("enable-feature-flag", "diego_docker").Wait()
+			Expect(session).To(Exit(0), "cannot enable diego_docker feature flag")
+
+			session = cf.Cf("curl", "/routing/v1/router_groups").Wait()
 			Expect(session).To(Exit(0), "cannot retrieve current router groups")
 
 			routerGroupGuid, reservablePorts = routerGroupIdAndPorts(session.Out.Contents())
@@ -131,6 +134,9 @@ var _ = VolumeServicesDescribe("Volume Services", func() {
 			payload := fmt.Sprintf(`{ "reservable_ports":"%s", "name":"default-tcp", "type": "tcp"}`, reservablePorts)
 			session := cf.Cf("curl", fmt.Sprintf("/routing/v1/router_groups/%s", routerGroupGuid), "-X", "PUT", "-d", payload).Wait()
 			Expect(session).To(Exit(0), "cannot retrieve current router groups")
+
+			session = cf.Cf("disable-feature-flag", "diego_docker").Wait()
+			Expect(session).To(Exit(0), "cannot disable diego_docker feature flag")
 		})
 	})
 


### PR DESCRIPTION
- and disable again afterwards


Co-authored-by: Paul Warren <pwarren@pivotal.io>
Co-authored-by: Lisa Burns <lcho@pivotal.io>

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to master once they've passed acceptance._



### What is this change about?

We are paying down some tech debt.  we wanted both pats and cats to work the same way; i.e. be responsible for enabling docker, rather than having the responsibility in the test one place and in the pipeline in another.

### Please provide contextual information.

[#172250234](https://www.pivotaltracker.com/story/show/172250234)

### What version of cf-deployment have you run this cf-acceptance-test change against?

a smith claimed cf-deployment

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [X] YES
- [ ] N/A




### How should this change be described in cf-acceptance-tests release notes?

n/a


### How many more (or fewer) seconds of runtime will this change introduce to CATs?

negligible.  all the test does is run two extra cf commands to enable the docker feature flag

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@cloudfoundry/cf-volume-services 
