### PR TITLE
UAA v75 CAT flakes

### DIFF
--- a/helpers/services/sso.go
+++ b/helpers/services/sso.go
@@ -117,7 +117,7 @@ func AuthorizeScopes(cookie string, config OAuthConfig) (authCode string) {
 	Expect(curl).To(Exit(0))
 	apiResponse := string(curl.Out.Contents())
 
-	pattern := fmt.Sprintf(`%v\?code=([a-zA-Z0-9]+)`, regexp.QuoteMeta(config.RedirectUri))
+	pattern := fmt.Sprintf(`%v\?code=([^&\r\n]+)`, regexp.QuoteMeta(config.RedirectUri))
 	regEx, _ := regexp.Compile(pattern)
 
 	stringMatch := regEx.FindStringSubmatch(apiResponse)


### PR DESCRIPTION
* The test was expecting the UAA authorization code to only contain
  letters and numbers, which was a incorrect expectation. For example,
  as of today, the code can contain dashes "-".

* The regex was updated so that the code can contain any character. If
  the UAA decides one day to add another CGI parameter to the redirect
  URL, the test won't break because of the "^&" in the regex.

* The '\r' and '\n' are there to end the regex match at the end of the
  line.

* For context, this is what an UAA API response looks like. See line 6
  the code we are trying to extract.

HTTP/2 302
cache-control: no-store
content-language: en-US
content-length: 0
date: Tue, 02 Feb 2021 22:10:17 GMT
location: http://example.com?code=gfCMdm9L3P                # <- code here
strict-transport-security: max-age=31536000
x-content-type-options: nosniff
x-frame-options: DENY
x-vcap-request-id: 82abfda5-bf9c-4790-726a-b45d20d8883c
x-xss-protection: 1; mode=block
via: 1.1 google
alt-svc: clear

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes!


### What is this change about?

Fixing the CATs compatibility with UAA.


### Please provide contextual information.

https://cloudfoundry.slack.com/archives/C03FXANBV/p1612201884012700


### What version of cf-deployment have you run this cf-acceptance-test change against?

latest


### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

0

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@reedr3 , @peterhaochen47 