### PR TITLE
Add test for app renaming

### DIFF
--- a/apps/renaming.go
+++ b/apps/renaming.go
@@ -1,0 +1,54 @@
+package apps
+
+import (
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers"
+	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
+	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
+)
+
+var _ = AppsDescribe("renaming", func() {
+	var appName string
+
+	BeforeEach(func() {
+		appName = random_name.CATSRandomName("APP")
+		Expect(cf.Cf(app_helpers.CatnipWithArgs(
+			appName,
+			"-m", DEFAULT_MEMORY_LIMIT)...,
+		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+		helpers.CurlApp(Config, appName, "log/sleep/1")
+	})
+
+	AfterEach(func() {
+		app_helpers.AppReport(appName)
+		Expect(cf.Cf("delete", appName, "-f", "-r").Wait()).To(Exit(0))
+	})
+
+	It("changes the app name in emitted logs without a restart", func() {
+		newAppName := random_name.CATSRandomName("APP")
+		Expect(cf.Cf("rename", appName, newAppName).Wait()).To(Exit(0))
+		appName = newAppName
+
+		appGuid := app_helpers.GetAppGuid(newAppName)
+		token := v3_helpers.GetAuthToken()
+		Eventually(func() bool {
+			resp := logs.RecentEnvelopes(appGuid, token, Config)
+			for _, e := range resp.Envelopes.Batch {
+				if e.Tags["origin"] == "rep" && e.Tags["app_name"] == newAppName {
+					return true
+				}
+			}
+			return false
+		}).Should(BeTrue())
+	})
+
+})

--- a/helpers/logs/logs_helper.go
+++ b/helpers/logs/logs_helper.go
@@ -1,9 +1,30 @@
 package logs
 
 import (
+	"encoding/json"
+	"fmt"
+
+	logcache "code.cloudfoundry.org/go-log-cache/rpc/logcache_v1"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/config"
 	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
+	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+	"google.golang.org/protobuf/encoding/protojson"
 )
+
+func RecentEnvelopes(appGuid, oauthToken string, config config.CatsConfig) *logcache.ReadResponse {
+	GinkgoHelper()
+	endpoint := getLogCacheEndpoint()
+	reqURL := fmt.Sprintf("%s/api/v1/read/%s?envelope_type=LOG&limit=1000", endpoint, appGuid)
+	session := helpers.CurlRedact(oauthToken, config, reqURL, "-H", fmt.Sprintf("Authorization: %s", oauthToken))
+	Expect(session.Wait()).To(gexec.Exit(0))
+	var resp logcache.ReadResponse
+	err := protojson.Unmarshal(session.Buffer().Contents(), &resp)
+	Expect(err).NotTo(HaveOccurred())
+	return &resp
+}
 
 func Recent(appName string) *gexec.Session {
 	return cf.Cf("logs", "--recent", appName)
@@ -11,4 +32,23 @@ func Recent(appName string) *gexec.Session {
 
 func Follow(appName string) *gexec.Session {
 	return cf.Cf("logs", appName)
+}
+
+func getLogCacheEndpoint() string {
+	GinkgoHelper()
+	infoCmd := cf.Cf("curl", "/")
+	Expect(infoCmd.Wait()).To(gexec.Exit(0))
+
+	var resp struct {
+		Links struct {
+			LogCache struct {
+				HREF string `json:"href"`
+			} `json:"log_cache"`
+		} `json:"links"`
+	}
+
+	err := json.Unmarshal(infoCmd.Buffer().Contents(), &resp)
+	Expect(err).NotTo(HaveOccurred())
+
+	return resp.Links.LogCache.HREF
 }

--- a/v3/buildpacks.go
+++ b/v3/buildpacks.go
@@ -12,6 +12,7 @@ import (
 	archive_helpers "code.cloudfoundry.org/archiver/extractor/test_helper"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 	. "github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers"
@@ -75,7 +76,7 @@ var _ = V3Describe("buildpack", func() {
 		It("Stages with a user specified admin buildpack", func() {
 			StageBuildpackPackage(packageGuid, buildpackName)
 			Eventually(func() string {
-				return FetchRecentLogs(appGuid, token, Config)
+				return logs.RecentEnvelopes(appGuid, token, Config).String()
 			}).Should(ContainSubstring("STAGED WITH CUSTOM BUILDPACK"))
 		})
 
@@ -86,7 +87,7 @@ var _ = V3Describe("buildpack", func() {
 			StageBuildpackPackage(packageGuid, "https://github.com/cloudfoundry/example-git-buildpack")
 
 			Eventually(func() string {
-				return FetchRecentLogs(appGuid, token, Config)
+				return logs.RecentEnvelopes(appGuid, token, Config).String()
 			}).Should(ContainSubstring("I'm a buildpack!"))
 		})
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes.

### What is this change about?

- Logs that are emitted by a renamed app are tagged with the new name without requiring a restart.
- Check the origin of the emitted log as the cloud controller will emit logs against the new app name when the rename is performed.
- Move recent logs function to the logs helper.

The new test is dependent on PRs opened against Diego and CAPI which have not yet been merged. This PR should not be merged prior to release of the Diego and CAPI changes.

This is a breaking change as it requires those new versions of Diego and CAPI.

### Please provide contextual information.

cloudfoundry/diego-release#662

### What version of cf-deployment have you run this cf-acceptance-test change against?

None

### Please check all that apply for this PR:

- [X] introduces a new test --- Are you sure everyone should be running this test? - Yes
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [X] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

This is testing a common operator workflow.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

45 seconds more.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@ctlong