### PR TITLE
change string compare for user provided services to a more robust Mat…

### DIFF
--- a/user_provided_services/lifecycle.go
+++ b/user_provided_services/lifecycle.go
@@ -71,7 +71,7 @@ var _ = UserProvidedServicesDescribe("Service Instance Lifecycle", func() {
 				instanceGUID := getGuidFor("service", instanceName)
 				credentials := cf.Cf("curl", fmt.Sprintf("/v3/service_instances/%s/credentials", instanceGUID)).Wait()
 				Expect(credentials).To(Exit(0), "failed to curl fetch credentials")
-				Expect(credentials).To(Say(`"param1": "value"`))
+				Expect(credentials.Out.Contents()).To(MatchJSON(`{"param1":"value"}`))
 			})
 
 			It("can delete a service instance", func() {
@@ -106,7 +106,7 @@ var _ = UserProvidedServicesDescribe("Service Instance Lifecycle", func() {
 					instanceGUID := getGuidFor("service", instanceName)
 					credentials := cf.Cf("curl", fmt.Sprintf("/v3/service_instances/%s/credentials", instanceGUID)).Wait()
 					Expect(credentials).To(Exit(0), "failed to curl fetch credentials")
-					Expect(credentials).To(Say(`"param2": "newValue"`))
+					Expect(credentials.Out.Contents()).To(MatchJSON(`{"param2":"newValue"}`))
 				})
 
 				It("can update service tags", func() {
@@ -175,7 +175,7 @@ var _ = UserProvidedServicesDescribe("Service Instance Lifecycle", func() {
 					detailsEndpoint := getBindingDetailsEndpoint(appGUID, serviceInstanceGUID)
 
 					fetchBindingDetails := cf.Cf("curl", detailsEndpoint).Wait()
-					Expect(fetchBindingDetails).To(Say(`"username": "%s"`, username))
+					Expect(fetchBindingDetails.Out.Contents()).To(MatchJSON(fmt.Sprintf(`{"credentials":{"username": "%s"}}`, username)))
 					Expect(fetchBindingDetails).To(Exit(0), "failed to fetch binding details")
 				})
 


### PR DESCRIPTION
…chJSON (the latest versions of the Cloud Controller respond with "condensed" json responses now)

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

CATS are failing with the latest versions of cf-deployment, specifically because the capi /v3 api responses are no longer json-formatted and you get "condensed" json back, this makes a couple of tests fail because they use a plain string compare.

### Please provide contextual information.
-

### What version of cf-deployment have you run this cf-acceptance-test change against?
cf-deployment v21.9.0 
cf-deployment v21.10.0


### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x ] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

No new test 

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

0

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
none