### PR TITLE
Remove unused Fuse Mount assets

### DIFF
--- a/helpers/assets/assets.go
+++ b/helpers/assets/assets.go
@@ -8,7 +8,6 @@ type Assets struct {
 	Dora                       string
 	DoraZip                    string
 	DotnetCore                 map[string]string
-	Fuse                       string
 	GoCallsRubyZip             string
 	Golang                     string
 	GRPC                       string
@@ -57,7 +56,6 @@ func NewAssets() Assets {
 			"cflinuxfs3": "assets/dotnet-core/cflinuxfs3",
 			"cflinuxfs4": "assets/dotnet-core/cflinuxfs4",
 		},
-		Fuse:                       "assets/fuse-mount",
 		GoCallsRubyZip:             "assets/go_calls_ruby.zip",
 		Golang:                     "assets/golang",
 		GRPC:                       "assets/grpc",


### PR DESCRIPTION
Signed-off-by: Aram Price <pricear@vmware.com>

### What is this change about?

The Fuse Mount asset is no longer used. This just removes the dead code from the Assets object

### What version of cf-deployment have you run this cf-acceptance-test change against?
N/A


### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
N/A


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@aramprice 
