### PR TITLE
Service bindings test flake fix [179005915] 

### DIFF
--- a/credhub/service_bindings.go
+++ b/credhub/service_bindings.go
@@ -228,12 +228,16 @@ EOF
 
 		AssistedCredhubDescribe("", func() {
 			It("has CredHub references in VCAP_SERVICES interpolated", func() {
-				Eventually(func() string {
-					appLogsSession := logs.Recent(appName)
-					appLogsSession.Wait()
+				Eventually(
+					func() string {
+						appLogsSession := logs.Recent(appName)
+						appLogsSession.Wait()
 
-					return string(appLogsSession.Out.Contents())
-				}, 3*time.Minute, 10*time.Second).Should(ContainSubstring(`{"password":"rainbowDash","user-name":"pinkyPie"}`))
+						return string(appLogsSession.Out.Contents())
+					},
+					3*time.Minute,
+					10*time.Second,
+				).Should(ContainSubstring(`{"password":"rainbowDash","user-name":"pinkyPie"}`))
 
 				appLogsSession := logs.Recent(appName)
 				appLogsSession.Wait()


### PR DESCRIPTION
### What is this change about?

Fixes a credhub test that fails intermittently.


### Please provide contextual information.

[179005915](https://www.pivotaltracker.com/story/show/180465755)



### What version of cf-deployment have you run this cf-acceptance-test change against?

latest

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config



### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A



### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._



### How should this change be described in cf-acceptance-tests release notes?

Fixes a credhub test that fails intermittently.



### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Maybe 10 seconds as the test polls for output. There's a 3-minute timeout if the test fails.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**



### Tag your pair, your PM, and/or team!
@bruce-ricard @peterhaochen47 