### PR TITLE
oneline http/2 test suite refactor

### DIFF
--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -145,6 +145,7 @@ func HTTP2RoutingDescribe(description string, callback func()) bool {
 				Skip(skip_messages.SkipHTTP2RoutingMessage)
 			}
 		})
+		SkipOnK8s("Not yet supported in CF-for-K8s")
 		Describe(description, callback)
 	})
 }

--- a/http2_routing/http2_routing.go
+++ b/http2_routing/http2_routing.go
@@ -21,7 +21,6 @@ import (
 )
 
 var _ = HTTP2RoutingDescribe("HTTP/2 Routing", func() {
-	SkipOnK8s("Not yet supported in CF-for-K8s")
 
 	Context("when a destination only supports HTTP/2", func() {
 		It("routes traffic to that destination over HTTP/2", func() {


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?
yes 

### What is this change about?

It was confusing to see some conditional switch behavior explicitly called out in a given test (`http2_routing/http2_routing.go`), and some abstracted away behind `HTTP2RoutingDescribe`, which appears to be a helper function pattern.

### Please provide contextual information.

I don't have a strong feeling whether we keep variable test-specific behavior (e.g. skip-on-k8s, skip-on-config-flag)
- tucked away in a Describe helper, or
- called explicitly (e.g. where SkipOnK8s used to be invoked)
However, it was confusing to find the SkipOnK8s call, and too easy to ignore the fact that the Describe was in fact a wrapper. In other words, I would expect consistency of one or the other pattern

### What version of cf-deployment have you run this cf-acceptance-test change against?

Currently runnning against the current version of cf-deployment used by toolsmiths, which appears to be v16.23.0

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config


### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A



### How should this change be described in cf-acceptance-tests release notes?

N/A


### How many more (or fewer) seconds of runtime will this change introduce to CATs?
0

### What is the level of urgency for publishing this change?
- [ ] not urgent


### Tag your pair, your PM, and/or team!
@Benjamintf1 