### PR TITLE
Test new /v3/service_instances/:guid/permissions

### DIFF
--- a/helpers/services/broker.go
+++ b/helpers/services/broker.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"strings"
 
 	. "github.com/onsi/gomega"
@@ -121,6 +122,18 @@ func (b ServiceBroker) PushWithBuildpackAndManifest(config cats_config.CatsConfi
 		"--health-check-type", "http",
 		"--endpoint", "/v2/catalog",
 	).Wait(Config.BrokerStartTimeoutDuration())).To(Exit(0))
+}
+
+func (b ServiceBroker) GetApiInfoUrl() string {
+	brokerURL := helpers.AppUri(b.Name, "/cf_api_info_url", Config)
+	resp, err := http.Get(brokerURL)
+	Expect(err == nil)
+	Expect(resp.StatusCode == 200)
+
+	respData, err := ioutil.ReadAll(resp.Body)
+	Expect(err == nil)
+	resp.Body.Close()
+	return string(respData)
 }
 
 func (b ServiceBroker) Configure() {


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Broadly, two changes. Both are related to the sso (services) test suite, which tests the [single sign-on lifecycle for service dashboards](https://docs.cloudfoundry.org/services/dashboard-sso.html).
1. Updates the helper `QueryServiceInstancePermissionEndpoint` to hit `/v3/service_instances/:guid/permissions` instead of its v2 equivalent. We recently found that the suite would fail with v2 of the CF API disabled, and were surprised to find there was no v3 equivalent of `/v2/service_instances/:guid/permissions`, which we've now implemented (see cloudfoundry/cloud_controller_ng#2946)
2. Updates the way the tests get the CF API's info endpoint, which is needed as part of the SSO OAuth flow. The CATS service broker will now grab the CF API info endpoint from the [X-Api-Info-Location header](https://docs.cloudfoundry.org/services/supporting-multiple-cf-instances.html#x-api-info-location), which is included in all calls brokers receive from the Cloud Controller. The CATS broker now stores its value in memory, and then exposes it to the tests via a new endpoint. X-Api-Info-Location [is always](https://github.com/cloudfoundry/cloud_controller_ng/blob/c8c63950125c698ca1f93fe2c677ef0274e9a953/lib/services/service_brokers/v2/http_client.rb#L102) a url for `/v2/info`. Previously the broker ignored this header, and the test suite  was just hardcoded to hit `/info`:
https://github.com/cloudfoundry/cf-acceptance-tests/blob/145a74556952c17cbc898bfb7147dd3fc2b198a1/helpers/services/sso.go#L44
That worked only because the response objects for `/v2/info` and `/info` (the ['legacy' info endpoint](https://github.com/cloudfoundry/cloud_controller_ng/blob/c8c63950125c698ca1f93fe2c677ef0274e9a953/lib/cloud_controller/legacy_api/legacy_info.rb)) both have an `authorization_endpoint` as a top-level field

As an aside, note that the tests will now succeed with v2 disabled, as `/v2/info` is in fact [the sole v2 endpoint that continues to be served](https://github.com/cloudfoundry/capi-release/blob/35623fa6d49179deff7fd077b5cc7981fe4a9311/jobs/cloud_controller_ng/templates/nginx_external_endpoints.conf.erb#L33) even when the v2 API is disabled in the capi-release.



### Please provide contextual information.

* cloudfoundry/cloud_controller_ng#2946 - needs to be merged before the current PR (update: this is now done)

### What version of cf-deployment have you run this cf-acceptance-test change against?

v21.2.0, patching the CAPI release for [capi 1.135.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.135.0) with the cloud_controller_ng submodule swapped out for a [branch implementing the v3 API](https://github.com/sap-contributions/cloud_controller_ng/tree/service_instance_permissions).

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

n/a

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

n/a

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**