### PR TITLE
Skip the memory resources test on K8s

### DIFF
--- a/apps/instance_reporting.go
+++ b/apps/instance_reporting.go
@@ -14,6 +14,8 @@ import (
 
 var _ = AppsDescribe("Getting instance information", func() {
 	Describe("scaling memory", func() {
+		SkipOnK8s("CF-for-K8s generates a timeout instead of the expected error message")
+
 		var appName string
 		var runawayTestSetup *workflowhelpers.ReproducibleTestSuiteSetup
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -229,6 +229,9 @@ jobs:
       OPS_FILES: |
         operations/use-compiled-releases.yml
         operations/use-internal-lookup-for-route-services.yml
+        operations/windows2019-cell.yml
+        operations/use-online-windows2019fs.yml
+        operations/experimental/use-compiled-releases-windows.yml
 
   - task: run-bosh-cleanup
     file: cf-deployment-concourse-tasks/bosh-cleanup/task.yml


### PR DESCRIPTION
### What is this change about?

This PR updates the memory resource scaling test to be skipped when the `infrastructure` config option is set to `Kubernetes`.

### Please provide contextual information.

This test fails often but is not worth changing now that cf-for-k8s is not under active development.

### What version of cf-deployment have you run this cf-acceptance-test change against?

N/A

### Please check all that apply for this PR:
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?
- [ ] YES
- [x] N/A

### How should this change be described in cf-acceptance-tests release notes?

Skip the memory resource scaling test when the `infrastructure` config option is set to `Kubernetes`.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@acosta11 @Birdrock @ctlong 