### PR TITLE
Print AppReport after dynamic ASG test for better debugging

### DIFF
--- a/credhub/service_bindings.go
+++ b/credhub/service_bindings.go
@@ -1,6 +1,7 @@
 package credhub
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path"
@@ -14,8 +15,6 @@ import (
 	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
 
-	"encoding/json"
-
 	"strings"
 
 	archive_helpers "code.cloudfoundry.org/archiver/extractor/test_helper"
@@ -27,7 +26,7 @@ import (
 	"github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
 )
 
-var _ = CredhubDescribe("service bindings", func() {
+var _ = NonAssistedCredhubDescribe("service bindings", func() {
 	var (
 		chBrokerAppName string
 		chServiceName   string
@@ -36,95 +35,12 @@ var _ = CredhubDescribe("service bindings", func() {
 	)
 
 	BeforeEach(func() {
-		TestSetup.RegularUserContext().TargetSpace()
-		cf.Cf("target", "-o", TestSetup.RegularUserContext().Org, "-s", TestSetup.RegularUserContext().Space)
-
-		chBrokerAppName = random_name.CATSRandomName("BRKR-CH")
-
-		Expect(cf.Cf(
-			"push", chBrokerAppName,
-			"-b", Config.GetGoBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
-			"-p", assets.NewAssets().CredHubServiceBroker,
-			"-f", assets.NewAssets().CredHubServiceBroker+"/manifest.yml",
-		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed pushing credhub-enabled service broker")
-
-		existingEnvVar := string(cf.Cf("running-environment-variable-group").Wait().Out.Contents())
-
-		if !strings.Contains(existingEnvVar, "CREDHUB_API") {
-			Expect(cf.Cf(
-				"set-env", chBrokerAppName,
-				"CREDHUB_API", Config.GetCredHubLocation(),
-			).Wait()).To(Exit(0), "failed setting CREDHUB_API env var on credhub-enabled service broker")
-		}
-
-		chServiceName = random_name.CATSRandomName("SERVICE-NAME")
-		Expect(cf.Cf(
-			"set-env", chBrokerAppName,
-			"SERVICE_NAME", chServiceName,
-		).Wait()).To(Exit(0), "failed setting SERVICE_NAME env var on credhub-enabled service broker")
-
-		Expect(cf.Cf(
-			"set-env", chBrokerAppName,
-			"CREDHUB_CLIENT", Config.GetCredHubBrokerClientCredential(),
-		).Wait()).To(Exit(0), "failed setting CREDHUB_CLIENT env var on credhub-enabled service broker")
-
-		Expect(cf.CfRedact(
-			Config.GetCredHubBrokerClientSecret(), "set-env", chBrokerAppName,
-			"CREDHUB_SECRET", Config.GetCredHubBrokerClientSecret(),
-		).Wait()).To(Exit(0), "failed setting CREDHUB_SECRET env var on credhub-enabled service broker")
-
-		Expect(cf.Cf(
-			"restart", chBrokerAppName,
-		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed restarting credhub-enabled service broker")
-
-		workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
-			serviceUrl := "https://" + chBrokerAppName + "." + Config.GetAppsDomain()
-			createServiceBroker := cf.Cf("create-service-broker", chBrokerAppName, Config.GetAdminUser(), Config.GetAdminPassword(), serviceUrl).Wait()
-			Expect(createServiceBroker).To(Exit(0), "failed creating credhub-enabled service broker")
-
-			enableAccess := cf.Cf("enable-service-access", chServiceName, "-o", TestSetup.RegularUserContext().Org).Wait()
-			Expect(enableAccess).To(Exit(0), "failed to enable service access for credhub-enabled broker")
-
-			TestSetup.RegularUserContext().TargetSpace()
-			instanceName = random_name.CATSRandomName("SVIN-CH")
-			createService := cf.Cf("create-service", chServiceName, "credhub-read-plan", instanceName).Wait()
-			Expect(createService).To(Exit(0), "failed creating credhub enabled service")
-		})
+		chBrokerAppName, chServiceName, instanceName = sharedCredhubSetup()
 	})
 
 	AfterEach(func() {
-		workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
-			TestSetup.RegularUserContext().TargetSpace()
-
-			Expect(cf.Cf("purge-service-instance", instanceName, "-f").Wait()).To(Exit(0))
-			Expect(cf.Cf("delete-service-broker", chBrokerAppName, "-f").Wait()).To(Exit(0))
-		})
+		sharedCredhubTeardown(chBrokerAppName, instanceName)
 	})
-
-	bindServiceAndStartApp := func(appName string) {
-		Expect(chServiceName).ToNot(Equal(""))
-		setServiceName := cf.Cf("set-env", appName, "SERVICE_NAME", chServiceName).Wait()
-		Expect(setServiceName).To(Exit(0), "failed setting SERVICE_NAME env var on app")
-
-		existingEnvVar := string(cf.Cf("running-environment-variable-group").Wait().Out.Contents())
-
-		if !strings.Contains(existingEnvVar, "CREDHUB_API") {
-			Expect(cf.Cf(
-				"set-env", appName,
-				"CREDHUB_API", Config.GetCredHubLocation(),
-			).Wait()).To(Exit(0), "failed setting CREDHUB_API env var on app")
-		}
-
-		workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
-			TestSetup.RegularUserContext().TargetSpace()
-
-			bindService := cf.Cf("bind-service", appName, instanceName).Wait()
-			Expect(bindService).To(Exit(0), "failed binding app to service")
-		})
-		appStartSession = cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())
-		Expect(appStartSession).To(Exit(0))
-	}
 
 	Context("during staging", func() {
 		var (
@@ -132,8 +48,111 @@ var _ = CredhubDescribe("service bindings", func() {
 			appName       string
 			appPath       string
 
-			buildpackPath        string
-			buildpackArchivePath string
+			tmpdir string
+		)
+
+		SkipOnK8s("Custom buildpacks not yet supported")
+
+		BeforeEach(func() {
+			buildpackName, appName, appPath, tmpdir = createBuildpack()
+			Expect(cf.Cf("push", appName,
+				"--no-start",
+				"-b", buildpackName,
+				"-m", DEFAULT_MEMORY_LIMIT,
+				"-p", appPath,
+			).Wait()).To(Exit(0))
+
+			appStartSession = bindServiceAndStartApp(appName, chServiceName, instanceName)
+		})
+
+		AfterEach(func() {
+			app_helpers.AppReport(appName)
+
+			Expect(cf.Cf("delete", appName, "-f", "-r").Wait()).To(Exit(0))
+			deleteBuildpack(buildpackName, tmpdir)
+		})
+
+		It("still contains CredHub references in VCAP_SERVICES", func() {
+			Expect(appStartSession).NotTo(Say("pinkyPie"))
+			Expect(appStartSession).NotTo(Say("rainbowDash"))
+			Expect(appStartSession).To(Say("credhub-ref"))
+		})
+	})
+
+	Context("during runtime", func() {
+		var appName, appURL string
+		BeforeEach(func() {
+			appName = random_name.CATSRandomName("APP-CH")
+			appURL = "https://" + appName + "." + Config.GetAppsDomain()
+
+			createApp := cf.Cf(
+				"push", appName,
+				"--no-start",
+				"-b", Config.GetJavaBuildpackName(),
+				"-m", "1024M",
+				"-p", assets.NewAssets().CredHubEnabledApp,
+			).Wait(Config.CfPushTimeoutDuration())
+			Expect(createApp).To(Exit(0), "failed creating credhub-enabled app")
+			appStartSession = bindServiceAndStartApp(appName, chServiceName, instanceName)
+		})
+
+		AfterEach(func() {
+			app_helpers.AppReport(appName)
+			app_helpers.AppReport(chBrokerAppName)
+
+			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+				TestSetup.RegularUserContext().TargetSpace()
+				unbindService := cf.Cf("unbind-service", appName, instanceName).Wait()
+				Expect(unbindService).To(Exit(0), "failed unbinding app and service")
+
+				Expect(cf.Cf("delete", appName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			})
+		})
+
+		It("the broker returns credhub-ref in the credentials block", func() {
+			appEnv := string(cf.Cf("env", appName).Wait().Out.Contents())
+			Expect(appEnv).To(ContainSubstring("credentials"), "credential block missing from service")
+			Expect(appEnv).To(ContainSubstring("credhub-ref"), "credhub-ref not found")
+		})
+
+		It("the bound app retrieves the credentials for the ref from CredHub", func() {
+			curlCmd := helpers.CurlSkipSSL(true, appURL+"/test").Wait()
+			Expect(curlCmd).To(Exit(0))
+
+			bytes := curlCmd.Out.Contents()
+			var response struct {
+				UserName string `json:"user-name"`
+				Password string `json:"password"`
+			}
+
+			json.Unmarshal(bytes, &response)
+			Expect(response.UserName).To(Equal("pinkyPie"))
+			Expect(response.Password).To(Equal("rainbowDash"))
+		})
+
+	})
+})
+
+var _ = AssistedCredhubDescribe("service bindings", func() {
+	var (
+		chBrokerAppName string
+		chServiceName   string
+		instanceName    string
+	)
+
+	BeforeEach(func() {
+		chBrokerAppName, chServiceName, instanceName = sharedCredhubSetup()
+	})
+
+	AfterEach(func() {
+		sharedCredhubTeardown(chBrokerAppName, instanceName)
+	})
+
+	Context("during staging", func() {
+		var (
+			buildpackName string
+			appName       string
+			appPath       string
 
 			tmpdir string
 		)
@@ -141,39 +160,214 @@ var _ = CredhubDescribe("service bindings", func() {
 		SkipOnK8s("Custom buildpacks not yet supported")
 
 		BeforeEach(func() {
+			buildpackName, appName, appPath, tmpdir = createBuildpack()
+			Expect(cf.Cf("push", appName,
+				"--no-start",
+				"-b", buildpackName,
+				"-m", DEFAULT_MEMORY_LIMIT,
+				"-p", appPath,
+			).Wait()).To(Exit(0))
+
+			bindServiceAndStartApp(appName, chServiceName, instanceName)
+		})
+
+		AfterEach(func() {
+			app_helpers.AppReport(appName)
+
+			Expect(cf.Cf("delete", appName, "-f", "-r").Wait()).To(Exit(0))
+			deleteBuildpack(buildpackName, tmpdir)
+		})
+
+		It("has CredHub references in VCAP_SERVICES interpolated", func() {
+			Eventually(
+				func() string {
+					appLogsSession := logs.Recent(appName)
+					appLogsSession.Wait()
+
+					return string(appLogsSession.Out.Contents())
+				},
+				3*time.Minute,
+				10*time.Second,
+			).Should(ContainSubstring(`{"password":"rainbowDash","user-name":"pinkyPie"}`))
+
+			appLogsSession := logs.Recent(appName)
+			appLogsSession.Wait()
+			Expect(string(appLogsSession.Out.Contents())).ToNot(ContainSubstring("credhub-ref"))
+		})
+	})
+
+	Context("during runtime", func() {
+		var appName, appURL string
+		BeforeEach(func() {
+			appName = random_name.CATSRandomName("APP-CH")
+			appURL = "https://" + appName + "." + Config.GetAppsDomain()
+			createApp := cf.Cf(app_helpers.CatnipWithArgs(
+				appName,
+				"--no-start",
+				"-m", DEFAULT_MEMORY_LIMIT)...,
+			).Wait(Config.CfPushTimeoutDuration())
+			Expect(createApp).To(Exit(0), "failed creating credhub-enabled app")
+			bindServiceAndStartApp(appName, chServiceName, instanceName)
+		})
+
+		AfterEach(func() {
+			app_helpers.AppReport(appName)
+			app_helpers.AppReport(chBrokerAppName)
+
 			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
-				buildpackName = random_name.CATSRandomName("BPK")
-				appName = random_name.CATSRandomName("APP")
+				TestSetup.RegularUserContext().TargetSpace()
+				unbindService := cf.Cf("unbind-service", appName, instanceName).Wait()
+				Expect(unbindService).To(Exit(0), "failed unbinding app and service")
 
-				var err error
-				tmpdir, err = ioutil.TempDir("", "buildpack_env")
-				Expect(err).ToNot(HaveOccurred())
-				appPath, err = ioutil.TempDir(tmpdir, "matching-app")
-				Expect(err).ToNot(HaveOccurred())
+				Expect(cf.Cf("delete", appName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			})
+		})
 
-				buildpackPath, err = ioutil.TempDir(tmpdir, "matching-buildpack")
-				Expect(err).ToNot(HaveOccurred())
+		It("the broker returns credhub-ref in the credentials block", func() {
+			appEnv := string(cf.Cf("env", appName).Wait().Out.Contents())
+			Expect(appEnv).To(ContainSubstring("credentials"), "credential block missing from service")
+			Expect(appEnv).To(ContainSubstring("credhub-ref"), "credhub-ref not found")
+		})
 
-				buildpackArchivePath = path.Join(buildpackPath, "buildpack.zip")
+		It("the bound app gets CredHub refs in VCAP_SERVICES interpolated", func() {
+			curlCmd := helpers.CurlSkipSSL(true, appURL+"/env/VCAP_SERVICES").Wait()
+			Expect(curlCmd).To(Exit(0))
 
-				archive_helpers.CreateZipArchive(buildpackArchivePath, []archive_helpers.ArchiveFile{
-					{
-						Name: "bin/compile",
-						Body: `#!/usr/bin/env bash
+			bytes := curlCmd.Out.Contents()
+			Expect(string(bytes)).To(ContainSubstring(`"rainbowDash"`))
+			Expect(string(bytes)).To(ContainSubstring(`"pinkyPie"`))
+		})
+	})
+})
+
+func bindServiceAndStartApp(appName, chServiceName, instanceName string) *Session {
+	Expect(chServiceName).ToNot(Equal(""))
+	setServiceName := cf.Cf("set-env", appName, "SERVICE_NAME", chServiceName).Wait()
+	Expect(setServiceName).To(Exit(0), "failed setting SERVICE_NAME env var on app")
+
+	existingEnvVar := string(cf.Cf("running-environment-variable-group").Wait().Out.Contents())
+
+	if !strings.Contains(existingEnvVar, "CREDHUB_API") {
+		Expect(cf.Cf(
+			"set-env", appName,
+			"CREDHUB_API", Config.GetCredHubLocation(),
+		).Wait()).To(Exit(0), "failed setting CREDHUB_API env var on app")
+	}
+
+	workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+		TestSetup.RegularUserContext().TargetSpace()
+
+		bindService := cf.Cf("bind-service", appName, instanceName).Wait()
+		Expect(bindService).To(Exit(0), "failed binding app to service")
+	})
+	appStartSession := cf.Cf("start", appName).Wait(Config.CfPushTimeoutDuration())
+	Expect(appStartSession).To(Exit(0))
+	return appStartSession
+}
+
+func sharedCredhubSetup() (chBrokerAppName, chServiceName, instanceName string) {
+	TestSetup.RegularUserContext().TargetSpace()
+	cf.Cf("target", "-o", TestSetup.RegularUserContext().Org, "-s", TestSetup.RegularUserContext().Space)
+
+	chBrokerAppName = random_name.CATSRandomName("BRKR-CH")
+
+	Expect(cf.Cf(
+		"push", chBrokerAppName,
+		"-b", Config.GetGoBuildpackName(),
+		"-m", DEFAULT_MEMORY_LIMIT,
+		"-p", assets.NewAssets().CredHubServiceBroker,
+		"-f", assets.NewAssets().CredHubServiceBroker+"/manifest.yml",
+	).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed pushing credhub-enabled service broker")
+
+	existingEnvVar := string(cf.Cf("running-environment-variable-group").Wait().Out.Contents())
+
+	if !strings.Contains(existingEnvVar, "CREDHUB_API") {
+		Expect(cf.Cf(
+			"set-env", chBrokerAppName,
+			"CREDHUB_API", Config.GetCredHubLocation(),
+		).Wait()).To(Exit(0), "failed setting CREDHUB_API env var on credhub-enabled service broker")
+	}
+
+	chServiceName = random_name.CATSRandomName("SERVICE-NAME")
+	Expect(cf.Cf(
+		"set-env", chBrokerAppName,
+		"SERVICE_NAME", chServiceName,
+	).Wait()).To(Exit(0), "failed setting SERVICE_NAME env var on credhub-enabled service broker")
+
+	Expect(cf.Cf(
+		"set-env", chBrokerAppName,
+		"CREDHUB_CLIENT", Config.GetCredHubBrokerClientCredential(),
+	).Wait()).To(Exit(0), "failed setting CREDHUB_CLIENT env var on credhub-enabled service broker")
+
+	Expect(cf.CfRedact(
+		Config.GetCredHubBrokerClientSecret(), "set-env", chBrokerAppName,
+		"CREDHUB_SECRET", Config.GetCredHubBrokerClientSecret(),
+	).Wait()).To(Exit(0), "failed setting CREDHUB_SECRET env var on credhub-enabled service broker")
+
+	Expect(cf.Cf(
+		"restart", chBrokerAppName,
+	).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed restarting credhub-enabled service broker")
+
+	workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+		serviceUrl := "https://" + chBrokerAppName + "." + Config.GetAppsDomain()
+		createServiceBroker := cf.Cf("create-service-broker", chBrokerAppName, Config.GetAdminUser(), Config.GetAdminPassword(), serviceUrl).Wait()
+		Expect(createServiceBroker).To(Exit(0), "failed creating credhub-enabled service broker")
+
+		enableAccess := cf.Cf("enable-service-access", chServiceName, "-o", TestSetup.RegularUserContext().Org).Wait()
+		Expect(enableAccess).To(Exit(0), "failed to enable service access for credhub-enabled broker")
+
+		TestSetup.RegularUserContext().TargetSpace()
+		instanceName = random_name.CATSRandomName("SVIN-CH")
+		createService := cf.Cf("create-service", chServiceName, "credhub-read-plan", instanceName).Wait()
+		Expect(createService).To(Exit(0), "failed creating credhub enabled service")
+	})
+
+	return
+}
+
+func sharedCredhubTeardown(chBrokerAppName, instanceName string) {
+	workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+		TestSetup.RegularUserContext().TargetSpace()
+
+		Expect(cf.Cf("purge-service-instance", instanceName, "-f").Wait()).To(Exit(0))
+		Expect(cf.Cf("delete-service-broker", chBrokerAppName, "-f").Wait()).To(Exit(0))
+	})
+}
+
+func createBuildpack() (buildpackName, appName, appPath, tmpdir string) {
+	workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+		buildpackName = random_name.CATSRandomName("BPK")
+		appName = random_name.CATSRandomName("APP")
+
+		var err error
+		tmpdir, err = ioutil.TempDir("", "buildpack_env")
+		Expect(err).ToNot(HaveOccurred())
+		appPath, err = ioutil.TempDir(tmpdir, "matching-app")
+		Expect(err).ToNot(HaveOccurred())
+
+		buildpackPath, err := ioutil.TempDir(tmpdir, "matching-buildpack")
+		Expect(err).ToNot(HaveOccurred())
+
+		buildpackArchivePath := path.Join(buildpackPath, "buildpack.zip")
+
+		archive_helpers.CreateZipArchive(buildpackArchivePath, []archive_helpers.ArchiveFile{
+			{
+				Name: "bin/compile",
+				Body: `#!/usr/bin/env bash
 echo COMPILING... really just dumping env...
 env
 `,
-					},
-					{
-						Name: "bin/detect",
-						Body: `#!/bin/bash
+			},
+			{
+				Name: "bin/detect",
+				Body: `#!/bin/bash
 
 exit 1
 `,
-					},
-					{
-						Name: "bin/release",
-						Body: `#!/usr/bin/env bash
+			},
+			{
+				Name: "bin/release",
+				Body: `#!/usr/bin/env bash
 
 cat <<EOF
 ---
@@ -184,151 +378,26 @@ default_process_types:
   web: while true; do { echo -e 'HTTP/1.1 200 OK\r\n'; echo "hi from a simple admin buildpack"; } | nc -l \$PORT; done
 EOF
 `,
-					},
-				})
-				_, err = os.Create(path.Join(appPath, "some-file"))
-				Expect(err).ToNot(HaveOccurred())
-
-				createBuildpack := cf.Cf("create-buildpack", buildpackName, buildpackArchivePath, "100").Wait()
-				Expect(createBuildpack).Should(Exit(0))
-				Expect(createBuildpack).Should(Say("Creating"))
-				Expect(createBuildpack).Should(Say("OK"))
-				Expect(createBuildpack).Should(Say("Uploading"))
-				Expect(createBuildpack).Should(Say("OK"))
-
-			})
-			Expect(cf.Cf("push", appName,
-				"--no-start",
-				"-b", buildpackName,
-				"-m", DEFAULT_MEMORY_LIMIT,
-				"-p", appPath,
-			).Wait()).To(Exit(0))
-
-			bindServiceAndStartApp(appName)
+			},
 		})
+		_, err = os.Create(path.Join(appPath, "some-file"))
+		Expect(err).ToNot(HaveOccurred())
 
-		AfterEach(func() {
-			app_helpers.AppReport(appName)
-
-			Expect(cf.Cf("delete", appName, "-f", "-r").Wait()).To(Exit(0))
-
-			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
-				Expect(cf.Cf("delete-buildpack", buildpackName, "-f").Wait()).To(Exit(0))
-			})
-
-			os.RemoveAll(tmpdir)
-		})
-
-		NonAssistedCredhubDescribe("", func() {
-			It("still contains CredHub references in VCAP_SERVICES", func() {
-				Expect(appStartSession).NotTo(Say("pinkyPie"))
-				Expect(appStartSession).NotTo(Say("rainbowDash"))
-				Expect(appStartSession).To(Say("credhub-ref"))
-			})
-		})
-
-		AssistedCredhubDescribe("", func() {
-			It("has CredHub references in VCAP_SERVICES interpolated", func() {
-				Eventually(
-					func() string {
-						appLogsSession := logs.Recent(appName)
-						appLogsSession.Wait()
-
-						return string(appLogsSession.Out.Contents())
-					},
-					3*time.Minute,
-					10*time.Second,
-				).Should(ContainSubstring(`{"password":"rainbowDash","user-name":"pinkyPie"}`))
-
-				appLogsSession := logs.Recent(appName)
-				appLogsSession.Wait()
-				Expect(string(appLogsSession.Out.Contents())).ToNot(ContainSubstring("credhub-ref"))
-			})
-		})
+		createBuildpack := cf.Cf("create-buildpack", buildpackName, buildpackArchivePath, "100").Wait()
+		Expect(createBuildpack).Should(Exit(0))
+		Expect(createBuildpack).Should(Say("Creating"))
+		Expect(createBuildpack).Should(Say("OK"))
+		Expect(createBuildpack).Should(Say("Uploading"))
+		Expect(createBuildpack).Should(Say("OK"))
 	})
 
-	Context("during runtime", func() {
-		Describe("service bindings to credhub enabled broker", func() {
-			var appName, appURL string
-			BeforeEach(func() {
-				appName = random_name.CATSRandomName("APP-CH")
-				appURL = "https://" + appName + "." + Config.GetAppsDomain()
-			})
+	return
+}
 
-			AfterEach(func() {
-				app_helpers.AppReport(appName)
-				app_helpers.AppReport(chBrokerAppName)
-
-				workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
-					TestSetup.RegularUserContext().TargetSpace()
-					unbindService := cf.Cf("unbind-service", appName, instanceName).Wait()
-					Expect(unbindService).To(Exit(0), "failed unbinding app and service")
-
-					Expect(cf.Cf("delete", appName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-				})
-			})
-
-			NonAssistedCredhubDescribe("", func() {
-				BeforeEach(func() {
-					createApp := cf.Cf(
-						"push", appName,
-						"--no-start",
-						"-b", Config.GetJavaBuildpackName(),
-						"-m", "1024M",
-						"-p", assets.NewAssets().CredHubEnabledApp,
-					).Wait(Config.CfPushTimeoutDuration())
-					Expect(createApp).To(Exit(0), "failed creating credhub-enabled app")
-					bindServiceAndStartApp(appName)
-				})
-
-				It("the broker returns credhub-ref in the credentials block", func() {
-					appEnv := string(cf.Cf("env", appName).Wait().Out.Contents())
-					Expect(appEnv).To(ContainSubstring("credentials"), "credential block missing from service")
-					Expect(appEnv).To(ContainSubstring("credhub-ref"), "credhub-ref not found")
-				})
-
-				It("the bound app retrieves the credentials for the ref from CredHub", func() {
-					curlCmd := helpers.CurlSkipSSL(true, appURL+"/test").Wait()
-					Expect(curlCmd).To(Exit(0))
-
-					bytes := curlCmd.Out.Contents()
-					var response struct {
-						UserName string `json:"user-name"`
-						Password string `json:"password"`
-					}
-
-					json.Unmarshal(bytes, &response)
-					Expect(response.UserName).To(Equal("pinkyPie"))
-					Expect(response.Password).To(Equal("rainbowDash"))
-				})
-			})
-
-			AssistedCredhubDescribe("", func() {
-				BeforeEach(func() {
-					createApp := cf.Cf(app_helpers.CatnipWithArgs(
-						appName,
-						"--no-start",
-						"-m", DEFAULT_MEMORY_LIMIT)...,
-					).Wait(Config.CfPushTimeoutDuration())
-					Expect(createApp).To(Exit(0), "failed creating credhub-enabled app")
-					bindServiceAndStartApp(appName)
-				})
-
-				It("the broker returns credhub-ref in the credentials block", func() {
-					appEnv := string(cf.Cf("env", appName).Wait().Out.Contents())
-					Expect(appEnv).To(ContainSubstring("credentials"), "credential block missing from service")
-					Expect(appEnv).To(ContainSubstring("credhub-ref"), "credhub-ref not found")
-				})
-
-				It("the bound app gets CredHub refs in VCAP_SERVICES interpolated", func() {
-					curlCmd := helpers.CurlSkipSSL(true, appURL+"/env/VCAP_SERVICES").Wait()
-					Expect(curlCmd).To(Exit(0))
-
-					bytes := curlCmd.Out.Contents()
-					Expect(string(bytes)).To(ContainSubstring(`"rainbowDash"`))
-					Expect(string(bytes)).To(ContainSubstring(`"pinkyPie"`))
-				})
-			})
-		})
+func deleteBuildpack(buildpackName, tmpdir string) {
+	workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+		Expect(cf.Cf("delete-buildpack", buildpackName, "-f").Wait()).To(Exit(0))
 	})
-})
+
+	os.RemoveAll(tmpdir)
+}

--- a/security_groups/dynamic_asgs.go
+++ b/security_groups/dynamic_asgs.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
@@ -46,6 +47,7 @@ var _ = Describe("Dynamic ASGs", func() {
 	})
 
 	AfterEach(func() {
+		app_helpers.AppReport(appName)
 		Expect(cf.Cf("delete", appName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		deleteSecurityGroup(securityGroupName)
 	})

--- a/services/service_instance_lifecycle.go
+++ b/services/service_instance_lifecycle.go
@@ -129,7 +129,7 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 					params := "{\"param1\": \"value\"}"
 
 					It("can rename a service", func() {
-						newname := "newname"
+						newname := random_name.CATSRandomName("SVC-RENAME")
 						updateService := cf.Cf("rename-service", instanceName, newname).Wait()
 						Expect(updateService).To(Exit(0))
 

--- a/user_provided_services/lifecycle.go
+++ b/user_provided_services/lifecycle.go
@@ -175,7 +175,17 @@ var _ = UserProvidedServicesDescribe("Service Instance Lifecycle", func() {
 					detailsEndpoint := getBindingDetailsEndpoint(appGUID, serviceInstanceGUID)
 
 					fetchBindingDetails := cf.Cf("curl", detailsEndpoint).Wait()
-					Expect(fetchBindingDetails.Out.Contents()).To(MatchJSON(fmt.Sprintf(`{"credentials":{"username": "%s"}}`, username)))
+
+					serviceBindingDetailsResponse := struct {
+						Credentials struct {
+							Username string `json:"username"`
+						} `json:"credentials"`
+					}{}
+
+					err := json.Unmarshal(fetchBindingDetails.Out.Contents(), &serviceBindingDetailsResponse)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(serviceBindingDetailsResponse.Credentials.Username).To(Equal(username))
+
 					Expect(fetchBindingDetails).To(Exit(0), "failed to fetch binding details")
 				})
 

--- a/user_provided_services/lifecycle.go
+++ b/user_provided_services/lifecycle.go
@@ -87,7 +87,7 @@ var _ = UserProvidedServicesDescribe("Service Instance Lifecycle", func() {
 				tags := "['tag1', 'tag2']"
 
 				It("can rename a service", func() {
-					newname := "newname"
+					newname := random_name.CATSRandomName("SVC-RENAME")
 					updateService := cf.Cf("rename-service", instanceName, newname).Wait()
 					Expect(updateService).To(Exit(0))
 


### PR DESCRIPTION
### What is this change about?

This change adds an app report to the end of the dynamic ASG tests. If something goes wrong with the app, it's not currently possible to know why.

### What version of cf-deployment have you run this cf-acceptance-test change against?
v21.8.0


### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

This change adds a single call to `cf logs --recent`, so at most a few seconds.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

