### PR TITLE
Use vendir to vendor the logging-route-service sample app

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "assets/logging-route-service"]
-	path = assets/logging-route-service
-	url = https://github.com/cloudfoundry-samples/logging-route-service

--- a/assets/logging-route-service/.gitignore
+++ b/assets/logging-route-service/.gitignore
@@ -1,0 +1,1 @@
+logging-route-service

--- a/assets/logging-route-service/LICENSE
+++ b/assets/logging-route-service/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/assets/logging-route-service/README.md
+++ b/assets/logging-route-service/README.md
@@ -1,0 +1,47 @@
+# Example Route Service
+
+An example route service for Cloud Foundry.
+
+## Route Service Overview
+
+The Route Service feature is currently in development, the proposal can be found in this [Google Doc](https://docs.google.com/document/d/1bGOQxiKkmaw6uaRWGd-sXpxL0Y28d3QihcluI15FiIA/edit#heading=h.8djffzes9pnb).
+
+This example route service uses the new headers/features that have been added to the GoRouter. For example:
+
+- `X-CF-Forwarded-Url`: A header that contains the original URL that the GoRouter received.
+- `X-CF-Proxy-Signature`: A header that the GoRouter uses to determine if a request has gone through the route service.
+
+## Getting Started
+
+- Download this repository and `cf push` to your chosen CF deployment.
+- Push your app which will be associated with the route service.
+- Create a user-provided route service ([see docs](http://docs.cloudfoundry.org/services/route-services.html#user-provided))
+- Bind the route service to the route (domain/hostname)
+- Tail the logs of this route service in order to verify that requests to your app go through the route service. The example logging route service will log requests and responses to and from your app.
+
+## Environment Variables
+
+### ROUTE_SERVICE_SLEEP_MILLI
+
+If you set this environment variable in the running app, the route service
+will sleep for that many milliseconds before proxying the request. This can
+be used to simulate route services that are slow to respond.
+
+Example (10 seconds):
+
+```sh
+cf set-env logging-route-service ROUTE_SERVICE_SLEEP_MILLI 10000
+cf restage logging-route-service
+```
+
+### SKIP_SSL_VALIDATION
+
+Set this environment variable to true in order to skip the validation of SSL certificates.
+By default the route service will attempt to validate certificates.
+
+Example:
+
+```sh
+cf set-env logging-route-service SKIP_SSL_VALIDATION true
+cf restart logging-route-service
+```

--- a/assets/logging-route-service/main.go
+++ b/assets/logging-route-service/main.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	DEFAULT_PORT              = "8080"
+	CF_FORWARDED_URL_HEADER   = "X-Cf-Forwarded-Url"
+	CF_PROXY_SIGNATURE_HEADER = "X-Cf-Proxy-Signature"
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if len(port) == 0 {
+		port = DEFAULT_PORT
+	}
+	skipSslValidation, _ := strconv.ParseBool(os.Getenv("SKIP_SSL_VALIDATION"))
+
+	log.SetOutput(os.Stdout)
+
+	roundTripper := NewLoggingRoundTripper(skipSslValidation)
+	proxy := NewProxy(roundTripper, skipSslValidation)
+
+	log.Fatal(http.ListenAndServe(":"+port, proxy))
+}
+
+func NewProxy(transport http.RoundTripper, skipSslValidation bool) http.Handler {
+	reverseProxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			forwardedURL := req.Header.Get(CF_FORWARDED_URL_HEADER)
+			sigHeader := req.Header.Get(CF_PROXY_SIGNATURE_HEADER)
+
+			var body []byte
+			var err error
+			if req.Body != nil {
+				body, err = ioutil.ReadAll(req.Body)
+				if err != nil {
+					log.Fatalln(err.Error())
+				}
+				req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+			}
+			logRequest(forwardedURL, sigHeader, string(body), req.Header, skipSslValidation)
+
+			err = sleep()
+			if err != nil {
+				log.Fatalln(err.Error())
+			}
+
+			// Note that url.Parse is decoding any url-encoded characters.
+			url, err := url.Parse(forwardedURL)
+			if err != nil {
+				log.Fatalln(err.Error())
+			}
+
+			req.URL = url
+			req.Host = url.Host
+		},
+		Transport: transport,
+	}
+	return reverseProxy
+}
+
+func logRequest(forwardedURL, sigHeader, body string, headers http.Header, skipSslValidation bool) {
+	log.Printf("Skip ssl validation set to %t", skipSslValidation)
+	log.Println("Received request: ")
+	log.Printf("%s: %s\n", CF_FORWARDED_URL_HEADER, forwardedURL)
+	log.Printf("%s: %s\n", CF_PROXY_SIGNATURE_HEADER, sigHeader)
+	log.Println("")
+	log.Printf("Headers: %#v\n", headers)
+	log.Println("")
+	log.Printf("Request Body: %s\n", body)
+}
+
+type LoggingRoundTripper struct {
+	transport http.RoundTripper
+}
+
+func NewLoggingRoundTripper(skipSslValidation bool) *LoggingRoundTripper {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipSslValidation},
+	}
+	return &LoggingRoundTripper{
+		transport: tr,
+	}
+}
+
+func (lrt *LoggingRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	var err error
+	var res *http.Response
+
+	log.Printf("Forwarding to: %s\n", request.URL.String())
+	res, err = lrt.transport.RoundTrip(request)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+	log.Println("")
+	log.Printf("Response Headers: %#v\n", res.Header)
+	log.Println("")
+	log.Printf("Response Body: %s\n", string(body))
+	log.Println("")
+	res.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+
+	log.Println("Sending response to GoRouter...")
+
+	return res, err
+}
+
+func sleep() error {
+	sleepMilliString := os.Getenv("ROUTE_SERVICE_SLEEP_MILLI")
+	if sleepMilliString != "" {
+		sleepMilli, err := strconv.ParseInt(sleepMilliString, 0, 64)
+		if err != nil {
+			return err
+		}
+
+		log.Printf("Sleeping for %d milliseconds\n", sleepMilli)
+		time.Sleep(time.Duration(sleepMilli) * time.Millisecond)
+
+	}
+	return nil
+}

