### PR TITLE
Split the syslog drain test into a separate suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ include_v3
 
 ##### Optional parameters:
 `include_*` parameters are used to specify whether to skip tests based on how a deployment is configured.
+* `include_app_syslog_tcp`: Flag to include the app syslog drain over TCP test group.
 * `include_apps`: Flag to include the apps test group.
 * `include_container_networking`: Flag to include tests related to container networking.
   `include_security_groups` must also be set for tests to run. [See below](#container-networking-and-application-security-groups)
@@ -168,7 +169,7 @@ include_v3
 * `private_docker_registry_password`: Password to access the private docker repository. [See below](#private-docker)
 * `unallocated_ip_for_security_group`: An unused IP address in the private network used by CF. Defaults to 10.0.244.255. [See below](#container-networking-and-application-security-groups)
 
-* `require_proxied_app_traffic`: Set this to `true` if Diego was configured to require proxied port mappings, i.e. if `containers.proxy.enable_unproxied_port_mappings` is set to `false`.  Note that this also requires using the [cf-syslog-skip-cert-verify](https://github.com/cloudfoundry/cf-deployment/blob/main/operations/cf-syslog-skip-cert-verify.yml).
+* `require_proxied_app_traffic`: Set this to `true` if Diego was configured to require proxied port mappings, i.e. if `containers.proxy.enable_unproxied_port_mappings` is set to `false`.
 
 * `staticfile_buildpack_name` [See below](#buildpack-names)
 * `java_buildpack_name` [See below](#buildpack-names)
@@ -338,6 +339,7 @@ You can of course combine the `-v` flag with the `-nodes=N` flag.
 
 Test Group Name| Description
 --- | ---
+`app_syslog_tcp`| Tests the ability to configure an app syslog drain listener.
 `apps`| Tests the core functionalities of Cloud Foundry: staging, running, logging, routing, buildpacks, etc.  This test group should always pass against a sound Cloud Foundry deployment.
 `credhub`| Tests CredHub-delivered Secure Service credentials in the service binding. [CredHub configuration][credhub-secure-service-credentials] is required to run these tests. In addition to selecting a `credhub_mode`, `credhub_client` and `credhub_secret` values are required for these tests.
 `detect` | Tests the ability of the platform to detect the correct buildpack for compiling an application if no buildpack is explicitly specified.

--- a/app_syslog_tcp/syslog_drain.go
+++ b/app_syslog_tcp/syslog_drain.go
@@ -18,7 +18,7 @@ import (
 	. "github.com/onsi/gomega/gexec"
 )
 
-var _ = AppsDescribe("Logging", func() {
+var _ = AppSyslogTcpDescribe("Syslog Drain over TCP", func() {
 	var logWriterAppName1 string
 	var logWriterAppName2 string
 	var listenerAppName string

--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -37,6 +37,17 @@ func SkipOnK8s(reason string) {
 	})
 }
 
+func AppSyslogTcpDescribe(description string, callback func()) bool {
+	return Describe("[app_syslog_tcp]", func() {
+		BeforeEach(func() {
+			if !Config.GetIncludeAppSyslogTcp() {
+				Skip(skip_messages.SkipAppSyslogTcpMessage)
+			}
+		})
+		Describe(description, callback)
+	})
+}
+
 func AppsDescribe(description string, callback func()) bool {
 	return Describe("[apps]", func() {
 		BeforeEach(func() {

--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/mholt/archiver"
 
+	_ "github.com/cloudfoundry/cf-acceptance-tests/app_syslog_tcp"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/apps"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/credhub"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/detect"

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -5,6 +5,7 @@ import (
 )
 
 type CatsConfig interface {
+	GetIncludeAppSyslogTcp() bool
 	GetIncludeApps() bool
 	GetIncludeContainerNetworking() bool
 	GetIncludeCredhubAssisted() bool

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -66,29 +66,30 @@ type config struct {
 	VolumeServicePlanName     *string `json:"volume_service_plan_name"`
 	VolumeServiceCreateConfig *string `json:"volume_service_create_config"`
 
+	IncludeAppSyslogTcp             *bool `json:"include_app_syslog_tcp"`
 	IncludeApps                     *bool `json:"include_apps"`
 	IncludeContainerNetworking      *bool `json:"include_container_networking"`
+	IncludeDeployments              *bool `json:"include_deployments"`
 	IncludeDetect                   *bool `json:"include_detect"`
 	IncludeDocker                   *bool `json:"include_docker"`
 	IncludeInternetDependent        *bool `json:"include_internet_dependent"`
 	IncludeInternetless             *bool `json:"include_internetless"`
+	IncludeIsolationSegments        *bool `json:"include_isolation_segments"`
 	IncludePrivateDockerRegistry    *bool `json:"include_private_docker_registry"`
 	IncludeRouteServices            *bool `json:"include_route_services"`
 	IncludeRouting                  *bool `json:"include_routing"`
+	IncludeRoutingIsolationSegments *bool `json:"include_routing_isolation_segments"`
 	IncludeSSO                      *bool `json:"include_sso"`
 	IncludeSecurityGroups           *bool `json:"include_security_groups"`
-	IncludeServices                 *bool `json:"include_services"`
 	IncludeServiceDiscovery         *bool `json:"include_service_discovery"`
 	IncludeServiceInstanceSharing   *bool `json:"include_service_instance_sharing"`
+	IncludeServices                 *bool `json:"include_services"`
 	IncludeSsh                      *bool `json:"include_ssh"`
-	IncludeTasks                    *bool `json:"include_tasks"`
 	IncludeTCPRouting               *bool `json:"include_tcp_routing"`
+	IncludeTasks                    *bool `json:"include_tasks"`
 	IncludeV3                       *bool `json:"include_v3"`
-	IncludeDeployments              *bool `json:"include_deployments"`
-	IncludeZipkin                   *bool `json:"include_zipkin"`
-	IncludeIsolationSegments        *bool `json:"include_isolation_segments"`
-	IncludeRoutingIsolationSegments *bool `json:"include_routing_isolation_segments"`
 	IncludeVolumeServices           *bool `json:"include_volume_services"`
+	IncludeZipkin                   *bool `json:"include_zipkin"`
 
 	CredhubMode         *string `json:"credhub_mode"`
 	CredhubLocation     *string `json:"credhub_location"`
@@ -154,6 +155,7 @@ func getDefaults() config {
 	defaults.RubyBuildpackName = ptrToString("ruby_buildpack")
 	defaults.StaticFileBuildpackName = ptrToString("staticfile_buildpack")
 
+	defaults.IncludeAppSyslogTcp = ptrToBool(true)
 	defaults.IncludeApps = ptrToBool(true)
 	defaults.IncludeDetect = ptrToBool(true)
 	defaults.IncludeRouting = ptrToBool(true)
@@ -378,6 +380,9 @@ func validateConfig(config *config) Errors {
 	}
 	if config.StaticFileBuildpackName == nil {
 		errs.Add(fmt.Errorf("* 'staticfile_buildpack_name' must not be null"))
+	}
+	if config.IncludeAppSyslogTcp == nil {
+		errs.Add(fmt.Errorf("* 'include_app_syslog_tcp' must not be null"))
 	}
 	if config.IncludeApps == nil {
 		errs.Add(fmt.Errorf("* 'include_apps' must not be null"))
@@ -824,6 +829,10 @@ func (c *config) GetApiEndpoint() string {
 
 func (c *config) GetIncludeSsh() bool {
 	return *c.IncludeSsh
+}
+
+func (c *config) GetIncludeAppSyslogTcp() bool {
+	return *c.IncludeAppSyslogTcp
 }
 
 func (c *config) GetIncludeApps() bool {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -238,11 +238,11 @@ var _ = Describe("Config", func() {
 		requiredCfgFilePath := writeConfigFile(requiredCfg)
 		config, err := cfg.NewCatsConfig(requiredCfgFilePath)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(config.GetIncludeApps()).To(BeTrue())
 
 		Expect(config.GetIsolationSegmentName()).To(Equal(""))
 		Expect(config.GetIsolationSegmentDomain()).To(Equal(""))
 
+		Expect(config.GetIncludeAppSyslogTcp()).To(BeTrue())
 		Expect(config.GetIncludeApps()).To(BeTrue())
 		Expect(config.GetIncludeDetect()).To(BeTrue())
 		Expect(config.GetIncludeRouting()).To(BeTrue())

--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -1,5 +1,6 @@
 package skip_messages
 
+const SkipAppSyslogTcpMessage = `Skipping this test because config.IncludeAppSyslogTcp is set to 'false'.`
 const SkipAppsMessage = `Skipping this test because config.IncludeApps is set to 'false'.`
 const SkipContainerNetworkingMessage = `Skipping this test because config.IncludeContainerNetworking is set to 'false'.`
 const SkipDetectMessage = `Skipping this test because config.IncludeDetect is set to 'false'.`


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

This change moves the `syslog drain` test to a separate suite to allow it to be skipped while still running the majority of the `apps` suite.

### Please provide contextual information.

The original request to update this test to always use TLS came from PR #441. This was reverted via https://github.com/cloudfoundry/cf-acceptance-tests/commit/7e1089ca9c538664f3b77293e53380b954abc1dc due to CI failures. After discussions with @jvshahid, we decided to move the test to a separate suite to allow it to be skipped.

### What version of cf-deployment have you run this cf-acceptance-test change against?

v15.0.0

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [x] YES
- [ ] N/A

### How should this change be described in cf-acceptance-tests release notes?

Moved the syslog drain test to a new suite to allow it to be skipped on environments that do not allow internal TCP traffic.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@jamespollard8 