### PR TITLE
Fix: stop using deprecated grpc.WithTimeout

### DIFF
--- a/http2_routing/http2_routing.go
+++ b/http2_routing/http2_routing.go
@@ -81,18 +81,17 @@ var _ = HTTP2RoutingDescribe("HTTP/2 Routing", func() {
 			tlsConfig := tls.Config{InsecureSkipVerify: true}
 			creds := credentials.NewTLS(&tlsConfig)
 
-			conn, err := grpc.Dial(
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			conn, err := grpc.DialContext(
+				ctx,
 				appURI,
 				grpc.WithTransportCredentials(creds),
 				grpc.WithBlock(),
 				grpc.FailOnNonTempDialError(true),
-				grpc.WithTimeout(time.Duration(1)*time.Second),
 			)
 			Expect(err).ToNot(HaveOccurred())
 			defer conn.Close()
-
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-			defer cancel()
 
 			client := protobuff.NewTestClient(conn)
 			response, err := client.Run(ctx, &protobuff.Request{})


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

`grpc.Dial` with `grpc.WithTimeout` is deprecated and should be replaced
by `grpc.DialContext` with a context that has a timeout.

### Please provide contextual information.

Closes #489 

https://pkg.go.dev/google.golang.org/grpc#WithTimeout

### What version of cf-deployment have you run this cf-acceptance-test change against?

v20.2.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

N/A