### PR TITLE
Remove go version

### DIFF
--- a/assets/logging-route-service/manifest.yml
+++ b/assets/logging-route-service/manifest.yml
@@ -3,5 +3,4 @@ applications:
 - buildpacks:
   - go_buildpack
   env:
-    GOVERSION: 1.x
     GOPACKAGENAME: github.com/cloudfoundry-samples/logging-route-service


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._



### What is this change about?

Removing go specific version from a test app manifest. The latest go version 1.16 does not compile test apps in this repo.


### Please provide contextual information.

[Slack thread](https://vmware.slack.com/archives/C3LV25ZCM/p1617814780120600)

### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [x] YES
- [ ] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._



### How should this change be described in cf-acceptance-tests release notes?

_Something brief that conveys the change and is written with the component author audience in mind._



### How many more (or fewer) seconds of runtime will this change introduce to CATs?



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
