### PR TITLE
Compile catnip with CGO_ENABLED=0

### DIFF
--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -79,6 +79,7 @@ func TestCATS(t *testing.T) {
 		buildCmd := exec.Command("go", "build", "-o", "bin/catnip")
 		buildCmd.Dir = "assets/catnip"
 		buildCmd.Env = append(os.Environ(),
+			"CGO_ENABLED=0",
 			"GOOS=linux",
 			"GOARCH=amd64",
 		)


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes.

### What is this change about?

[Recent changes in Go 1.20](https://go.dev/doc/go1.20#go-command) mean that if the machine where CATs is running has a newer version of glibc than Cloud Foundry then catnip will fail to push.

Fixes the following errors pushing catnip when compiling with Go 1.20:

```
[APP/PROC/WEB/0] ERR ./catnip: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./catnip)
[APP/PROC/WEB/0] ERR ./catnip: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./catnip)
```

### Please provide contextual information.

https://go.dev/doc/go1.20#go-command

### What version of cf-deployment have you run this cf-acceptance-test change against?

None

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [X] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@ctlong 