### PR TITLE
Fix: replace ioutil use as the package is deprecated

### DIFF
--- a/apps/admin_buildpack_lifecycle.go
+++ b/apps/admin_buildpack_lifecycle.go
@@ -2,7 +2,6 @@ package apps
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -69,12 +68,12 @@ var _ = AppsDescribe("Admin Buildpacks", func() {
 			appName = CATSRandomName("APP")
 			appNames = append(appNames, appName)
 
-			tmpdir, err := ioutil.TempDir(os.TempDir(), "matching-app")
+			tmpdir, err := os.MkdirTemp(os.TempDir(), "matching-app")
 			Expect(err).ToNot(HaveOccurred())
 
 			appPath = tmpdir
 
-			tmpdir, err = ioutil.TempDir(os.TempDir(), "matching-buildpack")
+			tmpdir, err = os.MkdirTemp(os.TempDir(), "matching-buildpack")
 			Expect(err).ToNot(HaveOccurred())
 
 			buildpackPath = tmpdir
@@ -140,12 +139,12 @@ EOF
 			appName = CATSRandomName("APP")
 			appNames = append(appNames, appName)
 
-			tmpdir, err := ioutil.TempDir(os.TempDir(), "matching-app")
+			tmpdir, err := os.MkdirTemp(os.TempDir(), "matching-app")
 			Expect(err).ToNot(HaveOccurred())
 
 			appPath = tmpdir
 
-			tmpdir, err = ioutil.TempDir(os.TempDir(), "matching-buildpack")
+			tmpdir, err = os.MkdirTemp(os.TempDir(), "matching-buildpack")
 			Expect(err).ToNot(HaveOccurred())
 
 			buildpackPath = tmpdir
@@ -211,12 +210,12 @@ EOF
 			appName = CATSRandomName("APP")
 			appNames = append(appNames, appName)
 
-			tmpdir, err := ioutil.TempDir(os.TempDir(), "matching-app")
+			tmpdir, err := os.MkdirTemp(os.TempDir(), "matching-app")
 			Expect(err).ToNot(HaveOccurred())
 
 			appPath = tmpdir
 
-			tmpdir, err = ioutil.TempDir(os.TempDir(), "matching-buildpack")
+			tmpdir, err = os.MkdirTemp(os.TempDir(), "matching-buildpack")
 			Expect(err).ToNot(HaveOccurred())
 
 			buildpackPath = tmpdir

--- a/apps/app_stack.go
+++ b/apps/app_stack.go
@@ -2,7 +2,6 @@ package apps
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -46,12 +45,12 @@ var _ = AppsDescribe("Specifying a specific stack", func() {
 			appName = CATSRandomName("APP")
 
 			var err error
-			tmpdir, err = ioutil.TempDir("", "stack")
+			tmpdir, err = os.MkdirTemp("", "stack")
 			Expect(err).ToNot(HaveOccurred())
-			appPath, err = ioutil.TempDir(tmpdir, "matching-app")
+			appPath, err = os.MkdirTemp(tmpdir, "matching-app")
 			Expect(err).ToNot(HaveOccurred())
 
-			buildpackPath, err = ioutil.TempDir(tmpdir, "matching-buildpack")
+			buildpackPath, err = os.MkdirTemp(tmpdir, "matching-buildpack")
 			Expect(err).ToNot(HaveOccurred())
 
 			buildpackArchivePath = path.Join(buildpackPath, "buildpack.zip")

--- a/apps/app_staging_environment.go
+++ b/apps/app_staging_environment.go
@@ -2,7 +2,6 @@ package apps
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -44,12 +43,12 @@ var _ = AppsDescribe("Buildpack Environment", func() {
 			appName = CATSRandomName("APP")
 
 			var err error
-			tmpdir, err = ioutil.TempDir("", "buildpack_env")
+			tmpdir, err = os.MkdirTemp("", "buildpack_env")
 			Expect(err).ToNot(HaveOccurred())
-			appPath, err = ioutil.TempDir(tmpdir, "matching-app")
+			appPath, err = os.MkdirTemp(tmpdir, "matching-app")
 			Expect(err).ToNot(HaveOccurred())
 
-			buildpackPath, err = ioutil.TempDir(tmpdir, "matching-buildpack")
+			buildpackPath, err = os.MkdirTemp(tmpdir, "matching-buildpack")
 			Expect(err).ToNot(HaveOccurred())
 
 			buildpackArchivePath = path.Join(buildpackPath, "buildpack.zip")

--- a/apps/buildpack_cache.go
+++ b/apps/buildpack_cache.go
@@ -2,7 +2,6 @@ package apps
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -43,12 +42,12 @@ var _ = AppsDescribe("Buildpack cache", func() {
 			BuildpackName = CATSRandomName("BPK")
 			appName = CATSRandomName("APP")
 
-			tmpdir, err := ioutil.TempDir(os.TempDir(), "matching-app")
+			tmpdir, err := os.MkdirTemp(os.TempDir(), "matching-app")
 			Expect(err).ToNot(HaveOccurred())
 
 			appPath = tmpdir
 
-			tmpdir, err = ioutil.TempDir(os.TempDir(), "matching-buildpack")
+			tmpdir, err = os.MkdirTemp(os.TempDir(), "matching-buildpack")
 			Expect(err).ToNot(HaveOccurred())
 
 			buildpackPath = tmpdir

--- a/apps/default_environment_variables.go
+++ b/apps/default_environment_variables.go
@@ -2,7 +2,7 @@ package apps
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -25,7 +25,7 @@ import (
 
 var _ = AppsDescribe("Default Environment Variables", func() {
 	var createBuildpack = func() string {
-		tmpPath, err := ioutil.TempDir("", "default-env-var-test")
+		tmpPath, err := os.MkdirTemp("", "default-env-var-test")
 		Expect(err).ToNot(HaveOccurred())
 
 		buildpackArchivePath := path.Join(tmpPath, "buildpack.zip")

--- a/apps/droplet_uploading_and_downloading.go
+++ b/apps/droplet_uploading_and_downloading.go
@@ -1,7 +1,6 @@
 package apps
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -29,7 +28,7 @@ func appGuid(appName string) string {
 
 func makeTempDir() string {
 	// This defers from the typical way temp directories are created (using the OS default), because the GNUWin32 tar.exe does not allow file paths to be prefixed with a drive letter.
-	tmpdir, err := ioutil.TempDir(".", "droplet-download")
+	tmpdir, err := os.MkdirTemp(".", "droplet-download")
 	Expect(err).ToNot(HaveOccurred())
 	return tmpdir
 }

--- a/apps/environment_variables_group.go
+++ b/apps/environment_variables_group.go
@@ -3,7 +3,7 @@ package apps
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strconv"
 	"time"
@@ -32,7 +32,7 @@ var _ = AppsDescribe("Environment Variables Groups", func() {
 	}
 
 	var createBuildpack = func(envVarName string) string {
-		tmpPath, err := ioutil.TempDir("", "env-group-staging")
+		tmpPath, err := os.MkdirTemp("", "env-group-staging")
 		Expect(err).ToNot(HaveOccurred())
 
 		buildpackArchivePath := path.Join(tmpPath, "buildpack.zip")

--- a/assets/logging-route-service/main.go
+++ b/assets/logging-route-service/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -43,11 +43,11 @@ func NewProxy(transport http.RoundTripper, skipSslValidation bool) http.Handler 
 			var body []byte
 			var err error
 			if req.Body != nil {
-				body, err = ioutil.ReadAll(req.Body)
+				body, err = io.ReadAll(req.Body)
 				if err != nil {
 					log.Fatalln(err.Error())
 				}
-				req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+				req.Body = io.NopCloser(bytes.NewBuffer(body))
 			}
 			logRequest(forwardedURL, sigHeader, string(body), req.Header, skipSslValidation)
 
@@ -104,7 +104,7 @@ func (lrt *LoggingRoundTripper) RoundTrip(request *http.Request) (*http.Response
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Fatalln(err.Error())
 	}
@@ -113,7 +113,7 @@ func (lrt *LoggingRoundTripper) RoundTrip(request *http.Request) (*http.Response
 	log.Println("")
 	log.Printf("Response Body: %s\n", string(body))
 	log.Println("")
-	res.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+	res.Body = io.NopCloser(bytes.NewBuffer(body))
 
 	log.Println("Sending response to GoRouter...")
 

--- a/assets/pora/server.go
+++ b/assets/pora/server.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -79,13 +78,13 @@ func write(res http.ResponseWriter, req *http.Request) {
 	mountPointPath := getPath() + "/poratest-" + randomString(10)
 
 	d1 := []byte("Hello Persistent World!\n")
-	err := ioutil.WriteFile(mountPointPath, d1, 0644)
+	err := os.WriteFile(mountPointPath, d1, 0644)
 	if err != nil {
 		writeError(res, "Writing \n", err)
 		return
 	}
 
-	body, err := ioutil.ReadFile(mountPointPath)
+	body, err := os.ReadFile(mountPointPath)
 	if err != nil {
 		writeError(res, "Reading \n", err)
 		return
@@ -107,7 +106,7 @@ func dataLoad(res http.ResponseWriter, req *http.Request) {
 	mountPointPath := getPath() + "/poraload-" + randomString(10)
 
 	d1 := []byte("Hello Persistent World!\n")
-	err := ioutil.WriteFile(mountPointPath, d1, 0644)
+	err := os.WriteFile(mountPointPath, d1, 0644)
 	if err != nil {
 		writeError(res, "Writing \n", err)
 		return
@@ -116,12 +115,12 @@ func dataLoad(res http.ResponseWriter, req *http.Request) {
 	var totalIO int
 	for startTime := time.Now(); time.Since(startTime) < 4*time.Second; {
 		d2 := []byte(randomString(1048576))
-		err := ioutil.WriteFile(mountPointPath, d2, 0644)
+		err := os.WriteFile(mountPointPath, d2, 0644)
 		if err != nil {
 			writeError(res, "Writing Load\n", err)
 			return
 		}
-		body, err := ioutil.ReadFile(mountPointPath)
+		body, err := os.ReadFile(mountPointPath)
 		if err != nil {
 			writeError(res, "Reading Load\n", err)
 			return
@@ -159,13 +158,13 @@ func backgroundLoad() {
 		filePath := filepath.Join(dirPath, "poraload-"+os.Getenv("INSTANCE_INDEX"))
 
 		d2 := []byte(randomString(1048576))
-		err := ioutil.WriteFile(filePath, d2, 0644)
+		err := os.WriteFile(filePath, d2, 0644)
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
 
-		body, err := ioutil.ReadFile(filePath)
+		body, err := os.ReadFile(filePath)
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -207,7 +206,7 @@ func createFile(res http.ResponseWriter, _ *http.Request) {
 	mountPointPath := filepath.Join(getPath(), fileName)
 
 	d1 := []byte("Hello Persistent World!\n")
-	err := ioutil.WriteFile(mountPointPath, d1, 0644)
+	err := os.WriteFile(mountPointPath, d1, 0644)
 	if err != nil {
 		writeError(res, "Writing \n", err)
 		return
@@ -236,7 +235,7 @@ func readFile(res http.ResponseWriter, req *http.Request) {
 	fileName := parts[len(parts)-1]
 	mountPointPath := filepath.Join(getPath(), fileName)
 
-	body, err := ioutil.ReadFile(mountPointPath)
+	body, err := os.ReadFile(mountPointPath)
 	if err != nil {
 		res.WriteHeader(http.StatusNotFound)
 		res.Write([]byte(err.Error()))

--- a/assets/proxy/main.go
+++ b/assets/proxy/main.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -77,7 +77,7 @@ func handleRequest(destination string, resp http.ResponseWriter, req *http.Reque
 	}
 	defer getResp.Body.Close()
 
-	readBytes, err := ioutil.ReadAll(getResp.Body)
+	readBytes, err := io.ReadAll(getResp.Body)
 	if err != nil {
 		resp.WriteHeader(http.StatusInternalServerError)
 		_, _ = resp.Write([]byte(fmt.Sprintf("read body failed: %s", err)))

--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -2,7 +2,6 @@ package cats_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -89,7 +88,7 @@ func TestCATS(t *testing.T) {
 		err = buildCmd.Run()
 		Expect(err).NotTo(HaveOccurred())
 
-		doraFiles, err := ioutil.ReadDir(assets.NewAssets().Dora)
+		doraFiles, err := os.ReadDir(assets.NewAssets().Dora)
 		Expect(err).NotTo(HaveOccurred())
 
 		var doraFileNames []string

--- a/credhub/service_bindings.go
+++ b/credhub/service_bindings.go
@@ -1,7 +1,6 @@
 package credhub
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -146,12 +145,12 @@ var _ = CredhubDescribe("service bindings", func() {
 				appName = random_name.CATSRandomName("APP")
 
 				var err error
-				tmpdir, err = ioutil.TempDir("", "buildpack_env")
+				tmpdir, err = os.MkdirTemp("", "buildpack_env")
 				Expect(err).ToNot(HaveOccurred())
-				appPath, err = ioutil.TempDir(tmpdir, "matching-app")
+				appPath, err = os.MkdirTemp(tmpdir, "matching-app")
 				Expect(err).ToNot(HaveOccurred())
 
-				buildpackPath, err = ioutil.TempDir(tmpdir, "matching-buildpack")
+				buildpackPath, err = os.MkdirTemp(tmpdir, "matching-buildpack")
 				Expect(err).ToNot(HaveOccurred())
 
 				buildpackArchivePath = path.Join(buildpackPath, "buildpack.zip")

--- a/helpers/app_helpers/app_helpers.go
+++ b/helpers/app_helpers/app_helpers.go
@@ -2,7 +2,7 @@ package app_helpers
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -30,7 +30,7 @@ func CatnipWithArgs(appName string, args ...string) []string {
 	}
 
 	if Config.RunningOnK8s() {
-		ioutil.WriteFile("assets/catnip/bin/Procfile", []byte("web: ./catnip"), 0644)
+		os.WriteFile("assets/catnip/bin/Procfile", []byte("web: ./catnip"), 0644)
 	}
 
 	pushArgs = append(pushArgs, args...)
@@ -51,7 +51,7 @@ func BinaryWithArgs(appName string, args ...string) []string {
 	}
 
 	if Config.RunningOnK8s() {
-		ioutil.WriteFile("assets/binary/bin/Procfile", []byte("web: ./app"), 0644)
+		os.WriteFile("assets/binary/bin/Procfile", []byte("web: ./app"), 0644)
 	}
 
 	pushArgs = append(pushArgs, args...)

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -2,7 +2,6 @@ package config_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -175,7 +174,7 @@ var tmpFilePath string
 var testCfg testConfig
 
 func writeConfigFile(updatedConfig interface{}) string {
-	configFile, err := ioutil.TempFile("", "cf-test-helpers-config")
+	configFile, err := os.CreateTemp("", "cf-test-helpers-config")
 	Expect(err).NotTo(HaveOccurred())
 
 	encoder := json.NewEncoder(configFile)

--- a/helpers/services/broker.go
+++ b/helpers/services/broker.go
@@ -4,8 +4,9 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"strings"
 
 	. "github.com/onsi/gomega"
@@ -138,7 +139,7 @@ func (b ServiceBroker) GetApiInfoUrl() string {
 	Expect(err).ToNot(HaveOccurred())
 	defer resp.Body.Close()
 
-	respData, err := ioutil.ReadAll(resp.Body)
+	respData, err := io.ReadAll(resp.Body)
 	Expect(err).ToNot(HaveOccurred())
 	return string(respData)
 }
@@ -190,7 +191,7 @@ func (b ServiceBroker) Destroy() {
 }
 
 func (b ServiceBroker) ToJSON() string {
-	bytes, err := ioutil.ReadFile(assets.NewAssets().ServiceBroker + "/cats.json")
+	bytes, err := os.ReadFile(assets.NewAssets().ServiceBroker + "/cats.json")
 	Expect(err).To(BeNil())
 
 	planSchema, err := json.Marshal(b.SyncPlans[0].Schemas)

--- a/helpers/services/sso.go
+++ b/helpers/services/sso.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"regexp"
@@ -54,7 +53,7 @@ func SetOauthEndpoints(apiInfoEndpoint string, oAuthConfig *OAuthConfig, config 
 func AuthenticateUser(authorizationEndpoint string, username string, password string) (cookie string) {
 	loginCsrfUri := fmt.Sprintf("%v/login", authorizationEndpoint)
 
-	cookieFile, err := ioutil.TempFile("", random_name.CATSRandomName("CATS-CSRF-COOKIE"))
+	cookieFile, err := os.CreateTemp("", random_name.CATSRandomName("CATS-CSRF-COOKIE"))
 	Expect(err).ToNot(HaveOccurred())
 	cookiePath := cookieFile.Name()
 	defer func() {

--- a/routing/session_affinity.go
+++ b/routing/session_affinity.go
@@ -2,7 +2,6 @@ package routing
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -39,7 +38,7 @@ var _ = RoutingDescribe("Session Affinity", func() {
 				"-p", stickyAsset,
 			).Wait(Config.CfPushTimeoutDuration())).To(gexec.Exit(0))
 
-			cookieStore, err := ioutil.TempFile("", "cats-sticky-session")
+			cookieStore, err := os.CreateTemp("", "cats-sticky-session")
 			Expect(err).ToNot(HaveOccurred())
 			cookieStorePath = cookieStore.Name()
 			cookieStore.Close()
@@ -159,7 +158,7 @@ var _ = RoutingDescribe("Session Affinity", func() {
 			Expect(cf.Cf("map-route", app1, domain, "--hostname", hostname, "--path", app1Path).Wait()).To(gexec.Exit(0))
 			Expect(cf.Cf("map-route", app2, domain, "--hostname", hostname, "--path", app2Path).Wait()).To(gexec.Exit(0))
 
-			cookieStore, err := ioutil.TempFile("", "cats-sticky-session")
+			cookieStore, err := os.CreateTemp("", "cats-sticky-session")
 			Expect(err).ToNot(HaveOccurred())
 			cookieStorePath = cookieStore.Name()
 			cookieStore.Close()
@@ -239,7 +238,7 @@ var _ = RoutingDescribe("Session Affinity", func() {
 
 			Expect(cf.Cf("map-route", app2, domain, "--hostname", hostname, "--path", app2Path).Wait()).To(gexec.Exit(0))
 
-			cookieStore, err := ioutil.TempFile("", "cats-sticky-session")
+			cookieStore, err := os.CreateTemp("", "cats-sticky-session")
 			Expect(err).ToNot(HaveOccurred())
 			cookieStorePath = cookieStore.Name()
 			cookieStore.Close()

--- a/security_groups/dynamic_asgs.go
+++ b/security_groups/dynamic_asgs.go
@@ -3,7 +3,7 @@ package security_groups_test
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -65,7 +65,7 @@ var _ = Describe("Dynamic ASGs", func() {
 		resp, err := client.Get(proxyRequestURL)
 		Expect(err).NotTo(HaveOccurred())
 
-		respBytes, err := ioutil.ReadAll(resp.Body)
+		respBytes, err := io.ReadAll(resp.Body)
 		Expect(err).ToNot(HaveOccurred())
 		resp.Body.Close()
 		Expect(respBytes).To(MatchRegexp("refused"))
@@ -84,7 +84,7 @@ var _ = Describe("Dynamic ASGs", func() {
 			resp, err = client.Get(proxyRequestURL)
 			Expect(err).NotTo(HaveOccurred())
 
-			respBytes, err = ioutil.ReadAll(resp.Body)
+			respBytes, err = io.ReadAll(resp.Body)
 			Expect(err).ToNot(HaveOccurred())
 			resp.Body.Close()
 			return respBytes
@@ -98,7 +98,7 @@ var _ = Describe("Dynamic ASGs", func() {
 			resp, err = client.Get(proxyRequestURL)
 			Expect(err).NotTo(HaveOccurred())
 
-			respBytes, err = ioutil.ReadAll(resp.Body)
+			respBytes, err = io.ReadAll(resp.Body)
 			Expect(err).ToNot(HaveOccurred())
 			resp.Body.Close()
 			return respBytes

--- a/security_groups/running_security_groups.go
+++ b/security_groups/running_security_groups.go
@@ -3,7 +3,6 @@ package security_groups_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -99,7 +98,7 @@ type Destination struct {
 }
 
 func createSecurityGroup(allowedDestinations ...Destination) string {
-	file, err := ioutil.TempFile(os.TempDir(), "CATS-sg-rules")
+	file, err := os.CreateTemp(os.TempDir(), "CATS-sg-rules")
 	Expect(err).NotTo(HaveOccurred())
 	defer os.Remove(file.Name())
 

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -3,7 +3,7 @@ package ssh
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os/exec"
 	"strings"
 
@@ -117,10 +117,10 @@ var _ = SshDescribe("SSH", func() {
 			err = stdin.Close()
 			Expect(err).NotTo(HaveOccurred())
 
-			output, err := ioutil.ReadAll(stdout)
+			output, err := io.ReadAll(stdout)
 			Expect(err).NotTo(HaveOccurred())
 
-			errOutput, err := ioutil.ReadAll(stderr)
+			errOutput, err := io.ReadAll(stderr)
 			Expect(err).NotTo(HaveOccurred())
 
 			exitErr := envCmd.Wait()

--- a/tasks/task.go
+++ b/tasks/task.go
@@ -3,7 +3,6 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"strconv"
@@ -90,7 +89,7 @@ func getContainerIP(listenAddresses []string) string {
 }
 
 func createSecurityGroup(allowedDestinations ...Destination) string {
-	file, _ := ioutil.TempFile(os.TempDir(), "CATS-sg-rules")
+	file, _ := os.CreateTemp(os.TempDir(), "CATS-sg-rules")
 	defer os.Remove(file.Name())
 	Expect(json.NewEncoder(file).Encode(allowedDestinations)).To(Succeed())
 

--- a/v3/buildpacks.go
+++ b/v3/buildpacks.go
@@ -3,7 +3,7 @@ package v3
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"time"
 
@@ -177,7 +177,7 @@ var _ = V3Describe("buildpack", func() {
 })
 
 func createBuildpack() string {
-	tmpPath, err := ioutil.TempDir("", "buildpack-cats")
+	tmpPath, err := os.MkdirTemp("", "buildpack-cats")
 	Expect(err).ToNot(HaveOccurred())
 
 	buildpackArchivePath := path.Join(tmpPath, "buildpack.zip")

--- a/v3/deployment.go
+++ b/v3/deployment.go
@@ -2,7 +2,6 @@ package v3
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -218,7 +217,7 @@ func checkAppRemainsAlive(appName string) (chan<- bool, <-chan bool) {
 }
 
 func makeStaticFileZip() {
-	staticFiles, err := ioutil.ReadDir(assets.NewAssets().Staticfile)
+	staticFiles, err := os.ReadDir(assets.NewAssets().Staticfile)
 	Expect(err).NotTo(HaveOccurred())
 
 	var staticFileNames []string

--- a/v3/package.go
+++ b/v3/package.go
@@ -3,7 +3,6 @@ package v3
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -79,7 +78,7 @@ var _ = V3Describe("package features", func() {
 
 			WaitForPackageToBeReady(copiedPackageGuid)
 
-			tmpdir, err := ioutil.TempDir(os.TempDir(), "package-download")
+			tmpdir, err := os.MkdirTemp(os.TempDir(), "package-download")
 			Expect(err).ToNot(HaveOccurred())
 			app_package_path := path.Join(tmpdir, destinationAppName)
 

--- a/windows/credhub_assist.go
+++ b/windows/credhub_assist.go
@@ -1,7 +1,6 @@
 package windows
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -137,10 +136,10 @@ var _ = WindowsCredhubDescribe("CredHub Integration", func() {
 				appName = random_name.CATSRandomName("APP")
 
 				var err error
-				tmpdir, err = ioutil.TempDir("", "buildpack_env")
+				tmpdir, err = os.MkdirTemp("", "buildpack_env")
 				Expect(err).ToNot(HaveOccurred())
 
-				buildpackPath, err = ioutil.TempDir(tmpdir, "matching-buildpack")
+				buildpackPath, err = os.MkdirTemp(tmpdir, "matching-buildpack")
 				Expect(err).ToNot(HaveOccurred())
 
 				buildpackArchivePath = path.Join(buildpackPath, "buildpack.zip")

--- a/windows/running_security_groups_win.go
+++ b/windows/running_security_groups_win.go
@@ -3,7 +3,6 @@ package windows
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers"
@@ -80,7 +79,7 @@ type Destination struct {
 }
 
 func createSecurityGroup(allowedDestinations ...Destination) string {
-	file, _ := ioutil.TempFile(os.TempDir(), "CATS-sg-rules")
+	file, _ := os.CreateTemp(os.TempDir(), "CATS-sg-rules")
 	defer os.Remove(file.Name())
 	Expect(json.NewEncoder(file).Encode(allowedDestinations)).To(Succeed())
 

--- a/windows/ssh.go
+++ b/windows/ssh.go
@@ -3,7 +3,7 @@ package windows
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os/exec"
 	"strings"
 
@@ -117,7 +117,7 @@ var _ = WindowsDescribe("SSH", func() {
 			err = stdin.Close()
 			Expect(err).NotTo(HaveOccurred())
 
-			output, err := ioutil.ReadAll(stdout)
+			output, err := io.ReadAll(stdout)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = envCmd.Wait()


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

ioutil has been deprecated since Go 1.16 and should be replaced with io and os functions.

### Please provide contextual information.

None

### What version of cf-deployment have you run this cf-acceptance-test change against?

None

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None