### PR TITLE
Randomize names in rename test to avoid name collisions during parallel test runs or runs on environments with littered service instances

### DIFF
--- a/services/service_instance_lifecycle.go
+++ b/services/service_instance_lifecycle.go
@@ -129,7 +129,7 @@ var _ = ServicesDescribe("Service Instance Lifecycle", func() {
 					params := "{\"param1\": \"value\"}"
 
 					It("can rename a service", func() {
-						newname := "newname"
+						newname := random_name.CATSRandomName("SVC-RENAME")
 						updateService := cf.Cf("rename-service", instanceName, newname).Wait()
 						Expect(updateService).To(Exit(0))
 

--- a/user_provided_services/lifecycle.go
+++ b/user_provided_services/lifecycle.go
@@ -87,7 +87,7 @@ var _ = UserProvidedServicesDescribe("Service Instance Lifecycle", func() {
 				tags := "['tag1', 'tag2']"
 
 				It("can rename a service", func() {
-					newname := "newname"
+					newname := random_name.CATSRandomName("SVC-RENAME")
 					updateService := cf.Cf("rename-service", instanceName, newname).Wait()
 					Expect(updateService).To(Exit(0))
 


### PR DESCRIPTION
### What is this change about?

Generates a random name for a test artifact instead of using a hard-coded one.

### Please provide contextual information.

Sometimes when tests are canceled (e.g. by a developer using Ctrl-C), artifacts get littered. The left behind artifacts, in conjunction with not using unique names, made tests fail.

### What version of cf-deployment have you run this cf-acceptance-test change against?
v21.8.0


### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
