### PR TITLE
Remove `update_submodules` reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,6 @@ in such a way as to impact other tests.
 
 - Install [curl](http://curl.haxx.se/)
 - Check out a copy of `cf-acceptance-tests`. It uses Go modules, so there is no need to put it in `$GOPATH`.
-- Ensure all submodules are checked out to the correct SHA.
-  The easiest way to do this is by running:
-
-  ```bash
-  ./bin/update_submodules
-  ```
 
 - Install a running Cloud Foundry deployment
   to run these acceptance tests against.


### PR DESCRIPTION
#704 removed this script but missed it in beginning of the readme

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._

Yes

### What is this change about?

_Describe the change and why it's needed._

I got confused reading the readme trying to update submodules that didn't exist

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

#704 made the change and just missed a spot

### What version of cf-deployment have you run this cf-acceptance-test change against?

I didn't cause it is a readme change

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

I am not introducing a new acceptance test

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Hopefully no change

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
Just me