### PR TITLE
Add tests for user-provided services

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ include_v3
 * `include_sso`: Flag to include the services tests that integrate with Single Sign On. `include_services` must also be set for tests to run.
 * `include_tasks`: Flag to include the v3 task tests. `include_v3` must also be set for tests to run. The CC API task_creation feature flag must be enabled for these tests to pass.
 * `include_tcp_routing`: Flag to include the TCP Routing tests. These tests are equivalent to the [TCP Routing tests](https://github.com/cloudfoundry/routing-acceptance-tests/blob/master/tcp_routing/tcp_routing_test.go) from the Routing Acceptance Tests.
+* `include_user_provided_services`: Flag to include test for user-provided services.
 * `include_v3`: Flag to include tests for the v3 API.
 * `include_zipkin`: Flag to include tests for Zipkin tracing. `include_routing` must also be set for tests to run. CF must be deployed with `router.tracing.enable_zipkin` set for tests to pass.
 * `use_http`: Set to true if you would like CF Acceptance Tests to use HTTP when making api and application requests. (default is HTTPS)
@@ -355,6 +356,7 @@ Test Group Name| Description
 `ssh`| Tests communication with Diego apps via ssh, scp, and sftp.
 `tasks`| Tests Cloud Foundry's [Tasks](https://docs.cloudfoundry.org/devguide/using-tasks.html) feature.
 `tcp_routing`| Tests TCP Routing Feature of Cloud Foundry. You need to make sure you've set up a TCP domain `tcp.<SYSTEM_DOMAIN>` as described [here](https://docs.cloudfoundry.org/adminguide/enabling-tcp-routing.html). If you are using `bbl` (BOSH Bootloader), TCP domain is set up for you automatically.
+`user_provided_services` | Tests features related to creating and binding user-provided services for holding app credentials securely.
 `v3`| This test group contains tests for the next-generation v3 Cloud Controller API.
 `volume_services` | Tests the [Volume Services](https://docs.cloudfoundry.org/devguide/services/using-vol-services.html) feature of Cloud Foundry.
 

--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -230,6 +230,17 @@ func ServiceInstanceSharingDescribe(description string, callback func()) bool {
 	})
 }
 
