### PR TITLE
Add support for positive + negative dynamic ASG tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ include_v3
 * `include_app_syslog_tcp`: Flag to include the app syslog drain over TCP test group.
 * `include_apps`: Flag to include the apps test group.
 * `include_container_networking`: Flag to include tests related to container networking.
-  `include_security_groups` must also be set for tests to run. [See below](#container-networking-and-application-security-groups)
+* `include_security_groups` must also be set for tests to run. [See below](#container-networking-and-application-security-groups)
+* `dynamic_asgs_enabled`: Defaults to `true`. Set to false if dynamic ASGs are disabled in the test environment.
 * `credhub_mode`: Valid values are `assisted` or `non-assisted`. [See below](#credhub-modes).
 * `credhub_location`: Location of CredHub instance; default is `https://credhub.service.cf.internal:8844`
 * `credhub_client`: UAA client credential for Service Broker write access to CredHub (required for CredHub tests); default is `credhub_admin_client`.

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -75,6 +75,7 @@ type CatsConfig interface {
 	GetRubyBuildpackName() string
 	GetUnallocatedIPForSecurityGroup() string
 	GetRequireProxiedAppTraffic() bool
+	GetDynamicASGsEnabled() bool
 	Protocol() string
 
 	GetStacks() []string

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -112,6 +112,8 @@ type config struct {
 	UnallocatedIPForSecurityGroup *string `json:"unallocated_ip_for_security_group"`
 	RequireProxiedAppTraffic      *bool   `json:"require_proxied_app_traffic"`
 
+	DynamicASGsEnabled *bool `json:"dynamic_asgs_enabled"`
+
 	NamePrefix *string `json:"name_prefix"`
 
 	ReporterConfig *reporterConfig `json:"reporter_config"`
@@ -227,6 +229,8 @@ func getDefaults() config {
 
 	defaults.UnallocatedIPForSecurityGroup = ptrToString("10.0.244.255")
 	defaults.RequireProxiedAppTraffic = ptrToBool(false)
+
+	defaults.DynamicASGsEnabled = ptrToBool(true)
 
 	defaults.NamePrefix = ptrToString("CATS")
 
@@ -919,6 +923,9 @@ func (c *config) GetIncludeSecurityGroups() bool {
 	return *c.IncludeSecurityGroups
 }
 
+func (c *config) GetDynamicASGsEnabled() bool {
+	return *c.DynamicASGsEnabled
+}
 func (c *config) GetIncludeServices() bool {
 	return *c.IncludeServices
 }


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Enables negative testing of dynamic asgs (ensuring that when disabled dynamic updates are not applied)

### Please provide contextual information.

Based on the tests in 

### What version of cf-deployment have you run this cf-acceptance-test change against?

Latest toolsmiths cf-deployment

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [x] requires an update to a CATs integration-config

Not sure if this requires an update to integration-config. If CATS is run against an environment with dynamic asgs disabled, and the security group testing enabled, you must also specify `dynamic_asgs_enabled: false` in your test config. When dynamic asgs is enabled (on by default), no changes are needed.

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

No new tests

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Should not change the runtime for CATS under default circumstances. When dynamic asgs is enable, the test does not change. When disabled, it takes the same time as when enabled.

### What is the level of urgency for publishing this change?


- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
