### PR TITLE
Use configurable buildpack names instead of hard-coded strings

### DIFF
--- a/apps/default_environment_variables.go
+++ b/apps/default_environment_variables.go
@@ -114,7 +114,7 @@ exit 1
 			Eventually(cf.Cf(
 				"push", appName,
 				"-p", assets.NewAssets().Binary,
-				"-b", "binary_buildpack",
+				"-b", Config.GetBinaryBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 			),
 				Config.CfPushTimeoutDuration(),

--- a/apps/lifecycle.go
+++ b/apps/lifecycle.go
@@ -341,7 +341,7 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 				found, matchingEvent := lastAppUsageEventWithParentAppName(appName, "BUILDPACK_SET")
 
 				Expect(found).To(BeTrue())
-				Expect(matchingEvent.Buildpack.Name).To(Equal("binary_buildpack"))
+				Expect(matchingEvent.Buildpack.Name).To(Equal(Config.GetBinaryBuildpackName()))
 				Expect(matchingEvent.Buildpack.Guid).ToNot(BeZero())
 			})
 		})

--- a/isolation_segments/isolation_segments.go
+++ b/isolation_segments/isolation_segments.go
@@ -96,7 +96,7 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 					"push", appName,
 					"-p", assets.NewAssets().Binary,
 					"-m", DEFAULT_MEMORY_LIMIT,
-					"-b", "binary_buildpack",
+					"-b", Config.GetBinaryBuildpackName(),
 					"-c", "./app"),
 					Config.CfPushTimeoutDuration()).Should(Exit(0))
 
@@ -123,7 +123,7 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 					appName,
 					"-p", assets.NewAssets().Binary,
 					"-m", DEFAULT_MEMORY_LIMIT,
-					"-b", "binary_buildpack",
+					"-b", Config.GetBinaryBuildpackName(),
 					"-d", isoSegDomain,
 					"-c", "./app"),
 					Config.CfPushTimeoutDuration()).Should(Exit(0))
@@ -170,7 +170,7 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 					appName,
 					"-p", assets.NewAssets().Binary,
 					"-m", DEFAULT_MEMORY_LIMIT,
-					"-b", "binary_buildpack",
+					"-b", Config.GetBinaryBuildpackName(),
 					"-d", isoSegDomain,
 					"-c", "./app"),
 					Config.CfPushTimeoutDuration()).Should(Exit(1))
@@ -221,7 +221,7 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 					appName,
 					"-p", assets.NewAssets().Binary,
 					"-m", DEFAULT_MEMORY_LIMIT,
-					"-b", "binary_buildpack",
+					"-b", Config.GetBinaryBuildpackName(),
 					"-d", isoSegDomain,
 					"-c", "./app"),
 					Config.CfPushTimeoutDuration()).Should(Exit(0))

--- a/routing_isolation_segments/routing_isolation_segments.go
+++ b/routing_isolation_segments/routing_isolation_segments.go
@@ -83,7 +83,7 @@ var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
 					"push", appName,
 					"-p", assets.NewAssets().Binary,
 					"-m", DEFAULT_MEMORY_LIMIT,
-					"-b", "binary_buildpack",
+					"-b", Config.GetBinaryBuildpackName(),
 					"-c", "./app"),
 					Config.CfPushTimeoutDuration()).Should(Exit(0))
 			})
@@ -128,7 +128,7 @@ var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
 					appName,
 					"-p", assets.NewAssets().Binary,
 					"-m", DEFAULT_MEMORY_LIMIT,
-					"-b", "binary_buildpack",
+					"-b", Config.GetBinaryBuildpackName(),
 					"-d", isoSegDomain,
 					"-c", "./app"),
 					Config.CfPushTimeoutDuration()).Should(Exit(0))

--- a/v3/app_lifecycle.go
+++ b/v3/app_lifecycle.go
@@ -48,7 +48,7 @@ var _ = V3Describe("v3 buildpack app lifecycle", func() {
 		DeleteApp(appGuid)
 	})
 
-	Context("with a ruby_buildpack", func() {
+	Context("with a ruby buildpack", func() {
 		BeforeEach(func() {
 			UploadPackage(uploadUrl, assets.NewAssets().DoraZip, token)
 			WaitForPackageToBeReady(packageGuid)
@@ -151,7 +151,7 @@ var _ = V3Describe("v3 buildpack app lifecycle", func() {
 		})
 	})
 
-	Context("with a java_buildpack", func() {
+	Context("with a java buildpack", func() {
 		BeforeEach(func() {
 			UploadPackage(uploadUrl, assets.NewAssets().JavaSpringZip, token)
 			WaitForPackageToBeReady(packageGuid)

--- a/v3/buildpacks.go
+++ b/v3/buildpacks.go
@@ -146,14 +146,14 @@ var _ = V3Describe("buildpack", func() {
 			Expect(len(droplet.Buildpacks)).To(Equal(2))
 			i := 0
 			j := 1
-			if droplet.Buildpacks[0].Name == "go_buildpack" {
+			if droplet.Buildpacks[0].Name == Config.GetGoBuildpackName() {
 				i, j = j, i
 			}
-			Expect(droplet.Buildpacks[i].Name).To(Equal("ruby_buildpack"))
+			Expect(droplet.Buildpacks[i].Name).To(Equal(Config.GetRubyBuildpackName()))
 			Expect(droplet.Buildpacks[i].DetectOutput).To(Equal(""))
 			Expect(droplet.Buildpacks[i].BuildpackName).To(Equal("ruby"))
 			Expect(droplet.Buildpacks[i].Version).ToNot(BeEmpty())
-			Expect(droplet.Buildpacks[j].Name).To(Equal("go_buildpack"))
+			Expect(droplet.Buildpacks[j].Name).To(Equal(Config.GetGoBuildpackName()))
 			Expect(droplet.Buildpacks[j].DetectOutput).To(Equal("go"))
 			Expect(droplet.Buildpacks[j].BuildpackName).To(Equal("go"))
 			Expect(droplet.Buildpacks[j].Version).ToNot(BeEmpty())


### PR DESCRIPTION
Signed-off-by: Aram Price <pricear@vmware.com>

### What is this change about?

Some tests are still using hard-coded values to refer to buildpack names. These values can be retrieved from the Config object. Using the Config object in all places ensures that modifying the Config results in consistent behavior throughout CATs.

### What version of cf-deployment have you run this cf-acceptance-test change against?
v24.6.0


### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?
N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
None


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@aramprice 