### PR TITLE
Fix: double imports

### DIFF
--- a/routing/session_affinity.go
+++ b/routing/session_affinity.go
@@ -18,7 +18,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = RoutingDescribe("Session Affinity", func() {
@@ -38,7 +37,7 @@ var _ = RoutingDescribe("Session Affinity", func() {
 				"-b", Config.GetRubyBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", stickyAsset,
-			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			).Wait(Config.CfPushTimeoutDuration())).To(gexec.Exit(0))
 
 			cookieStore, err := ioutil.TempFile("", "cats-sticky-session")
 			Expect(err).ToNot(HaveOccurred())
@@ -48,14 +47,14 @@ var _ = RoutingDescribe("Session Affinity", func() {
 
 		AfterEach(func() {
 			app_helpers.AppReport(appName)
-			Expect(cf.Cf("delete", appName, "-f", "-r").Wait()).To(Exit(0))
+			Expect(cf.Cf("delete", appName, "-f", "-r").Wait()).To(gexec.Exit(0))
 			err := os.Remove(cookieStorePath)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("when an app has multiple instances", func() {
 			BeforeEach(func() {
-				Expect(cf.Cf("scale", appName, "-i", "3").Wait()).To(Exit(0))
+				Expect(cf.Cf("scale", appName, "-i", "3").Wait()).To(gexec.Exit(0))
 			})
 
 			Context("when the client sends VCAP_ID and JSESSION cookies", func() {
@@ -91,17 +90,17 @@ var _ = RoutingDescribe("Session Affinity", func() {
 				"-b", Config.GetRubyBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", helloWorldAsset,
-			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			).Wait(Config.CfPushTimeoutDuration())).To(gexec.Exit(0))
 		})
 
 		AfterEach(func() {
 			app_helpers.AppReport(appName)
-			Expect(cf.Cf("delete", appName, "-f", "-r").Wait()).To(Exit(0))
+			Expect(cf.Cf("delete", appName, "-f", "-r").Wait()).To(gexec.Exit(0))
 		})
 
 		Context("when an app has multiple instances", func() {
 			BeforeEach(func() {
-				Expect(cf.Cf("scale", appName, "-i", "3").Wait()).To(Exit(0))
+				Expect(cf.Cf("scale", appName, "-i", "3").Wait()).To(gexec.Exit(0))
 			})
 
 			Context("when the client does not send VCAP_ID and JSESSION cookies", func() {
@@ -144,21 +143,21 @@ var _ = RoutingDescribe("Session Affinity", func() {
 				"-b", Config.GetRubyBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", stickyAsset,
-			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			).Wait(Config.CfPushTimeoutDuration())).To(gexec.Exit(0))
 			app2 = random_name.CATSRandomName("APP")
 			Expect(cf.Cf("push",
 				app2,
 				"-b", Config.GetRubyBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", stickyAsset,
-			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			).Wait(Config.CfPushTimeoutDuration())).To(gexec.Exit(0))
 
-			Expect(cf.Cf("scale", app1, "-i", "3").Wait()).To(Exit(0))
-			Expect(cf.Cf("scale", app2, "-i", "3").Wait()).To(Exit(0))
+			Expect(cf.Cf("scale", app1, "-i", "3").Wait()).To(gexec.Exit(0))
+			Expect(cf.Cf("scale", app2, "-i", "3").Wait()).To(gexec.Exit(0))
 			hostname = random_name.CATSRandomName("ROUTE")
 
-			Expect(cf.Cf("map-route", app1, domain, "--hostname", hostname, "--path", app1Path).Wait()).To(Exit(0))
-			Expect(cf.Cf("map-route", app2, domain, "--hostname", hostname, "--path", app2Path).Wait()).To(Exit(0))
+			Expect(cf.Cf("map-route", app1, domain, "--hostname", hostname, "--path", app1Path).Wait()).To(gexec.Exit(0))
+			Expect(cf.Cf("map-route", app2, domain, "--hostname", hostname, "--path", app2Path).Wait()).To(gexec.Exit(0))
 
 			cookieStore, err := ioutil.TempFile("", "cats-sticky-session")
 			Expect(err).ToNot(HaveOccurred())
@@ -169,8 +168,8 @@ var _ = RoutingDescribe("Session Affinity", func() {
 		AfterEach(func() {
 			app_helpers.AppReport(app1)
 			app_helpers.AppReport(app2)
-			Expect(cf.Cf("delete", app1, "-f", "-r").Wait()).To(Exit(0))
-			Expect(cf.Cf("delete", app2, "-f", "-r").Wait()).To(Exit(0))
+			Expect(cf.Cf("delete", app1, "-f", "-r").Wait()).To(gexec.Exit(0))
+			Expect(cf.Cf("delete", app2, "-f", "-r").Wait()).To(gexec.Exit(0))
 
 			err := os.Remove(cookieStorePath)
 			Expect(err).ToNot(HaveOccurred())
@@ -225,20 +224,20 @@ var _ = RoutingDescribe("Session Affinity", func() {
 				"-b", Config.GetRubyBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", stickyAsset,
-			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			).Wait(Config.CfPushTimeoutDuration())).To(gexec.Exit(0))
 			app2 = random_name.CATSRandomName("APP")
 			Expect(cf.Cf("push",
 				app2,
 				"-b", Config.GetRubyBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", stickyAsset,
-			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			).Wait(Config.CfPushTimeoutDuration())).To(gexec.Exit(0))
 
-			Expect(cf.Cf("scale", app1, "-i", "3").Wait()).To(Exit(0))
-			Expect(cf.Cf("scale", app2, "-i", "3").Wait()).To(Exit(0))
+			Expect(cf.Cf("scale", app1, "-i", "3").Wait()).To(gexec.Exit(0))
+			Expect(cf.Cf("scale", app2, "-i", "3").Wait()).To(gexec.Exit(0))
 			hostname = app1
 
-			Expect(cf.Cf("map-route", app2, domain, "--hostname", hostname, "--path", app2Path).Wait()).To(Exit(0))
+			Expect(cf.Cf("map-route", app2, domain, "--hostname", hostname, "--path", app2Path).Wait()).To(gexec.Exit(0))
 
 			cookieStore, err := ioutil.TempFile("", "cats-sticky-session")
 			Expect(err).ToNot(HaveOccurred())
@@ -250,8 +249,8 @@ var _ = RoutingDescribe("Session Affinity", func() {
 			app_helpers.AppReport(app1)
 			app_helpers.AppReport(app2)
 
-			Expect(cf.Cf("delete", app1, "-f", "-r").Wait()).To(Exit(0))
-			Expect(cf.Cf("delete", app2, "-f", "-r").Wait()).To(Exit(0))
+			Expect(cf.Cf("delete", app1, "-f", "-r").Wait()).To(gexec.Exit(0))
+			Expect(cf.Cf("delete", app2, "-f", "-r").Wait()).To(gexec.Exit(0))
 
 			err := os.Remove(cookieStorePath)
 			Expect(err).ToNot(HaveOccurred())

--- a/v3/app_lifecycle.go
+++ b/v3/app_lifecycle.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
-	. "github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
@@ -56,25 +55,25 @@ var _ = V3Describe("v3 buildpack app lifecycle", func() {
 		})
 
 		It("can run apps with processes from the Procfile", func() {
-			lastUsageEventGuid := LastAppUsageEventGuid(TestSetup)
+			lastUsageEventGuid := app_helpers.LastAppUsageEventGuid(TestSetup)
 
 			buildGuid := StageBuildpackPackage(packageGuid, Config.GetRubyBuildpackName())
 
-			usageEvents := UsageEventsAfterGuid(lastUsageEventGuid)
-			event := AppUsageEvent{}
+			usageEvents := app_helpers.UsageEventsAfterGuid(lastUsageEventGuid)
+			event := app_helpers.AppUsageEvent{}
 			event.State.Current = "STAGING_STARTED"
 			event.App.Guid = appGuid
 			event.App.Name = appName
-			Expect(UsageEventsInclude(usageEvents, event)).To(BeTrue())
+			Expect(app_helpers.UsageEventsInclude(usageEvents, event)).To(BeTrue())
 
 			WaitForBuildToStage(buildGuid)
 
-			usageEvents = UsageEventsAfterGuid(lastUsageEventGuid)
-			event = AppUsageEvent{}
+			usageEvents = app_helpers.UsageEventsAfterGuid(lastUsageEventGuid)
+			event = app_helpers.AppUsageEvent{}
 			event.State.Current = "STAGING_STOPPED"
 			event.App.Guid = appGuid
 			event.App.Name = appName
-			Expect(UsageEventsInclude(usageEvents, event)).To(BeTrue())
+			Expect(app_helpers.UsageEventsInclude(usageEvents, event)).To(BeTrue())
 
 			dropletGuid := GetDropletFromBuild(buildGuid)
 
@@ -89,7 +88,7 @@ var _ = V3Describe("v3 buildpack app lifecycle", func() {
 
 			CreateAndMapRoute(appGuid, Config.GetAppsDomain(), webProcess.Name)
 
-			lastUsageEventGuid = LastAppUsageEventGuid(TestSetup)
+			lastUsageEventGuid = app_helpers.LastAppUsageEventGuid(TestSetup)
 
 			StartApp(appGuid)
 
@@ -104,47 +103,47 @@ var _ = V3Describe("v3 buildpack app lifecycle", func() {
 			Expect(string(cf.Cf("apps").Wait().Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(started)", webProcess.Name)))
 			Expect(string(cf.Cf("apps").Wait().Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(started)", workerProcess.Name)))
 
-			usageEvents = UsageEventsAfterGuid(lastUsageEventGuid)
+			usageEvents = app_helpers.UsageEventsAfterGuid(lastUsageEventGuid)
 
-			event1 := AppUsageEvent{}
+			event1 := app_helpers.AppUsageEvent{}
 			event1.Process.Type = webProcess.Type
 			event1.Process.Guid = webProcess.Guid
 			event1.State.Current = "STARTED"
 			event1.App.Guid = appGuid
 			event1.App.Name = appName
 
-			event2 := AppUsageEvent{}
+			event2 := app_helpers.AppUsageEvent{}
 			event2.Process.Type = workerProcess.Type
 			event2.Process.Guid = workerProcess.Guid
 			event2.State.Current = "STARTED"
 			event2.App.Guid = appGuid
 			event2.App.Name = appName
 
-			Expect(UsageEventsInclude(usageEvents, event1)).To(BeTrue())
-			Expect(UsageEventsInclude(usageEvents, event2)).To(BeTrue())
+			Expect(app_helpers.UsageEventsInclude(usageEvents, event1)).To(BeTrue())
+			Expect(app_helpers.UsageEventsInclude(usageEvents, event2)).To(BeTrue())
 
 			StopApp(appGuid)
 
 			Expect(string(cf.Cf("apps").Wait().Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(stopped)", webProcess.Name)))
 			Expect(string(cf.Cf("apps").Wait().Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(stopped)", workerProcess.Name)))
 
-			usageEvents = UsageEventsAfterGuid(lastUsageEventGuid)
-			event1 = AppUsageEvent{}
+			usageEvents = app_helpers.UsageEventsAfterGuid(lastUsageEventGuid)
+			event1 = app_helpers.AppUsageEvent{}
 			event1.Process.Type = webProcess.Type
 			event1.Process.Guid = webProcess.Guid
 			event1.State.Current = "STOPPED"
 			event1.App.Guid = appGuid
 			event1.App.Name = appName
 
-			event2 = AppUsageEvent{}
+			event2 = app_helpers.AppUsageEvent{}
 			event2.Process.Type = workerProcess.Type
 			event2.Process.Guid = workerProcess.Guid
 			event2.State.Current = "STOPPED"
 			event2.App.Guid = appGuid
 			event2.App.Name = appName
 
-			Expect(UsageEventsInclude(usageEvents, event1)).To(BeTrue())
-			Expect(UsageEventsInclude(usageEvents, event2)).To(BeTrue())
+			Expect(app_helpers.UsageEventsInclude(usageEvents, event1)).To(BeTrue())
+			Expect(app_helpers.UsageEventsInclude(usageEvents, event2)).To(BeTrue())
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, webProcess.Name)
@@ -173,7 +172,7 @@ var _ = V3Describe("v3 buildpack app lifecycle", func() {
 
 			CreateAndMapRoute(appGuid, Config.GetAppsDomain(), webProcess.Name)
 
-			lastUsageEventGuid := LastAppUsageEventGuid(TestSetup)
+			lastUsageEventGuid := app_helpers.LastAppUsageEventGuid(TestSetup)
 			StartApp(appGuid)
 
 			// Because v3 start returns immediately, the curl returning "ok" is the signal that Push has finished
@@ -184,28 +183,28 @@ var _ = V3Describe("v3 buildpack app lifecycle", func() {
 
 			Expect(string(cf.Cf("apps").Wait().Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(started)", webProcess.Name)))
 
-			usageEvents := UsageEventsAfterGuid(lastUsageEventGuid)
+			usageEvents := app_helpers.UsageEventsAfterGuid(lastUsageEventGuid)
 
-			event1 := AppUsageEvent{}
+			event1 := app_helpers.AppUsageEvent{}
 			event1.Process.Type = webProcess.Type
 			event1.Process.Guid = webProcess.Guid
 			event1.State.Current = "STARTED"
 			event1.App.Guid = appGuid
 			event1.App.Name = appName
-			Expect(UsageEventsInclude(usageEvents, event1)).To(BeTrue())
+			Expect(app_helpers.UsageEventsInclude(usageEvents, event1)).To(BeTrue())
 
 			StopApp(appGuid)
 
 			Expect(string(cf.Cf("apps").Wait().Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(stopped)", webProcess.Name)))
 
-			usageEvents = UsageEventsAfterGuid(lastUsageEventGuid)
-			event1 = AppUsageEvent{}
+			usageEvents = app_helpers.UsageEventsAfterGuid(lastUsageEventGuid)
+			event1 = app_helpers.AppUsageEvent{}
 			event1.Process.Type = webProcess.Type
 			event1.Process.Guid = webProcess.Guid
 			event1.State.Current = "STOPPED"
 			event1.App.Guid = appGuid
 			event1.App.Name = appName
-			Expect(UsageEventsInclude(usageEvents, event1)).To(BeTrue())
+			Expect(app_helpers.UsageEventsInclude(usageEvents, event1)).To(BeTrue())
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, webProcess.Name)
@@ -258,7 +257,7 @@ var _ = V3Describe("v3 docker app lifecycle", func() {
 
 		CreateAndMapRoute(appGuid, Config.GetAppsDomain(), webProcess.Name)
 
-		lastUsageEventGuid := LastAppUsageEventGuid(TestSetup)
+		lastUsageEventGuid := app_helpers.LastAppUsageEventGuid(TestSetup)
 		StartApp(appGuid)
 
 		Eventually(func() string {
@@ -270,28 +269,28 @@ var _ = V3Describe("v3 docker app lifecycle", func() {
 		Expect(output).To(ContainSubstring(appCreationEnvironmentVariables))
 
 		Expect(string(cf.Cf("apps").Wait().Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(started)", webProcess.Name)))
-		usageEvents := UsageEventsAfterGuid(lastUsageEventGuid)
+		usageEvents := app_helpers.UsageEventsAfterGuid(lastUsageEventGuid)
 
-		event := AppUsageEvent{}
+		event := app_helpers.AppUsageEvent{}
 		event.Process.Type = webProcess.Type
 		event.Process.Guid = webProcess.Guid
 		event.State.Current = "STARTED"
 		event.App.Guid = appGuid
 		event.App.Name = appName
-		Expect(UsageEventsInclude(usageEvents, event)).To(BeTrue())
+		Expect(app_helpers.UsageEventsInclude(usageEvents, event)).To(BeTrue())
 
 		StopApp(appGuid)
 
 		Expect(string(cf.Cf("apps").Wait().Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(stopped)", webProcess.Name)))
 
-		usageEvents = UsageEventsAfterGuid(lastUsageEventGuid)
-		event = AppUsageEvent{}
+		usageEvents = app_helpers.UsageEventsAfterGuid(lastUsageEventGuid)
+		event = app_helpers.AppUsageEvent{}
 		event.Process.Type = webProcess.Type
 		event.Process.Guid = webProcess.Guid
 		event.State.Current = "STOPPED"
 		event.App.Guid = appGuid
 		event.App.Name = appName
-		Expect(UsageEventsInclude(usageEvents, event)).To(BeTrue())
+		Expect(app_helpers.UsageEventsInclude(usageEvents, event)).To(BeTrue())
 
 		Eventually(func() string {
 			return helpers.CurlAppRoot(Config, webProcess.Name)


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Clean up code where packages are imported twice (as a dot import and regularly):
* `routing/session_affinity.go`
* `v3/app_lifecycle.go`

Decided to remove the dot imported packages for more idiomatic go.

### Please provide contextual information.

N/A

### What version of cf-deployment have you run this cf-acceptance-test change against?

None

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How should this change be described in cf-acceptance-tests release notes?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

N/A