### PR TITLE
Always target the test space

### DIFF
--- a/apps/wildcard_routes.go
+++ b/apps/wildcard_routes.go
@@ -19,6 +19,7 @@ var _ = AppsDescribe("Wildcard Routes", func() {
 	var appNameSimple string
 	var domainName string
 	var orgName string
+	var spaceName string
 
 	curlRoute := func(hostName string, path string) string {
 		uri := Config.Protocol() + hostName + "." + domainName + path
@@ -31,6 +32,7 @@ var _ = AppsDescribe("Wildcard Routes", func() {
 
 	BeforeEach(func() {
 		orgName = TestSetup.RegularUserContext().Org
+		spaceName = TestSetup.RegularUserContext().Space
 
 		domainName = random_name.CATSRandomName("DOMAIN") + "." + Config.GetAppsDomain()
 		workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
@@ -61,7 +63,7 @@ var _ = AppsDescribe("Wildcard Routes", func() {
 		app_helpers.AppReport(appNameSimple)
 
 		workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
-			Expect(cf.Cf("target", "-o", orgName).Wait()).To(Exit(0))
+			Expect(cf.Cf("target", "-o", orgName, "-s", spaceName).Wait()).To(Exit(0))
 			Expect(cf.Cf("delete-shared-domain", domainName, "-f").Wait()).To(Exit(0))
 		})
 
@@ -75,7 +77,7 @@ var _ = AppsDescribe("Wildcard Routes", func() {
 			regularRoute := "bar"
 
 			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
-				Expect(cf.Cf("target", "-o", orgName).Wait()).To(Exit(0))
+				Expect(cf.Cf("target", "-o", orgName, "-s", spaceName).Wait()).To(Exit(0))
 				Expect(cf.Cf("create-route", domainName, "-n", wildCardRoute).Wait()).To(Exit(0))
 			})
 			Expect(cf.Cf("create-route", domainName, "-n", regularRoute).Wait()).To(Exit(0))

--- a/credhub/service_bindings.go
+++ b/credhub/service_bindings.go
@@ -34,7 +34,7 @@ var _ = CredhubDescribe("service bindings", func() {
 
 	BeforeEach(func() {
 		TestSetup.RegularUserContext().TargetSpace()
-		cf.Cf("target", "-o", TestSetup.RegularUserContext().Org)
+		cf.Cf("target", "-o", TestSetup.RegularUserContext().Org, "-s", TestSetup.RegularUserContext().Space)
 
 		chBrokerAppName = random_name.CATSRandomName("BRKR-CH")
 

--- a/credhub/service_keys.go
+++ b/credhub/service_keys.go
@@ -26,7 +26,7 @@ var _ = CredhubDescribe("service keys", func() {
 
 	BeforeEach(func() {
 		TestSetup.RegularUserContext().TargetSpace()
-		cf.Cf("target", "-o", TestSetup.RegularUserContext().Org)
+		cf.Cf("target", "-o", TestSetup.RegularUserContext().Org, "-s", TestSetup.RegularUserContext().Space)
 
 		chBrokerAppName = random_name.CATSRandomName("BRKR-CH")
 

--- a/docker/credhub_enabled.go
+++ b/docker/credhub_enabled.go
@@ -25,7 +25,7 @@ var _ = DockerDescribe("Docker App Lifecycle CredHub Integration", func() {
 
 		JustBeforeEach(func() {
 			TestSetup.RegularUserContext().TargetSpace()
-			cf.Cf("target", "-o", TestSetup.RegularUserContext().Org)
+			cf.Cf("target", "-o", TestSetup.RegularUserContext().Org, "-s", TestSetup.RegularUserContext().Space)
 
 			chBrokerName = random_name.CATSRandomName("BRKR-CH")
 

--- a/windows/credhub_assist.go
+++ b/windows/credhub_assist.go
@@ -31,7 +31,7 @@ var _ = WindowsCredhubDescribe("CredHub Integration", func() {
 
 	BeforeEach(func() {
 		TestSetup.RegularUserContext().TargetSpace()
-		cf.Cf("target", "-o", TestSetup.RegularUserContext().Org)
+		cf.Cf("target", "-o", TestSetup.RegularUserContext().Org, "-s", TestSetup.RegularUserContext().Space)
 
 		chBrokerAppName = random_name.CATSRandomName("BRKR-CH")
 


### PR DESCRIPTION
### What is this change about?

_Describe the change and why it's needed._

Update tests to always target the test space to cause tests to explicitly fail if there are either no spaces in an org, or multiple spaces.

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/174075058

### What version of cf-deployment have you run this cf-acceptance-test change against?

v13.11.0

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in cf-acceptance-tests release notes?

Update tests to always target the test space to cause tests to explicitly fail if there are either no spaces in an org, or multiple spaces.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

cc @paulcwarren 