### PR TITLE
Update result for v8 service output

### DIFF
--- a/services/service_instance_sharing.go
+++ b/services/service_instance_sharing.go
@@ -123,7 +123,7 @@ var _ = ServiceInstanceSharingDescribe("Service Instance Sharing", func() {
 
 				sharedToCmd := cf.Cf("service", serviceInstanceName).Wait()
 				Expect(sharedToCmd).To(Exit(0))
-				Expect(sharedToCmd).To(Say("shared with spaces"))
+				Expect(sharedToCmd).To(Say("Shared with spaces"))
 			})
 		})
 

--- a/services/service_instance_sharing.go
+++ b/services/service_instance_sharing.go
@@ -2,7 +2,6 @@ package services_test
 
 import (
 	"encoding/json"
-
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/workflowhelpers"
@@ -123,7 +122,7 @@ var _ = ServiceInstanceSharingDescribe("Service Instance Sharing", func() {
 
 				sharedToCmd := cf.Cf("service", serviceInstanceName).Wait()
 				Expect(sharedToCmd).To(Exit(0))
-				Expect(sharedToCmd).To(Say("Shared with spaces"))
+				Expect(sharedToCmd).To(Say("[S|s]hared with spaces"))
 			})
 		})
 


### PR DESCRIPTION
[#176882923](https://www.pivotaltracker.com/story/show/176882923)

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._



### What is this change about?

v8 CLI output has changed for services. This fix should make CATs pass for [v8 CLI](https://ci.cli.fun/teams/main/pipelines/v8/jobs/cats/builds/184.1). 



### Please provide contextual information.

[#176882923](https://www.pivotaltracker.com/story/show/176882923)
[v8 CLI pipeline](https://ci.cli.fun/teams/main/pipelines/v8/jobs/cats/builds/184.1)

### What version of cf-deployment have you run this cf-acceptance-test change against?


### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A


### What is the level of urgency for publishing this change?

- [] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@cloudfoundry/services-api 