### PR TITLE
Using json matcher instead of string matcher to validate api response

### DIFF
--- a/services/service_instance_lifecycle.go
+++ b/services/service_instance_lifecycle.go
@@ -112,7 +112,7 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 					instanceGUID := getGuidFor("service", instanceName)
 					configParams := cf.Cf("curl", fmt.Sprintf("/v3/service_instances/%s/parameters", instanceGUID)).Wait()
 					Expect(configParams).To(Exit(0), "failed to curl fetch binding parameters")
-					Expect(configParams).To(Say("\"param1\": \"value\""))
+					Expect(configParams.Out.Contents()).To(MatchJSON("{\"param1\": \"value\"}"))
 				})
 
 				It("can delete a service instance", func() {
@@ -216,7 +216,7 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 							paramsEndpoint := fmt.Sprintf("/v3/service_credential_bindings/%s/parameters", serviceKeyGUID)
 
 							fetchServiceKeyParameters := cf.Cf("curl", paramsEndpoint).Wait()
-							Expect(fetchServiceKeyParameters).To(Say(`"param1": "value"`))
+							Expect(fetchServiceKeyParameters.Out.Contents()).To(MatchJSON(`{"param1": "value"}`))
 							Expect(fetchServiceKeyParameters).To(Exit(0), "failed to fetch service key parameters")
 						})
 
@@ -291,7 +291,7 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 						paramsEndpoint := getBindingParamsEndpoint(appGUID, serviceInstanceGUID)
 
 						fetchBindingParameters := cf.Cf("curl", paramsEndpoint).Wait()
-						Expect(fetchBindingParameters).To(Say(`"max_clients": 5`))
+						Expect(fetchBindingParameters.Out.Contents()).To(MatchJSON(`{"max_clients": 5}`))
 						Expect(fetchBindingParameters).To(Exit(0), "failed to fetch binding parameters")
 					})
 


### PR DESCRIPTION
Co-authored-by: Seth Boyles <sboyles@pivotal.io>
Co-authored-by: Alex Rocha <alexr1@vmware.com>

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

An upcoming change in capi no longer pretty prints json responses from cc api. This change updates a test that was dependent on a pretty printed response from ccapi.

### Please provide contextual information.

Details below:
https://github.com/cloudfoundry/cloud_controller_ng/pull/2930
https://github.com/cloudfoundry/capi-release/issues/262

### What version of cf-deployment have you run this cf-acceptance-test change against?
Release Candidate

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

- [x] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

- [x] None

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@sethboyles @xandroc 


