### PR TITLE
Revert "[#178937872] Adds TCP routing tests to apps on isolation segments"

### DIFF
--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -2,8 +2,6 @@ package cats_suite_helpers
 
 import (
 	"fmt"
-	"net"
-	"regexp"
 	"strings"
 	"time"
 
@@ -55,17 +53,6 @@ func AppsDescribe(description string, callback func()) bool {
 		BeforeEach(func() {
 			if !Config.GetIncludeApps() {
 				Skip(skip_messages.SkipAppsMessage)
-			}
-		})
-		Describe(description, callback)
-	})
-}
-
-func IsolatedTCPRoutingDescribe(description string, callback func()) bool {
-	return Describe("[tcp routing]", func() {
-		BeforeEach(func() {
-			if Config.GetIncludeRoutingIsolationSegments() || !Config.GetIncludeTCPRouting() || !Config.GetIncludeIsolationSegments() {
-				Skip(skip_messages.SkipIsolatedTCPRoutingMessage)
 			}
 		})
 		Describe(description, callback)
@@ -356,64 +343,4 @@ func VolumeServicesDescribe(description string, callback func()) bool {
 		})
 		Describe(description, callback)
 	})
-}
-
-func GetNServerResponses(n int, domainName, externalPort1 string) ([]string, error) {
-	var responses []string
-
-	for i := 0; i < n; i++ {
-		resp, err := SendAndReceive(domainName, externalPort1)
-		if err != nil {
-			return nil, err
-		}
-
-		responses = append(responses, resp)
-	}
-
-	return responses, nil
-}
-
-func MapTCPRoute(appName, domainName string) string {
-	createRouteSession := cf.Cf("map-route", appName, domainName).Wait()
-	Expect(createRouteSession).To(Exit(0))
-
-	r := regexp.MustCompile(fmt.Sprintf(`.+%s:(\d+).+`, domainName))
-	return r.FindStringSubmatch(string(createRouteSession.Out.Contents()))[1]
-}
-
-func SendAndReceive(addr string, externalPort string) (string, error) {
-	address := fmt.Sprintf("%s:%s", addr, externalPort)
-
-	conn, err := net.Dial("tcp", address)
-	if err != nil {
-		return "", err
-	}
-	defer conn.Close()
-
-	message := []byte(fmt.Sprintf("Time is %d", time.Now().Nanosecond()))
-
-	_, err = conn.Write(message)
-	if err != nil {
-		if ne, ok := err.(*net.OpError); ok {
-			if ne.Temporary() {
-				return SendAndReceive(addr, externalPort)
-			}
-		}
-
-		return "", err
-	}
-
-	buff := make([]byte, 1024)
-	_, err = conn.Read(buff)
-	if err != nil {
-		if ne, ok := err.(*net.OpError); ok {
-			if ne.Temporary() {
-				return SendAndReceive(addr, externalPort)
-			}
-		}
-
-		return "", err
-	}
-
-	return string(buff), nil
 }

--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -38,7 +38,6 @@ const SkipWindowsMessage = `Skipping this test because config.IncludeWindows is 
 NOTE: Ensure that your deployment includes at least one Windows cell before enabling this test.`
 const SkipWindowsContextPathsMessage = `Skipping this test because config.UseWindowsContextPath is set to 'false'.
 NOTE: Ensure that your deployment includes at least one Windows cell before enabling this test.`
-const SkipIsolatedTCPRoutingMessage = `Skipping this test because either or both of config.IncludeTCPRouting and config.IncludeIsolationSegments is set to 'false', or config.IncludeRoutingIsolationSegments is set to 'true'.`
 const SkipIsolationSegmentsMessage = `Skipping this test because config.IncludeIsolationSegments is set to 'false'`
 const SkipRoutingIsolationSegmentsMessage = `Skipping this test because Config.IncludeRoutingIsolationSegments is set to 'false'.`
 const SkipZipkinMessage = `Skipping this test because config.IncludeZipkin is set to 'false'`


### PR DESCRIPTION
Reverts cloudfoundry/cf-acceptance-tests#474

- we saw repeated failures in CI (for example, see https://release-integration.ci.cf-app.com/teams/main/pipelines/cf-deployment/jobs/upgrade-cats/builds/3204)