### PR TITLE
internet-dependent: nodejs to work with cflinuxfs3

### DIFF
--- a/internet_dependent/git_buildpack.go
+++ b/internet_dependent/git_buildpack.go
@@ -20,7 +20,7 @@ var _ = InternetDependentDescribe("GitBuildpack", func() {
 
 	It("uses a buildpack from a git url", func() {
 		appName = random_name.CATSRandomName("APP")
-		Expect(cf.Cf("push", appName, "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Node, "-b", "https://github.com/cloudfoundry/nodejs-buildpack.git#v1.3.1", "-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+		Expect(cf.Cf("push", appName, "-m", DEFAULT_MEMORY_LIMIT, "-p", assets.NewAssets().Node, "-b", "https://github.com/cloudfoundry/nodejs-buildpack.git#v1.7.24", "-d", Config.GetAppsDomain()).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 		Eventually(func() string {
 			return helpers.CurlAppRoot(Config, appName)


### PR DESCRIPTION
### What is this change about?

The nodejs buildpack is very old, and does not stage properly when running the internet dependent acceptance tests.

### Please provide contextual information.

Working
```
cf7 push test-node-app -b https://github.com/cloudfoundry/nodejs-buildpack.git#v1.7.24 --no-route -c 'sleep 3600' --health-check-type process
```

Not working
```
cf7 push test-node-app -b https://github.com/cloudfoundry/nodejs-buildpack.git#v1.3.1 --no-route -c 'sleep 3600' --health-check-type process
```

Error message
```
   gzip: stdin: unexpected end of file
   tar: Child returned status 1
   tar: Error is not recoverable: exiting now
   -----> Resource http://s3pository.heroku.com/node/v14.6.0/node-v14.6.0-linux-x64.tar.gz does not exist.
   mv: cannot stat '/tmp/app/node-v14.6.0-linux-x64': No such file or directory
   chmod: cannot access '/tmp/app/vendor/node/bin/*': No such file or directory
   /tmp/buildpackdownloads/4bc27550d5e24842f1e869c7ed2654ed/lib/build.sh: line 157: npm: command not found
          Using default npm version:
   -----> Building dependencies
   /tmp/buildpackdownloads/4bc27550d5e24842f1e869c7ed2654ed/lib/build.sh: line 236: node: command not found
   /tmp/buildpackdownloads/4bc27550d5e24842f1e869c7ed2654ed/lib/build.sh: line 237: npm: command not found
```

### What version of cf-deployment have you run this cf-acceptance-test change against?

I have replicated this on 13.2 and 13.7 using the 621.77 stemcells with 0.199 cflinuxfs3

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in cf-acceptance-tests release notes?

> Internet dependent suite uses more recent nodejs buildpack version, inline with the cf-deployment buildpack version.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

As more deployments upgrade their cflinuxfs3 versions, more people will run into this issue. Also v1.3.1 is from 2015 😱 

### Tag your pair, your PM, and/or team!

@schmie
