### PR TITLE
Add a restart to multi-port test

### DIFF
--- a/routing/multiple_app_ports.go
+++ b/routing/multiple_app_ports.go
@@ -72,6 +72,8 @@ var _ = RoutingDescribe("Multiple App Ports", func() {
 				Port: 7777,
 			}
 			InsertDestinations(getRouteGuid(secondRouteHostname), []Destination{destination})
+
+			Expect(cf.Cf("restart", appName, "--strategy", "rolling").Wait()).To(Exit(0))
 		})
 
 		It("should listen on multiple ports", func() {


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._

Yes.

### What is this change about?

CAPI has been working on implementing zero downtime updates for certain attributes, one of which is changing an app's ports. Making changes to an app's ports now requires a restart for the changes to take effect. 

This commit reflects that change by adding a `cf restart --strategy rolling` to the "Multiple App Ports" test.

### Please provide contextual information.

Link to the tracker epic: https://www.pivotaltracker.com/epic/show/4691338


### What version of cf-deployment have you run this cf-acceptance-test change against?

Latest release candidate (https://github.com/cloudfoundry/cf-deployment/commit/0cb79eba4528ce34dad24a7e1271bc3a0492345f).

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A


### How should this change be described in cf-acceptance-tests release notes?

May be worth calling out this new behavior for future test contributors, but nothing required for this immediate change.


### How many more (or fewer) seconds of runtime will this change introduce to CATs?

+10 seconds

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@sweinstein22 
