### PR TITLE
Remove extra space from zipkin header

### DIFF
--- a/routing/zipkin_tracing.go
+++ b/routing/zipkin_tracing.go
@@ -66,7 +66,7 @@ var _ = ZipkinDescribe("Zipkin Tracing", func() {
 			It("the sleuth error response has no error", func() {
 				traceID := "fee1f7ba6aeec41c"
 
-				header1 := fmt.Sprintf(`X-B3-TraceId: %s `, traceID)
+				header1 := fmt.Sprintf(`X-B3-TraceId: %s`, traceID)
 				header2 := `X-B3-SpanId: 579b36fd31cd8714`
 
 				var curlOutput string


### PR DESCRIPTION
This is causing failure on go 1.19

Signed-off-by: Marc Paquette <mpaquette@vmware.com>

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Remove trailing space in the Zipkin header X-B3-TraceId. Looks like a typo. This is causing test failures in go 1.19.4.

### What version of cf-deployment have you run this cf-acceptance-test change against?

This test was run against TAS 4.0.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [X] N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**
