### PR TITLE
Make dynamic ASG test endpoint configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,13 @@ include_v3
 
 * `infrastructure`: The name of the infrastructure for the environment that the tests will run against. Must be either "vms" or "kubernetes". Defaults to "vms".
 
+* `dynamic_asg_test_config`: By default the Dynamic ASG test allows and blocks access to the Cloud Controller internal endpoint by toggling access for TCP requests on port 9024 to 10.0.0.0/8. To test dynamic ASGs against another endpoint and/or by toggling a different IP range, include `dynamic_asg_test_config` as an object with the following properties:
+  * `endpoint_host`: Hostname or IP for test endpoint to allow/block
+  * `endpoint_port`: Port for test endpoint to allow/block
+  * `endpoint_path`: HTTP Path for test endpoint to allow/block
+  * `endpoint_allow_ip_range`: IP range used for allowing and blocking access to the test endpoint. This can be a single IP address, a range like 192.0.2.0-192.0.2.50, or a CIDR block like 10.0.0.0/8.
+  * `expected_response_regex`: Regex to match expected response body from test endpoint
+
 #### Buildpack Names
 Many tests specify a buildpack when pushing an app, so that on diego the app staging process completes in less time. The default names for the buildpacks are as follows; if you have buildpacks with different names, you can override them by setting different names:
 

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -86,6 +86,7 @@ type CatsConfig interface {
 	GetVolumeServiceCreateConfig() string
 
 	GetReporterConfig() reporterConfig
+	GetDynamicASGTestConfig() dynamicASGTestConfig
 
 	AsyncServiceOperationTimeoutDuration() time.Duration
 	BrokerStartTimeoutDuration() time.Duration


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

👍 

### What is this change about?

Currently the Dynamic ASG test works the following way:
* Make a request from a test app to `cloud-controller-ng.service.cf.internal:9024/v2/info`
* Verify the request was blocked
* Add a security group rule allows the app to make TCP connections to port `9024` in IP range `10.0.0.0/8`
* Verify the request is now allowed
* Remove the security group
* Verify the request is blocked again

This test requires/assumes that:
* `cloud-controller-ng.service.cf.internal:9024` is currently blocked by the platform-wide running ASGs
* The Cloud Controller is deployed to an IP in the range `10.0.0.0/8`
* `cloud-controller-ng.service.cf.internal` resolves to a Cloud Controller VM IP

This PR adds an optional configuration parameter `dynamic_asg_test_config` which can be used to change the test to work in environments where the above assumptions don't hold. By default the test will use the current logic, but `dynamic_asg_test_config` can be used to override the following parameters:
  * `endpoint_host`: Hostname or IP for test endpoint to allow/block
  * `endpoint_port`: Port for test endpoint to allow/block
  * `endpoint_path`: HTTP Path for test endpoint to allow/block
  * `endpoint_allow_ip_range`: IP range used for allowing and blocking access to the test endpoint. This can be a single IP address, a range like 192.0.2.0-192.0.2.50, or a CIDR block like 10.0.0.0/8.

### What version of cf-deployment have you run this cf-acceptance-test change against?

21.9

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

0

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

This work is done on behalf of [Fidelity International](https://github.com/FidelityInternational)
