### PR TITLE
Remove php buildpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ include_v3
 * `nodejs_buildpack_name` [See below](#buildpack-names)
 * `go_buildpack_name` [See below](#buildpack-names)
 * `python_buildpack_name` [See below](#buildpack-names)
-* `php_buildpack_name` [See below](#buildpack-names)
 * `r_buildpack_name` [See below](#buildpack-names)
 * `binary_buildpack_name` [See below](#buildpack-names)
 
@@ -202,7 +201,6 @@ Many tests specify a buildpack when pushing an app, so that on diego the app sta
 * `nodejs_buildpack_name: nodejs_buildpack`
 * `go_buildpack_name: go_buildpack`
 * `python_buildpack_name: python_buildpack`
-* `php_buildpack_name: php_buildpack`
 * `r_buildpack_name: r_buildpack`
 * `binary_buildpack_name: binary_buildpack`
 * `hwc_buildpack_name: hwc_buildpack`

--- a/ci/cats.md
+++ b/ci/cats.md
@@ -48,7 +48,6 @@ With the development of cf-for-k8s, we discovered different behavior in Kubernet
 "go_buildpack_name": "paketo-buildpacks/go",
 "java_buildpack_name": "paketo-buildpacks/java",
 "nodejs_buildpack_name": "paketo-buildpacks/nodejs",
-"php_buildpack_name": "paketo-buildpacks/php",
 "binary_buildpack_name": "paketo-buildpacks/procfile"
 ```
 

--- a/docs/run-on-k8s.md
+++ b/docs/run-on-k8s.md
@@ -37,7 +37,6 @@ The sample configuration will run CATS in an apps suite only mode, with addition
   "go_buildpack_name": "paketo-buildpacks/go",
   "java_buildpack_name": "paketo-buildpacks/java",
   "nodejs_buildpack_name": "paketo-buildpacks/nodejs",
-  "php_buildpack_name": "paketo-buildpacks/php",
   "binary_buildpack_name": "paketo-buildpacks/procfile"
 }
 ```

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -58,7 +58,6 @@ type config struct {
 	JavaBuildpackName       *string `json:"java_buildpack_name"`
 	NginxBuildpackName      *string `json:"nginx_buildpack_name"`
 	NodejsBuildpackName     *string `json:"nodejs_buildpack_name"`
-	PhpBuildpackName        *string `json:"php_buildpack_name"`
 	PythonBuildpackName     *string `json:"python_buildpack_name"`
 	RBuildpackName          *string `json:"r_buildpack_name"`
 	RubyBuildpackName       *string `json:"ruby_buildpack_name"`
@@ -155,7 +154,6 @@ func getDefaults() config {
 	defaults.JavaBuildpackName = ptrToString("java_buildpack")
 	defaults.NginxBuildpackName = ptrToString("nginx_buildpack")
 	defaults.NodejsBuildpackName = ptrToString("nodejs_buildpack")
-	defaults.PhpBuildpackName = ptrToString("php_buildpack")
 	defaults.PythonBuildpackName = ptrToString("python_buildpack")
 	defaults.RBuildpackName = ptrToString("r_buildpack")
 	defaults.RubyBuildpackName = ptrToString("ruby_buildpack")
@@ -384,9 +382,6 @@ func validateConfig(config *config) Errors {
 	}
 	if config.NodejsBuildpackName == nil {
 		errs.Add(fmt.Errorf("* 'nodejs_buildpack_name' must not be null"))
-	}
-	if config.PhpBuildpackName == nil {
-		errs.Add(fmt.Errorf("* 'php_buildpack_name' must not be null"))
 	}
 	if config.PythonBuildpackName == nil {
 		errs.Add(fmt.Errorf("* 'python_buildpack_name' must not be null"))

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -142,7 +142,6 @@ type nullConfig struct {
 	JavaBuildpackName       *string `json:"java_buildpack_name"`
 	NginxBuildpackName      *string `json:"nginx_buildpack_name"`
 	NodejsBuildpackName     *string `json:"nodejs_buildpack_name"`
-	PhpBuildpackName        *string `json:"php_buildpack_name"`
 	PythonBuildpackName     *string `json:"python_buildpack_name"`
 	RBuildpackName          *string `json:"r_buildpack_name"`
 	RubyBuildpackName       *string `json:"ruby_buildpack_name"`
@@ -411,7 +410,6 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(ContainSubstring("'go_buildpack_name' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'java_buildpack_name' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'nodejs_buildpack_name' must not be null"))
-			Expect(err.Error()).To(ContainSubstring("'php_buildpack_name' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'python_buildpack_name' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'ruby_buildpack_name' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'staticfile_buildpack_name' must not be null"))


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes, however, this change does depend on first merging https://github.com/cloudfoundry/cf-acceptance-tests/pull/697.

### What is this change about?

 The `php_buildpack_name` field is never used by CATs, so this PR removes all references to it. In fact, despite having this configuration parameter, the Config _interface_ does not expose a `GetPhpBuildpackName()` function as it does with most other buildpacks, so we know programatically that this field is never used.

(The PHP asset is used only in the `detect` test suite, where no buildpack name is specified on purpose -- the test exists to validate that a PHP app is successfully detected by CF even when the user does not explicitly specify a buildpack.)

### Please provide contextual information.

N/A

### What version of cf-deployment have you run this cf-acceptance-test change against?
N/A


### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
N/A


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@aramprice 
