### PR TITLE
Add tests for log rate limiting

### DIFF
--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -45,7 +45,7 @@ import (
 	. "github.com/onsi/gomega/gexec"
 )
 
-const minCliVersion = "6.33.1"
+const minCliVersion = "8.5.0"
 
 func TestCATS(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes.

### What is this change about?

The cf CLI, Cloud Controller API and Diego are being extended with support for defining log rate limit quotas. This PR adds tests to confirm that basic log rate limiting is working correctly. 

We added examples to the apps and windows tests.

We did not add tests for creation of quotas with an associated log rate limit.

For these tests to run the `minCliVersion` was updated to a version of the cf CLI that supports specifying a log rate limit when pushing an application.

This shouldn't be merged before [capi >= 1.137.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.137.0) is in cf-deployment release-candidate branch.

### Please provide contextual information.

* [Proposal doc](https://docs.google.com/document/d/1BEdtKHJ877Cn4HOfvAzIdMwoD0dpZuzRNBsmQ7c5_zM/edit#heading=h.sa8b0ujnd2tn)
* https://github.com/cloudfoundry/cli/issues/2297
* https://github.com/cloudfoundry/capi-release/issues/245

### What version of cf-deployment have you run this cf-acceptance-test change against?

* With cf-deployment v21.9.0 and [capi-release cdc85fb5](https://github.com/cloudfoundry/capi-release/tree/cdc85fb56cfae392dc4fdcc242633ba0c7457411)

### Please check all that apply for this PR:

- [X] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [X] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

This is intended to be core functionality.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Aside from pushing an app the tests do sleep for one second to verify that applications can log after previously hitting the log rate limit.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@rroberts2222 @Benjamintf1 @mkocher @duanemay