### PR TITLE
Add uptime counter to dora

### DIFF
--- a/assets/dora/dora.rb
+++ b/assets/dora/dora.rb
@@ -16,6 +16,7 @@ Bundler.require :default, ENV['RACK_ENV'].to_sym
 $stdout.sync = true
 $stderr.sync = true
 $counter = 0
+$start_time = Time.now
 
 class Dora < Sinatra::Base
   use Instances
@@ -117,6 +118,10 @@ class Dora < Sinatra::Base
     size = numKB > fiveMB ? fiveMB : numKB
     size.times {text+=ktext}
     text
+  end
+
+  get '/uptime' do
+    (Time.now - $start_time).to_s
   end
 
   run! if app_file == $0


### PR DESCRIPTION
- Useful for tracking if and when dora restarted

Authored-by: Greg Cobb <gcobb@pivotal.io>

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

CAPI is starting a track of work to avoid unexpected downtime when updating apps.

### Please provide contextual information.

Relevant proposal: https://docs.google.com/document/d/1xMJ6dVSmELHmYAqr9bRIFyBHEfWPbswqwvEuv3bP4D4/edit

### What version of cf-deployment have you run this cf-acceptance-test change against?

N/A

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How should this change be described in cf-acceptance-tests release notes?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**
