### PR TITLE
Unmarshal Route JSON instead of parsing as a string

### DIFF
--- a/helpers/v3_helpers/routes.go
+++ b/helpers/v3_helpers/routes.go
@@ -1,8 +1,8 @@
 package v3_helpers
 
 import (
+	"encoding/json"
 	"fmt"
-	"regexp"
 
 	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
 	. "github.com/onsi/gomega"
@@ -13,7 +13,14 @@ func GetRouteGuid(hostname string) string {
 	routeQuery := fmt.Sprintf("/v3/routes?hosts=%s", hostname)
 	getRoutesCurl := cf.Cf("curl", routeQuery)
 	Expect(getRoutesCurl.Wait()).To(Exit(0))
+	routesJSON := struct {
+		Resources []struct {
+			Guid string `json:"guid"`
+		} `json:"resources"`
+	}{}
+	bytes := getRoutesCurl.Out.Contents()
 
-	routeGuidRegex := regexp.MustCompile(`\s+"guid": "(.+)"`)
-	return routeGuidRegex.FindStringSubmatch(string(getRoutesCurl.Out.Contents()))[1]
+	json.Unmarshal(bytes, &routesJSON)
+
+	return routesJSON.Resources[0].Guid
 }


### PR DESCRIPTION
Co-authored-by: Seth Boyles <sboyles@pivotal.io>
Co-authored-by: Merric de Launey <mdelauney@pivotal.io>
Co-authored-by: David Alvarado <alvaradoda@vmware.com>

### What is this change about?

Similar to https://github.com/cloudfoundry/cf-acceptance-tests/pull/587, this test is failing on latest CAPI since it is parsing JSON responses as strings (considering whitespace, etc).

### Please provide contextual information.

https://github.com/cloudfoundry/cloud_controller_ng/pull/2930
https://github.com/cloudfoundry/capi-release/issues/262

### What version of cf-deployment have you run this cf-acceptance-test change against?

release-candidate

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

n/a

### How many more (or fewer) seconds of runtime will this change introduce to CATs?



### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@xandroc 
@MerricdeLauney 
@dalvarado 