+func UserProvidedServicesDescribe(description string, callback func()) bool {
+	return Describe("[user provided services]", func() {
+		BeforeEach(func() {
+			if !Config.GetIncludeUserProvidedServices() {
+				Skip(skip_messages.SkipUserProvidedServicesMessage)
+			}
+		})
+		Describe(description, callback)
+	})
+}
+
 func SshDescribe(description string, callback func()) bool {
 	return Describe("[ssh]", func() {
 		BeforeEach(func() {

--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/cloudfoundry/cf-acceptance-tests/ssh"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/tasks"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/tcp_routing"
+	_ "github.com/cloudfoundry/cf-acceptance-tests/user_provided_services"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/v3"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/volume_services"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/windows"

--- a/example-cats-config.json
+++ b/example-cats-config.json
@@ -30,6 +30,7 @@ IN DEVELOPMENT
   "include_ssh": true,
   "include_sso": true,
   "include_tasks": true,
+  "include_user_provided_services": true,
   "include_v3": true,
   "include_zipkin": true,
   "include_volume_services": false,

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -20,6 +20,7 @@ type CatsConfig interface {
 	GetIncludeSSO() bool
 	GetIncludeSecurityGroups() bool
 	GetIncludeServices() bool
+	GetIncludeUserProvidedServices() bool
 	GetIncludeServiceDiscovery() bool
 	GetIncludeSsh() bool
 	GetIncludeTasks() bool

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -83,6 +83,7 @@ type config struct {
 	IncludeServiceDiscovery         *bool `json:"include_service_discovery"`
 	IncludeServiceInstanceSharing   *bool `json:"include_service_instance_sharing"`
 	IncludeServices                 *bool `json:"include_services"`
+	IncludeUserProvidedServices     *bool `json:"include_user_provided_services"`
 	IncludeSsh                      *bool `json:"include_ssh"`
 	IncludeTCPIsolationSegments     *bool `json:"include_tcp_isolation_segments"`
 	IncludeHTTP2Routing             *bool `json:"include_http2_routing"`
@@ -179,6 +180,7 @@ func getDefaults() config {
 	defaults.IncludeSecurityGroups = ptrToBool(false)
 	defaults.IncludeServiceDiscovery = ptrToBool(false)
 	defaults.IncludeServices = ptrToBool(false)
+	defaults.IncludeUserProvidedServices = ptrToBool(false)
 	defaults.IncludeSsh = ptrToBool(false)
 	defaults.IncludeTasks = ptrToBool(false)
 	defaults.IncludeZipkin = ptrToBool(false)
@@ -426,6 +428,9 @@ func validateConfig(config *config) Errors {
 	}
 	if config.IncludeServices == nil {
 		errs.Add(fmt.Errorf("* 'include_services' must not be null"))
+	}
+	if config.IncludeUserProvidedServices == nil {
+		errs.Add(fmt.Errorf("* 'include_user_provided_services' must not be null"))
 	}
 	if config.IncludeServiceInstanceSharing == nil {
 		errs.Add(fmt.Errorf("* 'include_service_instance_sharing' must not be null"))
@@ -912,6 +917,10 @@ func (c *config) GetIncludeSecurityGroups() bool {
 
 func (c *config) GetIncludeServices() bool {
 	return *c.IncludeServices
+}
+
+func (c *config) GetIncludeUserProvidedServices() bool {
+	return *c.IncludeUserProvidedServices
 }
 
 func (c *config) GetIncludeSSO() bool {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -134,6 +134,7 @@ type allConfig struct {
 	IncludeSSO                      *bool `json:"include_sso"`
 	IncludeSecurityGroups           *bool `json:"include_security_groups"`
 	IncludeServices                 *bool `json:"include_services"`
+	IncludeUserProvidedServices     *bool `json:"include_user_provided_services"`
 	IncludeServiceInstanceSharing   *bool `json:"include_service_instance_sharing"`
 	IncludeSsh                      *bool `json:"include_ssh"`
 	IncludeTasks                    *bool `json:"include_tasks"`
@@ -255,6 +256,7 @@ var _ = Describe("Config", func() {
 		Expect(config.GetIncludeContainerNetworking()).To(BeFalse())
 		Expect(config.GetIncludeSecurityGroups()).To(BeFalse())
 		Expect(config.GetIncludeServices()).To(BeFalse())
+		Expect(config.GetIncludeUserProvidedServices()).To(BeFalse())
 		Expect(config.GetIncludeSsh()).To(BeFalse())
 		Expect(config.GetIncludeIsolationSegments()).To(BeFalse())
 		Expect(config.GetIncludeRoutingIsolationSegments()).To(BeFalse())
@@ -379,6 +381,7 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(ContainSubstring("'include_sso' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_security_groups' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_services' must not be null"))
+			Expect(err.Error()).To(ContainSubstring("'include_user_provided_services' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_service_instance_sharing' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_ssh' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_tasks' must not be null"))

--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -25,6 +25,7 @@ const SkipTCPRoutingMessage = `Skipping this test because config.IncludeTCPRouti
 const SkipSecurityGroupsMessage = `Skipping this test because config.IncludeSecurityGroups is set to 'false'.
 NOTE: Ensure that your platform restricts internal network traffic by default in order to run this test.`
 const SkipServicesMessage = `Skipping this test because config.IncludeServices is set to 'false'.`
+const SkipUserProvidedServicesMessage = `Skipping this test because config.IncludeUserProvidedServices is set to 'false'.`
 const SkipSSHMessage = `Skipping this test because config.IncludeSsh is set to 'false'.
 NOTE: Ensure that your platform is deployed with a Diego SSH proxy in order to run this test.`
 const SkipSSOMessage = `Skipping this test because config.IncludeSSO is not set to 'true'.

--- a/user_provided_services/lifecycle.go
+++ b/user_provided_services/lifecycle.go
@@ -1,0 +1,239 @@
+package user_provided_services_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
+
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+type LastOperation struct {
+	State string `json:"state"`
+}
+
+type Resource struct {
+	Name          string `json:"name"`
+	GUID          string
+	LastOperation LastOperation `json:"last_operation"`
+}
+
+type Response struct {
+	Resources []Resource `json:"resources"`
+}
+
+type ErrorResponse struct {
+	ErrorCode string `json:"error_code"`
+}
+
+var _ = UserProvidedServicesDescribe("Service Instance Lifecycle", func() {
+	Context("service instances with no bindings", func() {
+		var instanceName string
+		AfterEach(func() {
+			if instanceName != "" {
+				Expect(cf.Cf("delete-service", instanceName, "-f").Wait()).To(Exit(0))
+			}
+		})
+
+		It("can create a service instance", func() {
+			tags := "['tag1', 'tag2']"
+			creds := `{"param1": "value"}`
+
+			instanceName = random_name.CATSRandomName("SVIN")
+			createService := cf.Cf("create-user-provided-service", instanceName, "-p", creds, "-t", tags).Wait()
+			Expect(createService).To(Exit(0))
+
+			serviceInfo := cf.Cf("-v", "service", instanceName).Wait()
+			Expect(serviceInfo).To(Say("(service|type):\\s+user-provided"))
+			Expect(serviceInfo.Out.Contents()).To(MatchRegexp(`"tags":\s*\[\n.*tag1.*\n.*tag2.*\n.*\]`))
+		})
+
+		Context("when there is an existing service instance", func() {
+			BeforeEach(func() {
+				creds := `{"param1": "value"}`
+				instanceName = random_name.CATSRandomName("SVIN")
+				createService := cf.Cf("create-user-provided-service", instanceName, "-p", creds).Wait()
+				Expect(createService).To(Exit(0))
+			})
+
+			It("fetch the credentials", func() {
+				instanceGUID := getGuidFor("service", instanceName)
+				credentials := cf.Cf("curl", fmt.Sprintf("/v3/service_instances/%s/credentials", instanceGUID)).Wait()
+				Expect(credentials).To(Exit(0), "failed to curl fetch credentials")
+				Expect(credentials).To(Say(`"param1": "value"`))
+			})
+
+			It("can delete a service instance", func() {
+				deleteService := cf.Cf("delete-service", instanceName, "-f").Wait()
+				Expect(deleteService).To(Exit(0))
+
+				serviceInfo := cf.Cf("service", instanceName).Wait()
+				combinedBuffer := BufferWithBytes(append(serviceInfo.Out.Contents(), serviceInfo.Err.Contents()...))
+				Expect(combinedBuffer).To(Say("not found"))
+			})
+
+			Context("updating a service instance", func() {
+				tags := "['tag1', 'tag2']"
+
+				It("can rename a service", func() {
+					newname := "newname"
+					updateService := cf.Cf("rename-service", instanceName, newname).Wait()
+					Expect(updateService).To(Exit(0))
+
+					serviceInfo := cf.Cf("service", newname).Wait()
+					Expect(serviceInfo).To(Say(newname))
+
+					serviceInfo = cf.Cf("service", instanceName).Wait()
+					Expect(serviceInfo).To(Exit(1))
+				})
+
+				It("can update service credentials", func() {
+					newCreds := `{"param2": "newValue"}`
+					updateService := cf.Cf("update-user-provided-service", instanceName, "-p", newCreds).Wait()
+					Expect(updateService).To(Exit(0))
+
+					instanceGUID := getGuidFor("service", instanceName)
+					credentials := cf.Cf("curl", fmt.Sprintf("/v3/service_instances/%s/credentials", instanceGUID)).Wait()
+					Expect(credentials).To(Exit(0), "failed to curl fetch credentials")
+					Expect(credentials).To(Say(`"param2": "newValue"`))
+				})
+
+				It("can update service tags", func() {
+					updateService := cf.Cf("update-user-provided-service", instanceName, "-t", tags).Wait()
+					Expect(updateService).To(Exit(0))
+
+					serviceInfo := cf.Cf("-v", "service", instanceName).Wait()
+					Expect(serviceInfo.Out.Contents()).To(MatchRegexp(`"tags":\s*\[\n.*tag1.*\n.*tag2.*\n.*\]`))
+				})
+			})
+		})
+	})
+
+	Context("service instances with bindings", func() {
+		var instanceName, appName, username string
+
+		BeforeEach(func() {
+			appName = random_name.CATSRandomName("APP")
+			createApp := cf.Cf(app_helpers.CatnipWithArgs(
+				appName,
+				"-m", DEFAULT_MEMORY_LIMIT)...,
+			).Wait(Config.CfPushTimeoutDuration())
+			Expect(createApp).To(Exit(0), "failed creating app")
+
+			checkForAppEvent(appName, "audit.app.create")
+
+			username = random_name.CATSRandomName("CREDENTIAL")
+			creds := fmt.Sprintf(`{"username": "%s"}`, username)
+			instanceName = random_name.CATSRandomName("SVIN")
+			createService := cf.Cf("create-user-provided-service", instanceName, "-p", creds).Wait()
+			Expect(createService).To(Exit(0), "failed creating service")
+		})
+
+		AfterEach(func() {
+			app_helpers.AppReport(appName)
+			Expect(cf.Cf("delete", appName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			Expect(cf.Cf("delete-service", instanceName, "-f").Wait()).To(Exit(0))
+		})
+
+		Describe("bindings", func() {
+			It("can bind service to app and check app env and events", func() {
+				bindService := cf.Cf("bind-service", appName, instanceName).Wait()
+				Expect(bindService).To(Exit(0), "failed binding app to service")
+
+				checkForAppEvent(appName, "audit.app.update")
+
+				appEnv := cf.Cf("env", appName).Wait()
+				Expect(appEnv).To(Exit(0), "failed get env for app")
+				Expect(appEnv).To(Say("credentials"))
+
+				restartApp := cf.Cf("restart", appName).Wait(Config.CfPushTimeoutDuration())
+				Expect(restartApp).To(Exit(0), "failed restarting app")
+
+				Expect(helpers.CurlApp(Config, appName, "/env/VCAP_SERVICES")).Should(ContainSubstring(username))
+			})
+
+			Context("when there is an existing binding", func() {
+				BeforeEach(func() {
+					bindService := cf.Cf("bind-service", appName, instanceName).Wait()
+					Expect(bindService).To(Exit(0), "failed binding app to service")
+				})
+
+				It("can retrieve details", func() {
+					appGUID := app_helpers.GetAppGuid(appName)
+					serviceInstanceGUID := getGuidFor("service", instanceName)
+					detailsEndpoint := getBindingDetailsEndpoint(appGUID, serviceInstanceGUID)
+
+					fetchBindingDetails := cf.Cf("curl", detailsEndpoint).Wait()
+					Expect(fetchBindingDetails).To(Say(`"username": "%s"`, username))
+					Expect(fetchBindingDetails).To(Exit(0), "failed to fetch binding details")
+				})
+
+				It("updates to the service instance appear in app env", func() {
+					restartApp := cf.Cf("restart", appName).Wait(Config.CfPushTimeoutDuration())
+					Expect(restartApp).To(Exit(0), "failed restarting app")
+					Expect(helpers.CurlApp(Config, appName, "/env/VCAP_SERVICES")).Should(ContainSubstring(username))
+
+					newCreds := `{"username": "new-username"}`
+					updateService := cf.Cf("update-user-provided-service", instanceName, "-p", newCreds).Wait()
+					Expect(updateService).To(Exit(0))
+
+					restartApp = cf.Cf("restart", appName).Wait(Config.CfPushTimeoutDuration())
+					Expect(restartApp).To(Exit(0), "failed restarting app")
+					Expect(helpers.CurlApp(Config, appName, "/env/VCAP_SERVICES")).Should(ContainSubstring("new-username"))
+				})
+
+				It("can unbind service to app and check app env and events", func() {
+					unbindService := cf.Cf("unbind-service", appName, instanceName).Wait()
+					Expect(unbindService).To(Exit(0), "failed unbinding app to service")
+
+					checkForAppEvent(appName, "audit.app.update")
+
+					appEnv := cf.Cf("env", appName).Wait()
+					Expect(appEnv).To(Exit(0), "failed get env for app")
+					Expect(appEnv).ToNot(Say("credentials"))
+
+					restartApp := cf.Cf("restart", appName).Wait(Config.CfPushTimeoutDuration())
+					Expect(restartApp).To(Exit(0), "failed restarting app")
+
+					Expect(helpers.CurlApp(Config, appName, "/env/VCAP_SERVICES")).ShouldNot(ContainSubstring(username))
+				})
+			})
+		})
+	})
+})
+
+func checkForAppEvent(appName string, eventName string) {
+	Eventually(func() string {
+		return string(cf.Cf("events", appName).Wait().Out.Contents())
+	}).Should(MatchRegexp(eventName))
+}
+
+func getBindingDetailsEndpoint(appGUID string, instanceGUID string) string {
+	jsonResults := Response{}
+	bindingCurl := cf.Cf("curl", fmt.Sprintf("/v3/service_credential_bindings?app_guids=%s&service_instance_guids=%s", appGUID, instanceGUID)).Wait()
+	Expect(bindingCurl).To(Exit(0))
+	Expect(json.Unmarshal(bindingCurl.Out.Contents(), &jsonResults)).NotTo(HaveOccurred())
+
+	Expect(len(jsonResults.Resources)).To(BeNumerically(">", 0), "Expected to find at least one service resource.")
+
+	return fmt.Sprintf("/v3/service_credential_bindings/%s/details", jsonResults.Resources[0].GUID)
+}
+
+func getGuidFor(args ...string) string {
+	args = append(args, "--guid")
+	session := cf.Cf(args...).Wait()
+
+	out := string(session.Out.Contents())
+	return strings.TrimSpace(out)
+}


### PR DESCRIPTION
### What is this change about?
Add tests for user-provided service operations

### Please provide contextual information.
As part of fixing https://github.com/cloudfoundry/cloud_controller_ng/issues/2543 it is useful to have some CATs that exercise the user-provided service behaviour. In particular the test that service bindings get updated when the service gets updated will currently fail on `cf8` due to the CC v3 endpoint not having the correct behaviour.

Given these are dedicated user-facing commands on the CLI (`cf cups` and `cf uups`), I figured it made sense to have some CATs to cover their behaviour

### What version of cf-deployment have you run this cf-acceptance-test change against?
Latest (v16.25.0)

### Please check all that apply for this PR:
- [x] introduces a new test --- Are you sure everyone should be running this test? Yes, they are standard behaviour and they are fast
- [ ] changes an existing test
- [x] requires an update to a CATs integration-config - this felt like a new set of tests but I could understand if you would prefer them to fall under the existing service tests flag

### Did you update the README as appropriate for this change?
- [x] YES
- [ ] N/A

### How should this change be described in cf-acceptance-tests release notes?
Add tests for user-provided service operations

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
~60s with 4 nodes (slowest test is 60 seconds, fastest are <2 seconds)

### What is the level of urgency for publishing this change?
- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
Working with team at SAP (can contact @philippthun, @FloThinksPi or @stephanme for followup)