### PR TITLE
Add a dynamic ASG test to the security_groups test suite

### DIFF
--- a/assets/proxy/main.go
+++ b/assets/proxy/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -93,5 +94,8 @@ var httpClient = &http.Client{
 			Timeout:   10 * time.Second,
 			KeepAlive: 0,
 		}).Dial,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
 	},
 }

--- a/security_groups/dynamic_asgs.go
+++ b/security_groups/dynamic_asgs.go
@@ -1,0 +1,98 @@
+package security_groups_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
+)
+
+var _ = Describe("Dynamic ASGs", func() {
+	var (
+		orgName           string
+		spaceName         string
+		appName           string
+		securityGroupName string
+	)
+
+	BeforeEach(func() {
+		if !Config.GetIncludeSecurityGroups() {
+			Skip(skip_messages.SkipSecurityGroupsMessage)
+		}
+
+		orgName = TestSetup.RegularUserContext().Org
+		spaceName = TestSetup.RegularUserContext().Space
+		appName = random_name.CATSRandomName("APP")
+
+		By("pushing a proxy app")
+		Expect(cf.Cf(
+			"push", appName,
+			"-b", Config.GetGoBuildpackName(),
+			"-p", assets.NewAssets().Proxy,
+			"-f", assets.NewAssets().Proxy+"/manifest.yml",
+		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+	})
+
+	AfterEach(func() {
+		Expect(cf.Cf("delete", appName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+		deleteSecurityGroup(securityGroupName)
+	})
+
+	It("applies ASGs wihout app restart", func() {
+		proxyRequestURL := fmt.Sprintf("http://%s.%s/https_proxy/cloud-controller-ng.service.cf.internal:9024/v2/info", appName, Config.GetAppsDomain())
+
+		By("checking that our app can't initially reach cloud controller over internal address")
+		resp, err := http.Get(proxyRequestURL)
+		Expect(err).NotTo(HaveOccurred())
+
+		respBytes, err := ioutil.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		resp.Body.Close()
+		Expect(respBytes).To(MatchRegexp("refused"))
+
+		By("binding a new security group")
+		dest := Destination{
+			IP:       "10.0.0.0/0",
+			Ports:    "9024", // internal cc port
+			Protocol: "tcp",
+		}
+		securityGroupName = createSecurityGroup(dest)
+		bindSecurityGroup(securityGroupName, orgName, spaceName)
+
+		By("checking that our app can now reach cloud controller over internal address")
+		Eventually(func() []byte {
+			resp, err = http.Get(proxyRequestURL)
+			Expect(err).NotTo(HaveOccurred())
+
+			respBytes, err = ioutil.ReadAll(resp.Body)
+			Expect(err).ToNot(HaveOccurred())
+			resp.Body.Close()
+			return respBytes
+		}, 3*time.Minute).Should(MatchRegexp("api_version"))
+
+		By("unbinding the security group")
+		unbindSecurityGroup(securityGroupName, orgName, spaceName)
+
+		By("checking that our app can no longer reach cloud controller over internal address")
+		Eventually(func() []byte {
+			resp, err = http.Get(proxyRequestURL)
+			Expect(err).NotTo(HaveOccurred())
+
+			respBytes, err = ioutil.ReadAll(resp.Body)
+			Expect(err).ToNot(HaveOccurred())
+			resp.Body.Close()
+			return respBytes
+		}, 3*time.Minute).Should(MatchRegexp("refused"))
+	})
+})

--- a/security_groups/running_security_groups.go
+++ b/security_groups/running_security_groups.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 
@@ -233,8 +234,10 @@ var _ = SecurityGroupsDescribe("App Instance Networking", func() {
 			Expect(catnipCurlResponse.ReturnCode).NotTo(Equal(0), "no policy configured but client app can talk to server app using overlay")
 
 			By("Testing that external connectivity to a private ip is not refused (but may be unreachable for other reasons)")
-			catnipCurlResponse = testAppConnectivity(clientAppName, privateAddress, 80)
-			Expect(catnipCurlResponse.Stderr).To(MatchRegexp("Connection timed out after|No route to host"), "wide-open ASG configured but app is still refused by private ip")
+			Eventually(func() string {
+				resp := testAppConnectivity(clientAppName, privateAddress, 80)
+				return resp.Stderr
+			}, 3*time.Minute).Should(MatchRegexp("Connection timed out after|No route to host"), "wide-open ASG configured but app is still refused by private ip")
 
 			By("adding policy")
 			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
@@ -261,11 +264,13 @@ var _ = SecurityGroupsDescribe("App Instance Networking", func() {
 			Eventually(func() int {
 				catnipCurlResponse = testAppConnectivity(clientAppName, containerIp, containerPort)
 				return catnipCurlResponse.ReturnCode
-			}, "5s").Should(Equal(0), "policy is configured, asgs are not but client app cannot talk to server app using overlay")
+			}, 3*time.Minute).Should(Equal(0), "policy is configured, asgs are not but client app cannot talk to server app using overlay")
 
 			By("Testing that external connectivity to a private ip is refused")
-			catnipCurlResponse = testAppConnectivity(clientAppName, privateAddress, 80)
-			Expect(catnipCurlResponse.Stderr).To(MatchRegexp("refused|No route to host|Connection timed out"))
+			Eventually(func() string {
+				resp := testAppConnectivity(clientAppName, privateAddress, 80)
+				return resp.Stderr
+			}, 3*time.Minute).Should(MatchRegexp("refused|No route to host|Connection timed out"))
 
 			By("deleting policy")
 			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
@@ -279,7 +284,7 @@ var _ = SecurityGroupsDescribe("App Instance Networking", func() {
 			Eventually(func() int {
 				catnipCurlResponse = testAppConnectivity(clientAppName, containerIp, containerPort)
 				return catnipCurlResponse.ReturnCode
-			}, "5s").ShouldNot(Equal(0), "no policy is configured but client app can talk to server app using overlay")
+			}, 3*time.Minute).ShouldNot(Equal(0), "no policy is configured but client app can talk to server app using overlay")
 		})
 
 	})

--- a/security_groups/running_security_groups.go
+++ b/security_groups/running_security_groups.go
@@ -93,7 +93,7 @@ func getAppContainerIpAndPort(appName string) (string, int) {
 
 type Destination struct {
 	IP       string `json:"destination"`
-	Port     int    `json:"ports,string,omitempty"`
+	Ports    string `json:"ports,string,omitempty"`
 	Protocol string `json:"protocol"`
 }
 

--- a/tasks/task.go
+++ b/tasks/task.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 
@@ -344,7 +345,7 @@ exit 1`
 					outputName = taskDetails[1]
 					outputState = taskDetails[2]
 					return outputState
-				}, Config.CfPushTimeoutDuration()).Should(Equal("FAILED"))
+				}, 3*time.Minute).Should(Equal("FAILED"))
 				Expect(outputName).To(Equal(taskName))
 
 				Eventually(func() string {


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes


### What is this change about?

Acceptance tests for Dynamic ASGs, to be enabled by default in cf-deployment.


### Please provide contextual information.

https://www.pivotaltracker.com/story/show/181363273


### What version of cf-deployment have you run this cf-acceptance-test change against?

v18.0.0 with silk-release update to v 3.0 and policy-server-asg-syncer enabled with this ops file: https://www.pivotaltracker.com/story/show/180837394/comments/229193630


### Please check all that apply for this PR:
- [x] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

xCATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._



### How should this change be described in cf-acceptance-tests release notes?

Add a test for dynamic (no restart) security groups.


### How many more (or fewer) seconds of runtime will this change introduce to CATs?
3 mins


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
