### PR TITLE
Add new cat for route service with sticky sessions

### DIFF
--- a/route_services/route_services.go
+++ b/route_services/route_services.go
@@ -3,7 +3,9 @@ package route_services
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
@@ -18,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
 	. "github.com/onsi/gomega/gexec"
 )
 
@@ -34,7 +37,7 @@ var _ = RouteServicesDescribe("Route Services", func() {
 			)
 
 			BeforeEach(func() {
-				routeServiceName = random_name.CATSRandomName("APP")
+				routeServiceName = random_name.CATSRandomName("ROUTE_SVC_APP")
 				brokerName = random_name.CATSRandomName("BRKR")
 				serviceInstanceName = random_name.CATSRandomName("SVIN")
 				appName = random_name.CATSRandomName("APP")
@@ -87,6 +90,59 @@ var _ = RouteServicesDescribe("Route Services", func() {
 					Expect(logs.Wait()).To(Exit(0))
 					return logs
 				}).Should(Say("Response Body: go, world"))
+			})
+
+			Context("with sticky sessions", func() {
+				var doraAppName, cookieStorePath string
+
+				BeforeEach(func() {
+					doraAppName = random_name.CATSRandomName("DORA")
+
+					Expect(cf.Push(doraAppName,
+						"-p", assets.NewAssets().Dora,
+					).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+					bindRouteToService(doraAppName, serviceInstanceName)
+					Expect(cf.Cf("scale", doraAppName, "-i", "3").Wait()).To(Exit(0))
+
+					cookieStore, err := ioutil.TempFile("", "cats-sticky-session")
+					Expect(err).ToNot(HaveOccurred())
+					cookieStorePath = cookieStore.Name()
+					cookieStore.Close()
+				})
+
+				AfterEach(func() {
+					app_helpers.AppReport(doraAppName)
+
+					unbindRouteFromService(doraAppName, serviceInstanceName)
+					Expect(cf.Cf("delete", doraAppName, "-f", "-r").Wait()).To(Exit(0))
+
+					err := os.Remove(cookieStorePath)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("routes through the route service to the same app instance every time", func() {
+					// It is up
+					Eventually(func() *Session {
+						helpers.CurlAppRoot(Config, doraAppName)
+						logs := logshelper.Recent(routeServiceName)
+						Expect(logs.Wait()).To(Exit(0))
+						return logs
+					}).Should(Say("Response Body: Hi, I'm Dora!"))
+
+					// JsessionID is set in the cookie
+					body := curlAppWithCookies(doraAppName, "/session", cookieStorePath)
+					Expect(body).To(ContainSubstring("Please read the README.md for help on how to use sticky sessions."))
+
+					// get instance guid for the app it is sticky to
+					appGuid := curlAppWithCookies(doraAppName, "/id", cookieStorePath)
+
+					// get instance guid a bunch of times and see that it is routed to the same instance every time
+					for i := 0; i < 10; i++ {
+						body := curlAppWithCookies(doraAppName, "/id", cookieStorePath)
+						Expect(body).To(Equal(appGuid))
+					}
+				})
 			})
 		})
 
@@ -306,4 +362,11 @@ func initiateBrokerConfig(serviceName, serviceBrokerAppName string) {
 	Expect(err).NotTo(HaveOccurred())
 
 	helpers.CurlApp(Config, serviceBrokerAppName, "/config", "-X", "POST", "-d", string(changedJson))
+}
+
+func curlAppWithCookies(appName, path string, cookieStorePath string) string {
+	uri := helpers.AppUri(appName, path, Config)
+	curlCmd := helpers.Curl(Config, uri, "-b", cookieStorePath, "-c", cookieStorePath).Wait(helpers.CURL_TIMEOUT)
+	Expect(curlCmd).To(gexec.Exit(0))
+	return string(curlCmd.Out.Contents())
 }


### PR DESCRIPTION
⚠️⚠️⚠️⚠️ This PR will fail until a new version of routing release is cut. This will likely be 0.211.0.

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Adding new cat for route service with sticky sessions.


### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._
* [#175826411](https://www.pivotaltracker.com/story/show/175826411)


### What version of cf-deployment have you run this cf-acceptance-test change against?
v15.5.0


### Please check all that apply for this PR:
- [X] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

All tests for sticky session and route services are already in CATs. This CAT proves that these two features work together.


### How should this change be described in cf-acceptance-tests release notes?

add new cat for route service with sticky sessions



### How many more (or fewer) seconds of runtime will this change introduce to CATs?
It's a new CAT that pushes an app and a route service. Likely ~200.


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**


### Tag your pair, your PM, and/or team!
@cloudfoundry/runtime 
