### PR TITLE
Additional tests for r_buildpack and nginx_buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,12 @@ include_v3
 * `staticfile_buildpack_name` [See below](#buildpack-names)
 * `java_buildpack_name` [See below](#buildpack-names)
 * `ruby_buildpack_name` [See below](#buildpack-names)
+* `nginx_buildpack_name` [See below](#buildpack-names)
 * `nodejs_buildpack_name` [See below](#buildpack-names)
 * `go_buildpack_name` [See below](#buildpack-names)
 * `python_buildpack_name` [See below](#buildpack-names)
 * `php_buildpack_name` [See below](#buildpack-names)
+* `r_buildpack_name` [See below](#buildpack-names)
 * `binary_buildpack_name` [See below](#buildpack-names)
 
 * `include_windows`: Flag to include the tests that run against Windows cells.
@@ -202,10 +204,12 @@ Many tests specify a buildpack when pushing an app, so that on diego the app sta
 * `staticfile_buildpack_name: staticfile_buildpack`
 * `java_buildpack_name: java_buildpack`
 * `ruby_buildpack_name: ruby_buildpack`
+* `nginx_buildpack_name: nginx_buildpack`
 * `nodejs_buildpack_name: nodejs_buildpack`
 * `go_buildpack_name: go_buildpack`
 * `python_buildpack_name: python_buildpack`
 * `php_buildpack_name: php_buildpack`
+* `r_buildpack_name: r_buildpack`
 * `binary_buildpack_name: binary_buildpack`
 * `hwc_buildpack_name: hwc_buildpack`
 

--- a/assets/nginx/nginx.conf
+++ b/assets/nginx/nginx.conf
@@ -1,0 +1,13 @@
+events {
+   worker_connections  1024;
+}
+
+http {
+   server {
+       listen {{port}};
+
+       location = / {
+            return 200 "Hello NGINX!";
+       }
+   }
+}

--- a/assets/r/Procfile
+++ b/assets/r/Procfile
@@ -1,0 +1,1 @@
+web: R -f simple.r

--- a/assets/r/simple.r
+++ b/assets/r/simple.r
@@ -1,0 +1,14 @@
+library(shiny)
+
+# Define the UI
+ui <- fluidPage(
+  titlePanel("Hello R!")
+)
+
+# Define the server code
+server <- function(input, output) {
+}
+
+# Return a Shiny app object
+options(shiny.port = strtoi(Sys.getenv("PORT")), shiny.host = "0.0.0.0")
+shinyApp(ui = ui, server = server)

--- a/detect/buildpacks.go
+++ b/detect/buildpacks.go
@@ -204,4 +204,40 @@ var _ = DetectDescribe("Buildpacks", func() {
 			})
 		}
 	})
+
+	Describe("nginx", func() {
+		for _, stack := range Config.GetStacks() {
+			Context(fmt.Sprintf("when using %s stack", stack), func() {
+				It("makes the app reachable via its bound route", func() {
+					Expect(cf.Cf("push", appName,
+						"-m", DEFAULT_MEMORY_LIMIT,
+						"-p", assets.NewAssets().Nginx,
+						"-s", stack,
+					).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
+
+					Eventually(func() string {
+						return helpers.CurlAppRoot(Config, appName)
+					}).Should(ContainSubstring("Hello NGINX!"))
+				})
+			})
+		}
+	})
+
+	Describe("r", func() {
+		for _, stack := range Config.GetStacks() {
+			Context(fmt.Sprintf("when using %s stack", stack), func() {
+				It("makes the app reachable via its bound route", func() {
+					Expect(cf.Cf("push", appName,
+						"-m", DEFAULT_MEMORY_LIMIT,
+						"-p", assets.NewAssets().R,
+						"-s", stack,
+					).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
+
+					Eventually(func() string {
+						return helpers.CurlAppRoot(Config, appName)
+					}).Should(ContainSubstring("Hello R!"))
+				})
+			})
+		}
+	})
 })

--- a/detect/buildpacks.go
+++ b/detect/buildpacks.go
@@ -33,6 +33,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 
 	Describe("ruby", func() {
 		for _, stack := range Config.GetStacks() {
+			stack := stack
 			Context(fmt.Sprintf("when using %s stack", stack), func() {
 				It("makes the app reachable via its bound route", func() {
 					Expect(cf.Cf("push",
@@ -52,6 +53,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 
 	Describe("node", func() {
 		for _, stack := range Config.GetStacks() {
+			stack := stack
 			Context(fmt.Sprintf("when using %s stack", stack), func() {
 				It("makes the app reachable via its bound route", func() {
 					Expect(cf.Cf("push",
@@ -71,6 +73,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 
 	Describe("java", func() {
 		for _, stack := range Config.GetStacks() {
+			stack := stack
 			Context(fmt.Sprintf("when using %s stack", stack), func() {
 				It("makes the app reachable via its bound route", func() {
 					Expect(cf.Cf("push", appName,
@@ -90,6 +93,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 
 	Describe("golang", func() {
 		for _, stack := range Config.GetStacks() {
+			stack := stack
 			Context(fmt.Sprintf("when using %s stack", stack), func() {
 				It("makes the app reachable via its bound route", func() {
 					Expect(cf.Cf("push", appName,
@@ -109,6 +113,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 
 	Describe("python", func() {
 		for _, stack := range Config.GetStacks() {
+			stack := stack
 			Context(fmt.Sprintf("when using %s stack", stack), func() {
 				It("makes the app reachable via its bound route", func() {
 					Expect(cf.Cf("push", appName,
@@ -134,6 +139,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 		})
 
 		for _, stack := range Config.GetStacks() {
+			stack := stack
 			Context(fmt.Sprintf("when using %s stack", stack), func() {
 				It("makes the app reachable via its bound route", func() {
 					Expect(cf.Cf("push", appName,
@@ -170,6 +176,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 	Describe("staticfile", func() {
 		SkipOnK8s("staticfile not yet supported, as currently structured in CATS")
 		for _, stack := range Config.GetStacks() {
+			stack := stack
 			Context(fmt.Sprintf("when using %s stack", stack), func() {
 				It("makes the app reachable via its bound route", func() {
 					Expect(cf.Cf("push", appName,
@@ -188,6 +195,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 
 	Describe("binary", func() {
 		for _, stack := range Config.GetStacks() {
+			stack := stack
 			Context(fmt.Sprintf("when using %s stack", stack), func() {
 				It("makes the app reachable via its bound route", func() {
 					Expect(cf.Cf("push", appName,
@@ -207,6 +215,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 
 	Describe("nginx", func() {
 		for _, stack := range Config.GetStacks() {
+			stack := stack
 			Context(fmt.Sprintf("when using %s stack", stack), func() {
 				It("makes the app reachable via its bound route", func() {
 					Expect(cf.Cf("push", appName,
@@ -225,6 +234,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 
 	Describe("r", func() {
 		for _, stack := range Config.GetStacks() {
+			stack := stack
 			Context(fmt.Sprintf("when using %s stack", stack), func() {
 				It("makes the app reachable via its bound route", func() {
 					Expect(cf.Cf("push", appName,

--- a/helpers/assets/assets.go
+++ b/helpers/assets/assets.go
@@ -21,12 +21,14 @@ type Assets struct {
 	LoggregatorLoadGenerator   string
 	LoggregatorLoadGeneratorGo string
 	Python                     string
+	Nginx                      string
 	Node                       string
 	NodeWithProcfile           string
 	Nora                       string
 	Pora                       string
 	Php                        string
 	Proxy                      string
+	R                          string
 	RubySimple                 string
 	SecurityGroupBuildpack     string
 	ServiceBroker              string
@@ -67,6 +69,7 @@ func NewAssets() Assets {
 		JavaUnwriteableZip:         "assets/java-unwriteable-dir/java-unwriteable-dir.jar",
 		LoggregatorLoadGenerator:   "assets/loggregator-load-generator",
 		LoggregatorLoadGeneratorGo: "assets/loggregator-load-generator-go",
+		Nginx:                      "assets/nginx",
 		Node:                       "assets/node",
 		NodeWithProcfile:           "assets/node-with-procfile",
 		Nora:                       "assets/nora/NoraPublished",
@@ -74,6 +77,7 @@ func NewAssets() Assets {
 		Php:                        "assets/php",
 		Proxy:                      "assets/proxy",
 		Python:                     "assets/python",
+		R:                          "assets/r",
 		RubySimple:                 "assets/ruby_simple",
 		SecurityGroupBuildpack:     "assets/security_group_buildpack.zip",
 		ServiceBroker:              "assets/service_broker",

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -66,10 +66,12 @@ type CatsConfig interface {
 	GetIsolationSegmentDomain() string
 	GetJavaBuildpackName() string
 	GetNamePrefix() string
+	GetNginxBuildpackName() string
 	GetNodejsBuildpackName() string
 	GetPrivateDockerRegistryImage() string
 	GetPrivateDockerRegistryUsername() string
 	GetPrivateDockerRegistryPassword() string
+	GetRBuildpackName() string
 	GetRubyBuildpackName() string
 	GetUnallocatedIPForSecurityGroup() string
 	GetRequireProxiedAppTraffic() bool

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -56,9 +56,11 @@ type config struct {
 	GoBuildpackName         *string `json:"go_buildpack_name"`
 	HwcBuildpackName        *string `json:"hwc_buildpack_name"`
 	JavaBuildpackName       *string `json:"java_buildpack_name"`
+	NginxBuildpackName      *string `json:"nginx_buildpack_name"`
 	NodejsBuildpackName     *string `json:"nodejs_buildpack_name"`
 	PhpBuildpackName        *string `json:"php_buildpack_name"`
 	PythonBuildpackName     *string `json:"python_buildpack_name"`
+	RBuildpackName          *string `json:"r_buildpack_name"`
 	RubyBuildpackName       *string `json:"ruby_buildpack_name"`
 	StaticFileBuildpackName *string `json:"staticfile_buildpack_name"`
 
@@ -151,9 +153,11 @@ func getDefaults() config {
 	defaults.GoBuildpackName = ptrToString("go_buildpack")
 	defaults.HwcBuildpackName = ptrToString("hwc_buildpack")
 	defaults.JavaBuildpackName = ptrToString("java_buildpack")
+	defaults.NginxBuildpackName = ptrToString("nginx_buildpack")
 	defaults.NodejsBuildpackName = ptrToString("nodejs_buildpack")
 	defaults.PhpBuildpackName = ptrToString("php_buildpack")
 	defaults.PythonBuildpackName = ptrToString("python_buildpack")
+	defaults.RBuildpackName = ptrToString("r_buildpack")
 	defaults.RubyBuildpackName = ptrToString("ruby_buildpack")
 	defaults.StaticFileBuildpackName = ptrToString("staticfile_buildpack")
 
@@ -375,6 +379,9 @@ func validateConfig(config *config) Errors {
 	if config.JavaBuildpackName == nil {
 		errs.Add(fmt.Errorf("* 'java_buildpack_name' must not be null"))
 	}
+	if config.NginxBuildpackName == nil {
+		errs.Add(fmt.Errorf("* 'nginx_buildpack_name' must not be null"))
+	}
 	if config.NodejsBuildpackName == nil {
 		errs.Add(fmt.Errorf("* 'nodejs_buildpack_name' must not be null"))
 	}
@@ -383,6 +390,9 @@ func validateConfig(config *config) Errors {
 	}
 	if config.PythonBuildpackName == nil {
 		errs.Add(fmt.Errorf("* 'python_buildpack_name' must not be null"))
+	}
+	if config.RBuildpackName == nil {
+		errs.Add(fmt.Errorf("* 'r_buildpack_name' must not be null"))
 	}
 	if config.RubyBuildpackName == nil {
 		errs.Add(fmt.Errorf("* 'ruby_buildpack_name' must not be null"))
@@ -991,6 +1001,10 @@ func (c *config) GetIncludeVolumeServices() bool {
 	return *c.IncludeVolumeServices
 }
 
+func (c *config) GetRBuildpackName() string {
+	return *c.RBuildpackName
+}
+
 func (c *config) GetRubyBuildpackName() string {
 	return *c.RubyBuildpackName
 }
@@ -1005,6 +1019,10 @@ func (c *config) GetHwcBuildpackName() string {
 
 func (c *config) GetJavaBuildpackName() string {
 	return *c.JavaBuildpackName
+}
+
+func (c *config) GetNginxBuildpackName() string {
+	return *c.NginxBuildpackName
 }
 
 func (c *config) GetNodejsBuildpackName() string {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -114,9 +114,11 @@ type allConfig struct {
 	GoBuildpackName         *string `json:"go_buildpack_name"`
 	HwcBuildpackName        *string `json:"hwc_buildpack_name"`
 	JavaBuildpackName       *string `json:"java_buildpack_name"`
+	NginxBuildpackName      *string `json:"nginx_buildpack_name"`
 	NodejsBuildpackName     *string `json:"nodejs_buildpack_name"`
 	PhpBuildpackName        *string `json:"php_buildpack_name"`
 	PythonBuildpackName     *string `json:"python_buildpack_name"`
+	RBuildpackName          *string `json:"r_buildpack_name"`
 	RubyBuildpackName       *string `json:"ruby_buildpack_name"`
 	StaticFileBuildpackName *string `json:"staticfile_buildpack_name"`
 


### PR DESCRIPTION
### What is this change about?

Additional tests for r_buildpack and nginx_buildpack, in particular to test the new cflinuxfs4 stack.

### Please provide contextual information.

https://github.com/cloudfoundry/cf-deployment/issues/989

### What version of cf-deployment have you run this cf-acceptance-test change against?

v23.3.0

### Please check all that apply for this PR:

- [x] introduces a new test
- [ ] changes an existing test
- [x] requires an update to a CATs integration-config (only if r_buildpack or nginx_buildpack don't have the standard names)

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

We want to verify that all buildpacks that come with cf-deployment support the new cflinuxfs4 stack. This is tested in the cf-deployment pipeline here:
https://app-runtime-deployments.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/experimental-cats-cflinuxfs4

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Execution times were measured on https://app-runtime-deployments.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/experimental-cats

Before (229 specs): 39min 30sec average
After (331 specs): 37min

Looks like CATs on a warmed up CF run a bit faster... I would have expected a slight increase as we do 2 additional cf pushes.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
