### PR TITLE
Make test compatible with CLI output format

### DIFF
--- a/apps/admin_buildpack_lifecycle.go
+++ b/apps/admin_buildpack_lifecycle.go
@@ -273,7 +273,8 @@ exit 1
 
 		Expect(push).To(Exit(0))
 		appOutput := cf.Cf("app", appName).Wait()
-		Expect(appOutput).To(Say("buildpacks?:\\s+Simple"))
+		Expect(appOutput).To(Say("buildpacks"))
+		Expect(appOutput).To(Say("Simple"))
 	}
 
 	itDoesNotDetectForEmptyApp := func() {
@@ -346,7 +347,8 @@ exit 1
 			Expect(cf.Cf("push", appName, "-b", buildpackName, "-m", DEFAULT_MEMORY_LIMIT, "-p", appPath).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 			appOutput := cf.Cf("app", appName).Wait()
-			Expect(appOutput).To(Say("buildpacks?:\\s+" + buildpackName))
+			Expect(appOutput).To(Say("buildpacks?:"))
+			Expect(appOutput).To(Say(buildpackName))
 		})
 
 		It("fails if the specified buildpack is disabled", func() {


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?
yes

### What is this change about?
- The CLI output for `cf app` is changing in v7. The buildpacks output will be in table format. This breaks a couple CATS.
- This change makes the tests compatible with the new output as well as the old output.

### Please provide contextual information.
https://www.pivotaltracker.com/story/show/173716617

### What version of cf-deployment have you run this cf-acceptance-test change against?
master

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?
NA

### How should this change be described in cf-acceptance-tests release notes?
NA


### How many more (or fewer) seconds of runtime will this change introduce to CATs?
shouldn't affect runtime


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@cf-cli-eng 