### PR TITLE
Reduce flakiness of space-specific ASG test

### DIFF
--- a/tasks/task.go
+++ b/tasks/task.go
@@ -328,6 +328,8 @@ exit 1`
 				workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
 					Expect(cf.Cf("bind-security-group", securityGroupName, TestSetup.RegularUserContext().Org, "--space", TestSetup.RegularUserContext().Space).Wait()).To(Exit(0))
 				})
+				// Give time to allow the security group to propagate
+				time.Sleep(60 * time.Second)
 
 				By("restarting the app to apply the ASG")
 				Expect(cf.Cf("restart", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))


### PR DESCRIPTION
The current "binding a space-specific ASG" test fails approximately 80%
of the time on a vanilla Cloud Foundry deployment. In a nutshell, the
new space-specific ASG has not propagated by the time that the app has
restarted, and the app is beholden to the old ASGs: What should be a
timeout is a "connection refused".

This commit fixes that by inserting a 60-second delay between
setting the new ASG and restarting the app. The 60-second delay is not
arbitrary; rather, it is the result of the meticulous gathering of
empirical data presented in the chart below:

|Delay (seconds)|# of tests|Success Rate (%)|Success Rate Histogram     |
|--------------:|---------:|---------------:|:--------------------------|
|             0 |       60 |             20 | *****                     |
|             5 |       95 |             28 | *******                   |
|            10 |       75 |             41 | **********                |
|            15 |       70 |             38 | *********                 |
|            20 |       95 |             46 | ***********               |
|            25 |       75 |             68 | *****************         |
|            30 |      120 |             63 | ***************           |
|            35 |       60 |             76 | *******************       |
|            40 |       35 |             85 | *********************     |
|            45 |       20 |             85 | *********************     |
|            50 |       30 |            100 | ************************* |
|            55 |       35 |            100 | ************************* |
|            60 |       20 |            100 | ************************* |
|            65 |       30 |            100 | ************************* |
|            70 |       40 |            100 | ************************* |

Although 50 seconds should have been enough, we added another ten
seconds for no good reason other than headroom.

Fixes:
```
[Fail] [tasks] v3 tasks when associating a task with an app and binding a space-specific ASG [It] applies the associated app's ASGs to the task
/Users/cunnie/workspace/cf-acceptance-tests/tasks/task.go:355
```
```
2022-05-30T10:26:44.86-0700 [APP/TASK/woof/0] ERR 0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (7) Failed to connect to 10.0.244.255 port 80: Connection refused
```

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._

### What is this change about?

_Describe the change and why it's needed._

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [X] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

It'll add 60 seconds to a single suite.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
