### PR TITLE
Fix CATs to allow it to run in more configuration

### DIFF
--- a/apps/syslog_drain.go
+++ b/apps/syslog_drain.go
@@ -60,7 +60,6 @@ var _ = AppsDescribe("Logging", func() {
 			Eventually(cf.Cf(
 				"push",
 				logWriterAppName2,
-				"--no-start",
 				"-b", Config.GetRubyBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().RubySimple,

--- a/apps/syslog_drain.go
+++ b/apps/syslog_drain.go
@@ -1,7 +1,6 @@
 package apps
 
 import (
-	"regexp"
 	"time"
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
@@ -24,17 +23,14 @@ var _ = AppsDescribe("Logging", func() {
 	var listenerAppName string
 	var logs *Session
 	var interrupt chan struct{}
-	var serviceNames []string
+	var serviceName string
 
 	SkipOnK8s("Not yet supported")
 
 	Describe("Syslog drains", func() {
 		BeforeEach(func() {
 			interrupt = make(chan struct{}, 1)
-			serviceNames = []string{
-				random_name.CATSRandomName("SVIN"),
-				random_name.CATSRandomName("SVIN-INT"),
-			}
+			serviceName = random_name.CATSRandomName("SVIN")
 			listenerAppName = random_name.CATSRandomName("APP-SYSLOG-LISTENER")
 			logWriterAppName1 = random_name.CATSRandomName("APP-FIRST-LOG-WRITER")
 			logWriterAppName2 = random_name.CATSRandomName("APP-SECOND-LOG-WRITER")
@@ -77,34 +73,18 @@ var _ = AppsDescribe("Logging", func() {
 			Eventually(cf.Cf("delete", logWriterAppName1, "-f", "-r")).Should(Exit(0), "Failed to delete app")
 			Eventually(cf.Cf("delete", logWriterAppName2, "-f", "-r")).Should(Exit(0), "Failed to delete app")
 			Eventually(cf.Cf("delete", listenerAppName, "-f", "-r")).Should(Exit(0), "Failed to delete app")
-			for _, serviceName := range serviceNames {
-				if serviceName != "" {
-					Eventually(cf.Cf("delete-service", serviceName, "-f")).Should(Exit(0), "Failed to delete service")
-				}
+			if serviceName != "" {
+				Eventually(cf.Cf("delete-service", serviceName, "-f")).Should(Exit(0), "Failed to delete service")
 			}
 
 			Eventually(cf.Cf("delete-orphaned-routes", "-f"), Config.CfPushTimeoutDuration()).Should(Exit(0), "Failed to delete orphaned routes")
 		})
 
 		It("forwards app messages to registered syslog drains", func() {
-			// The syslog drains return two IP addresses: external & internal.
-			// On a vanilla environment, apps can connect through the syslog service
-			// to the external IP (Diego cell address and external port) of the drain
-			// container.
-			// On NSX-T, apps cannot connect to the external IP, but they can connect
-			// to the internal IP (container IP and port 8080).
-			for i, address := range getSyslogDrainAddresses(listenerAppName) {
-				var syslogDrainURL string
-				if Config.GetRequireProxiedAppTraffic() {
-					syslogDrainURL = "syslog-tls://" + address
-				} else {
-					syslogDrainURL = "syslog://" + address
-				}
+			syslogDrainURL := "https://" + listenerAppName + "." + Config.GetAppsDomain()
 
-				Eventually(cf.Cf("cups", serviceNames[i], "-l", syslogDrainURL)).Should(Exit(0), "Failed to create syslog drain service")
-				Eventually(cf.Cf("bind-service", logWriterAppName1, serviceNames[i])).Should(Exit(0), "Failed to bind service")
-				// We don't need to restage, because syslog service bindings don't change the app's environment variables
-			}
+			Eventually(cf.Cf("cups", serviceName, "-l", syslogDrainURL)).Should(Exit(0), "Failed to create syslog drain service")
+			Eventually(cf.Cf("bind-service", logWriterAppName1, serviceName)).Should(Exit(0), "Failed to bind service")
 
 			randomMessage1 := random_name.CATSRandomName("RANDOM-MESSAGE-A")
 			randomMessage2 := random_name.CATSRandomName("RANDOM-MESSAGE-B")
@@ -120,26 +100,6 @@ var _ = AppsDescribe("Logging", func() {
 		})
 	})
 })
-
-func getSyslogDrainAddresses(appName string) []string {
-	var address, internalAddress []byte
-
-	Eventually(func() [][]byte {
-		re, err := regexp.Compile("EXTERNAL ADDRESS: \\|(.*)\\|; INTERNAL ADDRESS: \\|(.*)\\|")
-		Expect(err).NotTo(HaveOccurred())
-
-		logs := logshelper.Recent(appName).Wait()
-		matched := re.FindSubmatch(logs.Out.Contents())
-		if len(matched) < 3 {
-			return nil
-		}
-		address = matched[1]
-		internalAddress = matched[2]
-		return [][]byte{address, internalAddress}
-	}).Should(Not(BeNil()))
-
-	return []string{string(address), string(internalAddress)}
-}
 
 func writeLogsUntilInterrupted(interrupt chan struct{}, randomMessage string, logWriterAppName string) {
 	defer GinkgoRecover()

--- a/assets/syslog-drain-listener/syslog_drain.go
+++ b/assets/syslog-drain-listener/syslog_drain.go
@@ -1,78 +1,25 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"net"
+	"io/ioutil"
+	"log"
+	"net/http"
 	"os"
-	"time"
 )
 
 func main() {
-	go logIP()
-
 	listenAddress := fmt.Sprintf(":%s", os.Getenv("PORT"))
-	listener, err := net.Listen("tcp", listenAddress)
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Println("Listening for new connections")
-	for {
-		conn, err := listener.Accept()
-		if err != nil {
-			panic(err)
-		}
-		go handleConnection(conn)
-	}
+	http.HandleFunc("/", handleHTTP)
+	panic(http.ListenAndServe(listenAddress, nil))
 }
 
-func handleConnection(conn net.Conn) {
-	buffer := make([]byte, 65536)
-
-	for {
-		n, err := conn.Read(buffer)
-
-		if err == io.EOF {
-			fmt.Println("connection closed")
-			return
-		} else if err != nil {
-			panic(err)
-		}
-
-		message := string(buffer[0:n])
-		fmt.Println(message)
-	}
-}
-
-func logIP() {
-	ip := os.Getenv("CF_INSTANCE_IP")
-	internalIP := os.Getenv("CF_INSTANCE_INTERNAL_IP")
-	portsJson := os.Getenv("CF_INSTANCE_PORTS")
-	ports := []struct {
-		External         uint16 `json:"external"`
-		ExternalTLSProxy uint16 `json:"external_tls_proxy"`
-	}{}
-
-	err := json.Unmarshal([]byte(portsJson), &ports)
+func handleHTTP(resp http.ResponseWriter, req *http.Request) {
+	msg, err := ioutil.ReadAll(req.Body)
 	if err != nil {
-		fmt.Printf("Cannot unmarshal CF_INSTANCE_PORTS: %s", err)
-		os.Exit(1)
+		http.Error(resp, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
-	if len(ports) <= 0 {
-		fmt.Printf("CF_INSTANCE_PORTS is empty")
-		os.Exit(1)
-	}
-
-	port := ports[0].External
-	if port == 0 {
-		port = ports[0].ExternalTLSProxy
-	}
-
-	for {
-		fmt.Printf("EXTERNAL ADDRESS: |%s:%d|; INTERNAL ADDRESS: |%s:8080|\n", ip, port, internalIP)
-		time.Sleep(5 * time.Second)
-	}
+	log.Println(string(msg))
 }

--- a/isolation_segments/isolation_segments.go
+++ b/isolation_segments/isolation_segments.go
@@ -125,7 +125,7 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 					Config.CfPushTimeoutDuration()).Should(Exit(0))
 
 				hostHeader := fmt.Sprintf("Host: %s.%s", appName, isoSegDomain)
-				host := fmt.Sprintf("http://wildcard-path.%s", isoSegDomain)
+				host := fmt.Sprintf(Config.Protocol()+"wildcard-path.%s", isoSegDomain)
 
 				curlSession := helpers.CurlSkipSSL(Config.GetSkipSSLValidation(), host, "-H", hostHeader)
 				Eventually(curlSession).Should(Exit(0))
@@ -221,7 +221,7 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 					Config.CfPushTimeoutDuration()).Should(Exit(0))
 
 				hostHeader := fmt.Sprintf("Host: %s.%s", appName, isoSegDomain)
-				host := fmt.Sprintf("http://wildcard-path.%s", isoSegDomain)
+				host := fmt.Sprintf(Config.Protocol()+"wildcard-path.%s", isoSegDomain)
 
 				curlSession := helpers.CurlSkipSSL(Config.GetSkipSSLValidation(), host, "-H", hostHeader)
 				Eventually(curlSession).Should(Exit(0))

--- a/tasks/task.go
+++ b/tasks/task.go
@@ -269,7 +269,7 @@ var _ = TasksDescribe("v3 tasks", func() {
 
 				By("getting the overlay ip of app")
 				appHostname := appName + "." + Config.GetAppsDomain()
-				curl := helpers.Curl(Config, appHostname, "-L").Wait()
+				curl := helpers.Curl(Config, Config.Protocol()+appHostname, "-L").Wait()
 				contents := curl.Out.Contents()
 
 				var proxyResponse ProxyResponse


### PR DESCRIPTION
This PR consists of three commits that can be reviewed in isolation.  The commit message of each change explains the intention behind the change.

### What is this change about?

We intend to run CATs in our managed environment on AWS.

### Please provide contextual information.

https://vmware.slack.com/messages/C3LUD2L04/p1602100943001300

### What version of cf-deployment have you run this cf-acceptance-test change against?

CATs 5.11.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config


### Did you update the README as appropriate for this change?

- [ ] YES
- [X] N/A

### How should this change be described in cf-acceptance-tests release notes?

I think the three commit messages are good candidates since they are descriptive and brief.  I will include them below:

```
Use https syslog drain URL instead of syslog-tls.
Use Config.Protocol() instead of hard coding the protocol.
Fix the test to reflect the original intention.
```

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

This change will make CATs faster since the Syslog test was simplified and doesn't wait or parse the Syslog listener logs anymore.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@Logiraptor @houlistonm