### PR TITLE
Remove python buildpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ include_v3
 * `nginx_buildpack_name` [See below](#buildpack-names)
 * `nodejs_buildpack_name` [See below](#buildpack-names)
 * `go_buildpack_name` [See below](#buildpack-names)
-* `python_buildpack_name` [See below](#buildpack-names)
 * `r_buildpack_name` [See below](#buildpack-names)
 * `binary_buildpack_name` [See below](#buildpack-names)
 
@@ -200,7 +199,6 @@ Many tests specify a buildpack when pushing an app, so that on diego the app sta
 * `nginx_buildpack_name: nginx_buildpack`
 * `nodejs_buildpack_name: nodejs_buildpack`
 * `go_buildpack_name: go_buildpack`
-* `python_buildpack_name: python_buildpack`
 * `r_buildpack_name: r_buildpack`
 * `binary_buildpack_name: binary_buildpack`
 * `hwc_buildpack_name: hwc_buildpack`

--- a/ci/cats.md
+++ b/ci/cats.md
@@ -44,7 +44,6 @@ With the development of cf-for-k8s, we discovered different behavior in Kubernet
 ```
 "infrastructure": "kubernetes",
 "ruby_buildpack_name": "paketo-buildpacks/ruby",
-"python_buildpack_name": "paketo-community/python",
 "go_buildpack_name": "paketo-buildpacks/go",
 "java_buildpack_name": "paketo-buildpacks/java",
 "nodejs_buildpack_name": "paketo-buildpacks/nodejs",

--- a/docs/run-on-k8s.md
+++ b/docs/run-on-k8s.md
@@ -33,7 +33,6 @@ The sample configuration will run CATS in an apps suite only mode, with addition
   "include_v3": false,
   "infrastructure": "kubernetes",
   "ruby_buildpack_name": "paketo-community/ruby",
-  "python_buildpack_name": "paketo-community/python",
   "go_buildpack_name": "paketo-buildpacks/go",
   "java_buildpack_name": "paketo-buildpacks/java",
   "nodejs_buildpack_name": "paketo-buildpacks/nodejs",

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -58,7 +58,6 @@ type config struct {
 	JavaBuildpackName       *string `json:"java_buildpack_name"`
 	NginxBuildpackName      *string `json:"nginx_buildpack_name"`
 	NodejsBuildpackName     *string `json:"nodejs_buildpack_name"`
-	PythonBuildpackName     *string `json:"python_buildpack_name"`
 	RBuildpackName          *string `json:"r_buildpack_name"`
 	RubyBuildpackName       *string `json:"ruby_buildpack_name"`
 	StaticFileBuildpackName *string `json:"staticfile_buildpack_name"`
@@ -154,7 +153,6 @@ func getDefaults() config {
 	defaults.JavaBuildpackName = ptrToString("java_buildpack")
 	defaults.NginxBuildpackName = ptrToString("nginx_buildpack")
 	defaults.NodejsBuildpackName = ptrToString("nodejs_buildpack")
-	defaults.PythonBuildpackName = ptrToString("python_buildpack")
 	defaults.RBuildpackName = ptrToString("r_buildpack")
 	defaults.RubyBuildpackName = ptrToString("ruby_buildpack")
 	defaults.StaticFileBuildpackName = ptrToString("staticfile_buildpack")
@@ -382,9 +380,6 @@ func validateConfig(config *config) Errors {
 	}
 	if config.NodejsBuildpackName == nil {
 		errs.Add(fmt.Errorf("* 'nodejs_buildpack_name' must not be null"))
-	}
-	if config.PythonBuildpackName == nil {
-		errs.Add(fmt.Errorf("* 'python_buildpack_name' must not be null"))
 	}
 	if config.RBuildpackName == nil {
 		errs.Add(fmt.Errorf("* 'r_buildpack_name' must not be null"))

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -142,7 +142,6 @@ type nullConfig struct {
 	JavaBuildpackName       *string `json:"java_buildpack_name"`
 	NginxBuildpackName      *string `json:"nginx_buildpack_name"`
 	NodejsBuildpackName     *string `json:"nodejs_buildpack_name"`
-	PythonBuildpackName     *string `json:"python_buildpack_name"`
 	RBuildpackName          *string `json:"r_buildpack_name"`
 	RubyBuildpackName       *string `json:"ruby_buildpack_name"`
 	StaticFileBuildpackName *string `json:"staticfile_buildpack_name"`
@@ -410,7 +409,6 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(ContainSubstring("'go_buildpack_name' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'java_buildpack_name' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'nodejs_buildpack_name' must not be null"))
-			Expect(err.Error()).To(ContainSubstring("'python_buildpack_name' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'ruby_buildpack_name' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'staticfile_buildpack_name' must not be null"))
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes, however, this change does depend on first merging https://github.com/cloudfoundry/cf-acceptance-tests/pull/697.

### What is this change about?

 The `python_buildpack_name` field is never used by CATs, so this PR removes all references to it. In fact, despite having this configuration parameter, the Config _interface_ does not expose a `GetPythonBuildpackName()` function as it does with most other buildpacks, so we know programatically that this field is never used.

(The Python asset is used only in the `detect` test suite, where no buildpack name is specified on purpose -- the test exists to validate that a Python app is successfully detected by CF even when the user does not explicitly specify a buildpack.)

### Please provide contextual information.

N/A

### What version of cf-deployment have you run this cf-acceptance-test change against?
N/A


### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
N/A


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@aramprice 
