### PR TITLE
CI: update cats domain after migration

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -157,7 +157,7 @@ jobs:
       vars-files: relint-envs
     params:
       BBL_STATE_DIR: environments/test/cats/bbl-state
-      SYSTEM_DOMAIN: cats.cf-app.com
+      SYSTEM_DOMAIN: cf.cats.env.wg-ard.ci.cloudfoundry.org
       OPS_FILES: |
         operations/use-compiled-releases.yml
         operations/use-internal-lookup-for-route-services.yml
@@ -237,7 +237,7 @@ jobs:
       bbl-state: relint-envs
     params:
       BBL_STATE_DIR: environments/test/cats/bbl-state
-      SYSTEM_DOMAIN: cats.cf-app.com
+      SYSTEM_DOMAIN: cf.cats.env.wg-ard.ci.cloudfoundry.org
       ENABLED_FEATURE_FLAGS: |
         diego_docker
         task_creation


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._

### What is this change about?

The pipeline needs the new system domain after the env migration.

### Please provide contextual information.

https://github.com/cloudfoundry/cf-deployment/pull/1010.

### What version of cf-deployment have you run this cf-acceptance-test change against?

N/A

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@jochenehret @davewalter 