### PR TITLE
change http to http for all iso_seg tests

### DIFF
--- a/isolation_segments/isolation_segments.go
+++ b/isolation_segments/isolation_segments.go
@@ -125,7 +125,7 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 					Config.CfPushTimeoutDuration()).Should(Exit(0))
 
 				hostHeader := fmt.Sprintf("Host: %s.%s", appName, isoSegDomain)
-				host := fmt.Sprintf("http://wildcard-path.%s", isoSegDomain)
+				host := fmt.Sprintf("https://wildcard-path.%s", isoSegDomain)
 
 				curlSession := helpers.CurlSkipSSL(Config.GetSkipSSLValidation(), host, "-H", hostHeader)
 				Eventually(curlSession).Should(Exit(0))
@@ -221,7 +221,7 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 					Config.CfPushTimeoutDuration()).Should(Exit(0))
 
 				hostHeader := fmt.Sprintf("Host: %s.%s", appName, isoSegDomain)
-				host := fmt.Sprintf("http://wildcard-path.%s", isoSegDomain)
+				host := fmt.Sprintf("https://wildcard-path.%s", isoSegDomain)
 
 				curlSession := helpers.CurlSkipSSL(Config.GetSkipSSLValidation(), host, "-H", hostHeader)
 				Eventually(curlSession).Should(Exit(0))

--- a/routing_isolation_segments/routing_isolation_segments.go
+++ b/routing_isolation_segments/routing_isolation_segments.go
@@ -91,7 +91,7 @@ var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
 
 		It("is reachable from the shared router", func() {
 			hostHeader := fmt.Sprintf("Host: %s.%s", appName, appsDomain)
-			host := fmt.Sprintf("http://wildcard-path.%s", appsDomain)
+			host := fmt.Sprintf("https://wildcard-path.%s", appsDomain)
 
 			curlSession := helpers.CurlSkipSSL(Config.GetSkipSSLValidation(), host, "-H", hostHeader)
 			Eventually(curlSession).Should(Exit(0))
@@ -101,7 +101,7 @@ var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
 		It("is not reachable from the isolation segment router", func() {
 			//send a request to app in the shared domain, but through the isolation segment router
 			hostHeader := fmt.Sprintf("Host: %s.%s", appName, appsDomain)
-			host := fmt.Sprintf("http://wildcard-path.%s", isoSegDomain)
+			host := fmt.Sprintf("https://wildcard-path.%s", isoSegDomain)
 
 			curlSession := helpers.CurlSkipSSL(Config.GetSkipSSLValidation(), host, "-H", hostHeader)
 
@@ -137,7 +137,7 @@ var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
 
 		It("the app is reachable from the isolated router", func() {
 			hostHeader := fmt.Sprintf("Host: %s.%s", appName, isoSegDomain)
-			host := fmt.Sprintf("http://wildcard-path.%s", isoSegDomain)
+			host := fmt.Sprintf("https://wildcard-path.%s", isoSegDomain)
 
 			curlSession := helpers.CurlSkipSSL(Config.GetSkipSSLValidation(), host, "-H", hostHeader)
 			Eventually(curlSession).Should(Exit(0))
@@ -146,7 +146,7 @@ var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
 
 		It("the app is not reachable from the shared router", func() {
 			hostHeader := fmt.Sprintf("Host: %s.%s", appName, isoSegDomain)
-			host := fmt.Sprintf("http://wildcard-path.%s", appsDomain)
+			host := fmt.Sprintf("https://wildcard-path.%s", appsDomain)
 
 			curlSession := helpers.CurlSkipSSL(Config.GetSkipSSLValidation(), host, "-H", hostHeader)
 			Eventually(curlSession).Should(Exit(0))


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to master once they've passed acceptance._

### What is this change about?

Changed Isolation_segment tests from http to https (the subsequent code attempts to veryify with ssl-no-verify, it it appears to be a typo.

### Please provide contextual information.

CATS tests were failing in our environments where http is disabled (all access should be via https).

### What version of cf-deployment have you run this cf-acceptance-test change against?

Not sure how to answer.  We've run this against OM 2.10.2, and cf version 6.51.0+2acd15650.2020-04-07

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How should this change be described in cf-acceptance-tests release notes?

All isolation segment tests now require https.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

This change allows the test to pass in HTTPS only environments.

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
`# pcf-eagle`. (find us on Pivotal Slack)