### PR TITLE
Update cats-dynamic-asgs PR branch with fixes for existing ASG tests in a DASG env

### DIFF
--- a/security_groups/running_security_groups.go
+++ b/security_groups/running_security_groups.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 
@@ -233,8 +234,10 @@ var _ = SecurityGroupsDescribe("App Instance Networking", func() {
 			Expect(catnipCurlResponse.ReturnCode).NotTo(Equal(0), "no policy configured but client app can talk to server app using overlay")
 
 			By("Testing that external connectivity to a private ip is not refused (but may be unreachable for other reasons)")
-			catnipCurlResponse = testAppConnectivity(clientAppName, privateAddress, 80)
-			Expect(catnipCurlResponse.Stderr).To(MatchRegexp("Connection timed out after|No route to host"), "wide-open ASG configured but app is still refused by private ip")
+			Eventually(func() string {
+				resp := testAppConnectivity(clientAppName, privateAddress, 80)
+				return resp.Stderr
+			}, 3*time.Minute).Should(MatchRegexp("Connection timed out after|No route to host"), "wide-open ASG configured but app is still refused by private ip")
 
 			By("adding policy")
 			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
@@ -261,11 +264,13 @@ var _ = SecurityGroupsDescribe("App Instance Networking", func() {
 			Eventually(func() int {
 				catnipCurlResponse = testAppConnectivity(clientAppName, containerIp, containerPort)
 				return catnipCurlResponse.ReturnCode
-			}, "5s").Should(Equal(0), "policy is configured, asgs are not but client app cannot talk to server app using overlay")
+			}, 3*time.Minute).Should(Equal(0), "policy is configured, asgs are not but client app cannot talk to server app using overlay")
 
 			By("Testing that external connectivity to a private ip is refused")
-			catnipCurlResponse = testAppConnectivity(clientAppName, privateAddress, 80)
-			Expect(catnipCurlResponse.Stderr).To(MatchRegexp("refused|No route to host|Connection timed out"))
+			Eventually(func() string {
+				resp := testAppConnectivity(clientAppName, privateAddress, 80)
+				return resp.Stderr
+			}, 3*time.Minute).Should(MatchRegexp("refused|No route to host|Connection timed out"))
 
 			By("deleting policy")
 			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
@@ -279,7 +284,7 @@ var _ = SecurityGroupsDescribe("App Instance Networking", func() {
 			Eventually(func() int {
 				catnipCurlResponse = testAppConnectivity(clientAppName, containerIp, containerPort)
 				return catnipCurlResponse.ReturnCode
-			}, "5s").ShouldNot(Equal(0), "no policy is configured but client app can talk to server app using overlay")
+			}, 3*time.Minute).ShouldNot(Equal(0), "no policy is configured but client app can talk to server app using overlay")
 		})
 
 	})

--- a/tasks/task.go
+++ b/tasks/task.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 
@@ -344,7 +345,7 @@ exit 1`
 					outputName = taskDetails[1]
 					outputState = taskDetails[2]
 					return outputState
-				}, Config.CfPushTimeoutDuration()).Should(Equal("FAILED"))
+				}, 3*time.Minute).Should(Equal("FAILED"))
 				Expect(outputName).To(Equal(taskName))
 
 				Eventually(func() string {


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

### What is this change about?

Update cats-dynamic-asgs PR branch with fixes for existing ASG tests in a DASG env

### Please provide contextual information.

Fixes failures seen for #501 

### What version of cf-deployment have you run this cf-acceptance-test change against?

latest 

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Up to 9 mins with the eventually statements, but with the use of cf-deployment/operations/test/speed-up-dynamic-asgs.yml that should be drastically reduced (mins -> seconds)

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@ctlong @davewalter 