### PR TITLE
Migrate CATs to use v7 CF CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ include_apps
 include_detect
 include_routing
 include_v3
-include_capi_no_bridge
 ```
 
 #### The full set of config parameters is explained below:
@@ -128,7 +127,6 @@ include_capi_no_bridge
 * `credhub_location`: Location of CredHub instance; default is `https://credhub.service.cf.internal:8844`
 * `credhub_client`: UAA client credential for Service Broker write access to CredHub (required for CredHub tests); default is `credhub_admin_client`.
 * `credhub_secret`: UAA client secret for Service Broker write access to CredHub (required for CredHub tests).
-* `include_capi_no_bridge`: Flag to run tests that require CAPI's (currently optional) bridge consumption features.
 * `include_deployments`: Flag to include tests for the cloud controller rolling deployments. V3 must also be enabled.
 * `include_detect`: Flag to include tests in the detect group.
 * `include_docker`: Flag to include tests related to running Docker apps on Diego. Diego must be deployed and the CC API docker_diego feature flag must be enabled for these tests to pass.

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -121,7 +121,6 @@ type allConfig struct {
 	ReporterConfig *testReporterConfig `json:"reporter_config"`
 
 	IncludeApps                     *bool `json:"include_apps"`
-	IncludeCapiNoBridge             *bool `json:"include_capi_no_bridge"`
 	IncludeContainerNetworking      *bool `json:"include_container_networking"`
 	IncludeDetect                   *bool `json:"include_detect"`
 	IncludeDocker                   *bool `json:"include_docker"`
@@ -244,8 +243,6 @@ var _ = Describe("Config", func() {
 		Expect(config.GetIncludeRouting()).To(BeTrue())
 		Expect(config.GetIncludeV3()).To(BeTrue())
 
-		Expect(config.GetIncludeBackendCompatiblity()).To(BeFalse())
-		Expect(config.GetIncludeCapiNoBridge()).To(BeTrue())
 		Expect(config.GetIncludeDocker()).To(BeFalse())
 		Expect(config.GetIncludeInternetDependent()).To(BeFalse())
 		Expect(config.GetIncludeInternetless()).To(BeFalse())
@@ -364,7 +361,6 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(ContainSubstring("'staticfile_buildpack_name' must not be null"))
 
 			Expect(err.Error()).To(ContainSubstring("'include_apps' must not be null"))
-			Expect(err.Error()).To(ContainSubstring("'include_capi_no_bridge' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_detect' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_docker' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_internet_dependent' must not be null"))

--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -1,7 +1,6 @@
 package skip_messages
 
 const SkipAppsMessage = `Skipping this test because config.IncludeApps is set to 'false'.`
-const SkipBackendCompatibilityMessage = `Skipping this test because config.IncludeBackendCompatibility is set to 'false'.`
 const SkipContainerNetworkingMessage = `Skipping this test because config.IncludeContainerNetworking is set to 'false'.`
 const SkipDetectMessage = `Skipping this test because config.IncludeDetect is set to 'false'.`
 const SkipDockerMessage = `Skipping this test because config.IncludeDocker is set to 'false'.
@@ -46,7 +45,6 @@ const SkipZipkinMessage = `Skipping this test because config.IncludeZipkin is se
 const SkipServiceDiscoveryMessage = `Skipping this test because config.IncludeServiceDiscovery is set to 'false'.`
 const SkipServiceInstanceSharingMessage = `Skipping this test because config.IncludeServiceInstanceSharing is set to 'false'.`
 const SkipCapiExperimentalMessage = `Skipping this test because config.IncludeCapiExperimental is set to 'false'.`
-const SkipCapiNoBridgeMessage = `Skipping this test because config.IncludeCapiNoBridge is set to 'false'.`
 const SkipSSHOnWindows2012R2Message = `cf ssh does not work on windows2012R2`
 const SkipWindowsTasksMessage = `Skipping Windows tasks tests (requires diego-release v1.20.0 and above)`
 const SkipNoAlternateStacksMessage = `Skipping this test because config.Stacks is empty.`


### PR DESCRIPTION
# DO NOT MERGE (YET)

Co-authored-by: Eric Promislow <epromislow@suse.com>

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

_Describe the change and why it's needed._

While moving CATs to use CF CLI 7, we're maintaining the changes as a PR to make it easier to 
solicit community feedback

### Please provide contextual information.
https://www.pivotaltracker.com/epic/show/4320018




### What version of cf-deployment have you run this cf-acceptance-test change against?
We actually ran this through the CATs ci before reverting and open a PR, which used the latest release: 13.6.0 


### Please check all that apply for this PR:
- [x] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [x] YES, but may warrant additional changes based on feedback.
- [ ] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?
The v7 cli and v3 api include new functionality, for which we would like new acceptance tests.

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._



### How should this change be described in cf-acceptance-tests release notes?
Update CATs to reflect the use of cf cli v7 instead of v6 going forward.


### How many more (or fewer) seconds of runtime will this change introduce to CATs?
N.A.


### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
@cloudfoundry/cf-release-integration 