### PR TITLE
Update logging-route-service test app to work with Go Buildpack v1.9.27

### DIFF
--- a/assets/logging-route-service/manifest.yml
+++ b/assets/logging-route-service/manifest.yml
@@ -5,3 +5,4 @@ applications:
   env:
     GOVERSION: 1.x
     GOPACKAGENAME: github.com/cloudfoundry-samples/logging-route-service
+    GO111MODULE: off


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Go buildpack [v1.9.27](https://github.com/cloudfoundry/go-buildpack/releases/tag/v1.9.27) sets `GO111MODULE=auto` by default (note the release notes state `GO111MODULES` but the actual env var is [`GO111MODULE`](https://blog.golang.org/modules2019) without the 's'). As the logging route service test app does not contain a `go.mod` file it now requires `GO111MODULE=off` to be set explicitly for staging to be successful.

### What version of cf-deployment have you run this cf-acceptance-test change against?

Go buildpack v1.9.27 is not yet in a cf-deployment version, but I have tested this against a Cloud Foundry based on cf-deployment v16.5.0 running Go buildpack v1.9.27. Setting `GO111MODULE=off` explicitly should not alter functionality of the test app for any other versions of the Go buildpack as it will either be ignored, or would have automatically been set to `off` anyway.

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config


### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?
n/a


### How should this change be described in cf-acceptance-tests release notes?

_Update logging route service test app for Go buildpack v1.9.27 compatibility_

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

0

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**


### Tag your pair, your PM, and/or team!
n/a