--- a/assets/logging-route-service/manifest.yml
+++ b/assets/logging-route-service/manifest.yml
@@ -1,0 +1,7 @@
+---
+applications:
+- buildpacks:
+  - go_buildpack
+  env:
+    GOVERSION: 1.x
+    GOPACKAGENAME: github.com/cloudfoundry-samples/logging-route-service

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -1,0 +1,9 @@
+apiVersion: vendir.k14s.io/v1alpha1
+directories:
+- contents:
+  - git:
+      commitTitle: 'formatting: conform to new buildpacks syntax...'
+      sha: d025c158fa7da855635fae4240cd8dbf6d2540c5
+    path: .
+  path: assets/logging-route-service
+kind: LockConfig

--- a/vendir.yml
+++ b/vendir.yml
@@ -1,0 +1,18 @@
+# See https://github.com/vmware-tanzu/carvel-vendir/blob/3f713be1c44bbf443658ec3508446102438b9482/docs/vendir-spec.md
+
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+
+# declaration of minimum required vendir binary version (optional)
+minimumRequiredVersion: 0.8.0
+
+directories:
+- path: assets/logging-route-service
+  contents:
+  - path: .
+    git:
+      url: https://github.com/cloudfoundry-samples/logging-route-service
+      ref: origin/master
+    # exclude paths are "placed" on top of include paths (optional)
+    excludePaths:
+    - ".git/**/*"


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

This PR changes the way we vendor `assets/logging-route-service/`.  Instead of using git submodules, the assets are now vendored using [vendir](https://github.com/vmware-tanzu/carvel-vendir).  This change makes it possible to download a self-contained CATs zip file from the Github releases page.  Previously the CATs zip file would be missing the asset mentioned before.

### Please provide contextual information.

https://vmware.slack.com/archives/C3LUD2L04/p1606239248053300


### What version of cf-deployment have you run this cf-acceptance-test change against?

I didn't run the tests.

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [X] N/A

### How should this change be described in cf-acceptance-tests release notes?

Vendor `assets/logging-route-service` using [vendir](https://github.com/vmware-tanzu/carvel-vendir).


### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Zero.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._