### PR TITLE
Fix: bump min go versions in go.mod files

### DIFF
--- a/assets/catnip/go.mod
+++ b/assets/catnip/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/catnip
 
-go 1.18
+go 1.19
 
 require (
 	code.cloudfoundry.org/clock v1.0.1-0.20220601152104-3983b71fbf93

--- a/assets/credhub-service-broker/go.mod
+++ b/assets/credhub-service-broker/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/credhub-service-broker
 
-go 1.18
+go 1.19
 
 require (
 	code.cloudfoundry.org/credhub-cli v0.0.0-20180712210539-55d15b91e8ce

--- a/assets/go_calls_ruby/go.mod
+++ b/assets/go_calls_ruby/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/go_calls_ruby
 
-go 1.18
+go 1.19

--- a/assets/golang/go.mod
+++ b/assets/golang/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/golang
 
-go 1.18
+go 1.19

--- a/assets/grpc/go.mod
+++ b/assets/grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/grpc
 
-go 1.18
+go 1.19
 
 require (
 	google.golang.org/grpc v1.53.0

--- a/assets/http2/go.mod
+++ b/assets/http2/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/http2
 
-go 1.18
+go 1.19
 
 require golang.org/x/net v0.0.0-20210614182718-04defd469f4e
 

--- a/assets/logging-route-service/go.mod
+++ b/assets/logging-route-service/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry-samples/logging-route-service
 
-go 1.18
+go 1.19

--- a/assets/pora/go.mod
+++ b/assets/pora/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/pora
 
-go 1.18
+go 1.19

--- a/assets/proxy/go.mod
+++ b/assets/proxy/go.mod
@@ -1,3 +1,3 @@
 module example-apps/proxy
 
-go 1.18
+go 1.19

--- a/assets/syslog-drain-listener/go.mod
+++ b/assets/syslog-drain-listener/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/syslog-drain-listener
 
-go 1.18
+go 1.19
 
 require code.cloudfoundry.org/tlsconfig v0.0.0-20220621140725-0e6fbd869921

--- a/assets/tcp-listener/go.mod
+++ b/assets/tcp-listener/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/tcp-listener
 
-go 1.18
+go 1.19

--- a/assets/worker-app/go.mod
+++ b/assets/worker-app/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/worker-app
 
-go 1.18
+go 1.19

--- a/assets/worker/go.mod
+++ b/assets/worker/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/worker
 
-go 1.18
+go 1.19

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests
 
-go 1.18
+go 1.19
 
 require (
 	code.cloudfoundry.org/archiver v0.0.0-20150428205605-f598990ddfed


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Replaces go1.18 with go1.19 wherever possible, as go1.18 is out of support. We want to encourage folks to use at least go1.19.

### Please provide contextual information.

None

### What version of cf-deployment have you run this cf-acceptance-test change against?

None

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

No

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None