### PR TITLE
Add a test for C2C over TLS

### DIFF
--- a/assets/proxy/main.go
+++ b/assets/proxy/main.go
@@ -22,6 +22,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/proxy/", proxyHandler)
+	mux.HandleFunc("/https_proxy/", httpsProxyHandler)
 	mux.HandleFunc("/", infoHandler(systemPort))
 
 	http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", systemPort), mux)
@@ -55,7 +56,17 @@ func infoHandler(port int) http.HandlerFunc {
 
 func proxyHandler(resp http.ResponseWriter, req *http.Request) {
 	destination := strings.TrimPrefix(req.URL.Path, "/proxy/")
-	destination = "http://" + destination
+	destination = fmt.Sprintf("%s://%s", "http", destination)
+	handleRequest(destination, resp, req)
+}
+
+func httpsProxyHandler(resp http.ResponseWriter, req *http.Request) {
+	destination := strings.TrimPrefix(req.URL.Path, "/https_proxy/")
+	destination = fmt.Sprintf("%s://%s", "https", destination)
+	handleRequest(destination, resp, req)
+}
+
+func handleRequest(destination string, resp http.ResponseWriter, req *http.Request) {
 	getResp, err := httpClient.Get(destination)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "request failed: %s", err)


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

YES

### What is this change about?

Adds test for C2C over TLS, new feature available in diego-release [v2.59.0](https://github.com/cloudfoundry/diego-release/releases/tag/v2.59.0)

### Please provide contextual information.

https://github.com/cloudfoundry/diego-release/issues/587

### What version of cf-deployment have you run this cf-acceptance-test change against?

cf-deployment did not pick up the latest diego-release yet. We have run it with latest cf-deployment and diego-release v2.59.0

### Please check all that apply for this PR:
- [X] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [X] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

We want to make sure C2C is working not just over HTTP but HTTPS as well.

### How should this change be described in cf-acceptance-tests release notes?

New test for container to container networking over TLS

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

56s

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!

@cloudfoundry/cf-diego 