### PR TITLE
Make app summary memory and disk units optional

### DIFF
--- a/apps/lifecycle.go
+++ b/apps/lifecycle.go
@@ -226,7 +226,7 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 
 			Context("is able to retrieve container metrics", func() {
 				// #0   running   2015-06-10 02:22:39 PM   0.0%   48.7M of 2G   14M of 1G
-				var metrics = regexp.MustCompile(`running.*(?:[\d\.]+)%\s+([\d\.]+)[KMG]? of (?:[\d\.]+)[KMG]\s+([\d\.]+)[KMG]? of (?:[\d\.]+)[KMG]`)
+				var metrics = regexp.MustCompile(`running.*(?:[\d\.]+)%\s+([\d\.]+)[KMG]? of (?:[\d\.]+)[KMG]?\s+([\d\.]+)[KMG]? of (?:[\d\.]+)[KMG]?`)
 				memdisk := func() (float64, float64) {
 					app := cf.Cf("app", appName)
 					Expect(app.Wait()).To(Exit(0))


### PR DESCRIPTION
### What is this change about?

We recently changed the process stats endpoint to return the actual disk and memory quotas rather than the desired quotas from the cloud controller database. When these metrics have not been propagated to log cache, ccng returns zeros, and the CLI does not display units.

### Please provide contextual information.

Associated Github Issue: https://github.com/cloudfoundry/cloud_controller_ng/issues/2098

### What version of cf-deployment have you run this cf-acceptance-test change against?

Latest

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in cf-acceptance-tests release notes?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

0 seconds

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@sethboyles @tstannard @elenasharma 