### PR TITLE
Make a more targetted assertion in the user_provided_services lifecycle test

### DIFF
--- a/user_provided_services/lifecycle.go
+++ b/user_provided_services/lifecycle.go
@@ -175,7 +175,17 @@ var _ = UserProvidedServicesDescribe("Service Instance Lifecycle", func() {
 					detailsEndpoint := getBindingDetailsEndpoint(appGUID, serviceInstanceGUID)
 
 					fetchBindingDetails := cf.Cf("curl", detailsEndpoint).Wait()
-					Expect(fetchBindingDetails.Out.Contents()).To(MatchJSON(fmt.Sprintf(`{"credentials":{"username": "%s"}}`, username)))
+
+					serviceBindingDetailsResponse := struct {
+						Credentials struct {
+							Username string `json:"username"`
+						} `json:"credentials"`
+					}{}
+
+					err := json.Unmarshal(fetchBindingDetails.Out.Contents(), &serviceBindingDetailsResponse)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(serviceBindingDetailsResponse.Credentials.Username).To(Equal(username))
+
 					Expect(fetchBindingDetails).To(Exit(0), "failed to fetch binding details")
 				})
 


### PR DESCRIPTION
### What is this change about?

In some scenarios, CAPI returns an empty 'syslog_drain_url' field in addition to the credentials. The MatchJSON matcher is fairly strict -- if there are additional fields to what is specified, it will fail. This change makes the targeted assertion that the test actually cares about -- that the username is properly stored in the credentials.

### Please provide contextual information.

N/A

### What version of cf-deployment have you run this cf-acceptance-test change against?
v21.8.0


### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

