### PR TITLE
Fix: log rate limiting lifecycle tests

### DIFF
--- a/apps/lifecycle.go
+++ b/apps/lifecycle.go
@@ -246,14 +246,20 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 				It("for memory usage", func() {
 					Eventually(func() float64 { m, _, _ := stats(); return m }, Config.CfPushTimeoutDuration()).Should(BeNumerically(">", 0.0))
 				})
+
 				Context("(cf-for-vms)", func() {
 					SkipOnK8s("App disk usage info unavailable")
 
 					It("for disk usage", func() {
 						Eventually(func() float64 { _, d, _ := stats(); return d }, Config.CfPushTimeoutDuration()).Should(BeNumerically(">", 0.0))
 					})
+
 					It("for log usage", func() {
-						Eventually(func() float64 { _, _, l := stats(); return l }, Config.CfPushTimeoutDuration()).Should(BeNumerically(">", 0.0))
+						Eventually(func() float64 {
+							helpers.CurlApp(Config, appName, "/logspew/1024")
+							_, _, l := stats()
+							return l
+						}, Config.CfPushTimeoutDuration()).Should(BeNumerically(">", 0.0))
 					})
 				})
 			})

--- a/windows/lifecycle.go
+++ b/windows/lifecycle.go
@@ -49,6 +49,8 @@ var _ = WindowsDescribe("Application Lifecycle", func() {
 			// #0   running   2015-06-10 02:22:39 PM   0.0%   48.7M of 2G   14M of 1G     68B/s of unlimited
 			var metrics = regexp.MustCompile(`running.*(?:[\d\.]+)%\s+([\d\.]+)[KMG]? of (?:[\d\.]+)[KMG]?\s+([\d\.]+)[KMG]? of (?:[\d\.]+)[KMG]?\s+([\d\.]+)[BKMG]?/s of (?:[\d\.]+[BKMG]?/s|unlimited)`)
 			stats := func() (float64, float64, float64) {
+				helpers.CurlApp(Config, appName, "/logspew/1024")
+
 				app := cf.Cf("app", appName)
 				Expect(app.Wait()).To(Exit(0))
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes.

### What is this change about?

* Apps that aren't logging anything don't show a log rate greater than zero.
  * Added a call to logspew in the polling so the app summary displays a log rate over zero.
* Also combined some tests to speed things up that were testing three things about the same output.
* Removed one SkipOnK8s call so we could merge tests.

### Please provide contextual information.

N/A

### What version of cf-deployment have you run this cf-acceptance-test change against?

None.

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [X] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Should save about 2 minutes because we combined tests.

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@rroberts2222