### PR TITLE
Remove unnecessary fmt.Sprintf usage

### DIFF
--- a/apps/default_environment_variables.go
+++ b/apps/default_environment_variables.go
@@ -2,7 +2,6 @@ package apps
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"path"
 	"strings"
@@ -34,12 +33,12 @@ var _ = AppsDescribe("Default Environment Variables", func() {
 		archive_helpers.CreateZipArchive(buildpackArchivePath, []archive_helpers.ArchiveFile{
 			{
 				Name: "bin/compile",
-				Body: fmt.Sprintf(`#!/usr/bin/env bash
+				Body: `#!/usr/bin/env bash
 env
 # wait for the log lines to make it through
 sleep 5
 exit 1
-`),
+`,
 			},
 			{
 				Name: "bin/detect",

--- a/assets/loggregator-load-generator-go/loggregator-load-generator.go
+++ b/assets/loggregator-load-generator-go/loggregator-load-generator.go
@@ -57,7 +57,7 @@ func logSpeed(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		for run {
 			time.Sleep(time.Duration(sleepTime) * time.Microsecond)
-			fmt.Println(fmt.Sprintf("Log: %s Muahaha...", r.Host))
+			fmt.Printf("Log: %s Muahaha...\n", r.Host)
 		}
 	}()
 
@@ -79,7 +79,7 @@ func logBytesize(w http.ResponseWriter, r *http.Request) {
 	}
 	logString := buffer.String()
 
-	fmt.Println(fmt.Sprintf("Muahaha... let's go. No wait. Logging %d bytes per logline.", byteSize))
+	fmt.Printf("Muahaha... let's go. No wait. Logging %d bytes per logline.\n", byteSize)
 
 	for run {
 		fmt.Println(logString)

--- a/helpers/v3_helpers/v3.go
+++ b/helpers/v3_helpers/v3.go
@@ -35,7 +35,7 @@ type App struct {
 }
 
 func CreateDeployment(appGuid string) string {
-	deploymentPath := fmt.Sprintf("/v3/deployments")
+	deploymentPath := "/v3/deployments"
 	deploymentRequestBody := fmt.Sprintf(`{"relationships": {"app": {"data": {"guid": "%s"}}}}`, appGuid)
 	session := cf.Cf("curl", deploymentPath, "-X", "POST", "-d", deploymentRequestBody).Wait()
 	Expect(session).To(Exit(0))
@@ -49,7 +49,7 @@ func CreateDeployment(appGuid string) string {
 }
 
 func CreateDeploymentForDroplet(appGuid, dropletGuid string) string {
-	deploymentPath := fmt.Sprintf("/v3/deployments")
+	deploymentPath := "/v3/deployments"
 	deploymentRequestBody := fmt.Sprintf(`{"droplet": {"guid": "%s"}, "relationships": {"app": {"data": {"guid": "%s"}}}}`, dropletGuid, appGuid)
 	session := cf.Cf("curl", deploymentPath, "-X", "POST", "-d", deploymentRequestBody).Wait()
 	Expect(session).To(Exit(0))
@@ -201,7 +201,7 @@ func CreateDockerApp(appName, spaceGuid, environmentVariables string) string {
 }
 
 func CreateDockerPackage(appGuid, imagePath string) string {
-	packageCreateUrl := fmt.Sprintf("/v3/packages")
+	packageCreateUrl := "/v3/packages"
 	session := cf.Cf("curl", packageCreateUrl, "-X", "POST", "-d", fmt.Sprintf(`{"relationships":{"app":{"data":{"guid":"%s"}}},"type":"docker", "data": {"image": "%s"}}`, appGuid, imagePath))
 	bytes := session.Wait().Out.Contents()
 	var pac struct {
@@ -233,7 +233,7 @@ func CreateOrGetIsolationSegment(name string) string {
 }
 
 func CreatePackage(appGuid string) string {
-	packageCreateUrl := fmt.Sprintf("/v3/packages")
+	packageCreateUrl := "/v3/packages"
 	session := cf.Cf("curl", packageCreateUrl, "-X", "POST", "-d", fmt.Sprintf(`{"relationships":{"app":{"data":{"guid":"%s"}}},"type":"bits"}`, appGuid))
 	bytes := session.Wait().Out.Contents()
 	var pac struct {

--- a/routing/multiple_app_ports.go
+++ b/routing/multiple_app_ports.go
@@ -28,7 +28,7 @@ var _ = RoutingDescribe("Multiple App Ports", func() {
 
 	BeforeEach(func() {
 		appName = random_name.CATSRandomName("APP")
-		cmd := fmt.Sprintf("go-online --ports=7777,8888,8080")
+		cmd := "go-online --ports=7777,8888,8080"
 
 		Expect(cf.Cf("push",
 			appName,

--- a/services/service_instance_lifecycle.go
+++ b/services/service_instance_lifecycle.go
@@ -266,7 +266,7 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 
 					appEnv := cf.Cf("env", appName).Wait()
 					Expect(appEnv).To(Exit(0), "failed get env for app")
-					Expect(appEnv).To(Say(fmt.Sprintf("credentials")))
+					Expect(appEnv).To(Say("credentials"))
 
 					restartApp := cf.Cf("restart", appName).Wait(Config.CfPushTimeoutDuration())
 					Expect(restartApp).To(Exit(0), "failed restarting app")
@@ -303,7 +303,7 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 
 						appEnv := cf.Cf("env", appName).Wait()
 						Expect(appEnv).To(Exit(0), "failed get env for app")
-						Expect(appEnv).ToNot(Say(fmt.Sprintf("credentials")))
+						Expect(appEnv).ToNot(Say("credentials"))
 
 						restartApp := cf.Cf("restart", appName).Wait(Config.CfPushTimeoutDuration())
 						Expect(restartApp).To(Exit(0), "failed restarting app")
@@ -448,7 +448,7 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 
 						appEnv := cf.Cf("env", appName).Wait()
 						Expect(appEnv).To(Exit(0), "failed get env for app")
-						Expect(appEnv).To(Say(fmt.Sprintf("credentials")))
+						Expect(appEnv).To(Say("credentials"))
 					})
 
 					It("can bind service to app and send arbitrary params", func() {
@@ -472,7 +472,7 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 
 							appEnv := cf.Cf("env", appName).Wait()
 							Expect(appEnv).To(Exit(0), "failed get env for app")
-							Expect(appEnv).ToNot(Say(fmt.Sprintf("credentials")))
+							Expect(appEnv).ToNot(Say("credentials"))
 						})
 					})
 				})


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Gets closer to idiomatic code by removing alot of unnecessary usage of `fmt.Sprintf`.

### Please provide contextual information.

N/A

### What version of cf-deployment have you run this cf-acceptance-test change against?

None

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How should this change be described in cf-acceptance-tests release notes?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

N/A