### PR TITLE
CI: remove unneeded task to deliver tracker stories

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -82,13 +82,6 @@ resources:
     git_user: "CF MEGA BOT <cf-mega@pivotal.io>"
     file: cats-version
 
-- name: deliver-tracker-story
-  type: tracker
-  source:
-    token: ((cf_relint_tracker_api_token))
-    project_id: "1382120"
-    tracker_url: https://www.pivotaltracker.com
-
 jobs:
 - name: run-unit-tests
   serial: true
@@ -271,10 +264,6 @@ jobs:
     params:
       repository: cf-acceptance-tests-develop
 
-  - put: deliver-tracker-story
-    params:
-      repos:
-        - cf-acceptance-tests-develop
   - task: update-cats-cfd-branch
     file: runtime-ci/tasks/update-cats-branch-with-cf-deployment-version/task.yml
     input_mapping:


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Removes unused task deliver-tracker-story from cats pipeline. This task is an artifact of when the folks managing this repo used a public tracker project. We've since switched to using GH projects.

### Please provide contextual information.

- [slack thread](https://cloudfoundry.slack.com/archives/C033ALST37V/p1675323741810389)

### What version of cf-deployment have you run this cf-acceptance-test change against?

N/A - this is a CI-only change

### Please check all that apply for this PR:

- [x] CI-only change
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None