### PR TITLE
Drop -d flag no longer supported after cf6

### DIFF
--- a/assets/service_broker/README.md
+++ b/assets/service_broker/README.md
@@ -168,11 +168,7 @@ Before running the script, you must:
 - `cf login` with an admin user and password
 - `cf target -o <some org> -s <some space>` with an org and space where you'd like to push the broker
 
-The script also takes parameters:
-- `broker_name`: Specifies the app name and route for the broker. Defaults to 'async-broker'.
-- `env`: Specifies the cf environment (used only for choosing an app domain). Allowed values are 'bosh-lite',
-         'tabasco', and 'a1'. Defaults to 'bosh-lite'.
-
+The script takes a single optional argument that can be used to set the app name and route for the broker, which defaults to 'async-broker'.
 
 ### Running multiple cases ###
 --------------------------

--- a/assets/service_broker/setup_new_broker.rb
+++ b/assets/service_broker/setup_new_broker.rb
@@ -7,19 +7,6 @@ require 'securerandom'
 broker_name = ARGV[0]
 broker_name ||= 'async-broker'
 
-env = ARGV[1]
-env ||= 'bosh-lite'
-
-env_to_domain_mapping = {
-  'bosh-lite' => 'bosh-lite.com',
-  'a1' => 'a1-app.cf-app.com',
-  'tabasco' => 'tabasco-app.cf-app.com'
-}
-
-domain = env_to_domain_mapping[env] || env
-
-puts "Setting up broker `#{broker_name}` on #{domain}"
-
 $service_name = nil
 
 def uniquify_config
@@ -64,9 +51,9 @@ def uniquify_config
   end
 end
 
-def push_broker(broker_name, domain)
+def push_broker(broker_name)
   puts "Pushing the broker"
-  IO.popen("cf push #{broker_name} -d #{domain}") do |cmd_output|
+  IO.popen("cf push #{broker_name}") do |cmd_output|
     cmd_output.each { |line| puts line }
   end
   puts
@@ -104,9 +91,17 @@ def enable_service_access
 end
 
 uniquify_config
-push_broker(broker_name, domain)
 
-url = "http://#{broker_name}.#{domain}"
+push_broker(broker_name)
+
+app_guid, routes_object, url = ""
+IO.popen("cf app #{broker_name} --guid") do |cmd|
+  cmd.each { |line| app_guid = "#{line.chop}" }
+end
+
+IO.popen("cf curl /v3/apps/#{app_guid}/routes") do |cmd|
+  url = "https://" + JSON.parse(cmd.read)["resources"][0]["url"]
+end
 
 output = create_service_broker(broker_name, url)
 if broker_already_exists?(output)

--- a/assets/service_broker/setup_new_broker.rb
+++ b/assets/service_broker/setup_new_broker.rb
@@ -96,7 +96,7 @@ push_broker(broker_name)
 
 app_guid, routes_object, url = ""
 IO.popen("cf app #{broker_name} --guid") do |cmd|
-  cmd.each { |line| app_guid = "#{line.chop}" }
+  app_guid = cmd.read.chomp
 end
 
 IO.popen("cf curl /v3/apps/#{app_guid}/routes") do |cmd|


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Updates the setup_new_broker.rb script used to bootstrap the test service broker.

The script used the now-defunct '-d' flag for cf push, which was deprecated in version 7 of the cf CLI. As it is no longer possible to specify an app's domain via commandline flags in a 'cf push', the script has been updated to retrieve the route of the test broker after it has been deployed. It then uses this to register the broker.

### What version of cf-deployment have you run this cf-acceptance-test change against?

n/a

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config


### Did you update the README as appropriate for this change?
- [x] YES
- [ ] N/A


### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

n/a

### How should this change be described in cf-acceptance-tests release notes?

n/a


### How many more (or fewer) seconds of runtime will this change introduce to CATs?

n/a

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!

@SAP/cf-controlplane