### PR TITLE
Fix: error on incorrect timeout scale

### DIFF
--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -315,6 +315,11 @@ func validateConfig(config *config) Errors {
 		errs.Add(err)
 	}
 
+	err = validateTimeoutScale(config)
+	if err != nil {
+		errs.Add(err)
+	}
+
 	if config.UseHttp == nil {
 		errs.Add(fmt.Errorf("* 'use_http' must not be null"))
 	}
@@ -359,9 +364,6 @@ func validateConfig(config *config) Errors {
 	}
 	if config.SleepTimeout == nil {
 		errs.Add(fmt.Errorf("* 'sleep_timeout' must not be null"))
-	}
-	if config.TimeoutScale == nil {
-		errs.Add(fmt.Errorf("* 'timeout_scale' must not be null"))
 	}
 	if config.BinaryBuildpackName == nil {
 		errs.Add(fmt.Errorf("* 'binary_buildpack_name' must not be null"))
@@ -720,24 +722,28 @@ func validateStacks(config *config) error {
 	return nil
 }
 
+func validateTimeoutScale(config *config) error {
+	if config.TimeoutScale == nil {
+		return fmt.Errorf("* 'timeout_scale' must not be null")
+	}
+
+	if *config.TimeoutScale <= 0 {
+		return fmt.Errorf("* 'timeout_scale' must be greater than zero")
+	}
+
+	return nil
+}
+
 func load(path string, config *config) Errors {
 	errs := Errors{}
+
 	err := loadConfigFromPath(path, config)
 	if err != nil {
 		errs.Add(fmt.Errorf("* Failed to unmarshal: %s", err))
 		return errs
 	}
 
-	errs = validateConfig(config)
-	if !errs.Empty() {
-		return errs
-	}
-
-	if *config.TimeoutScale <= 0 {
-		*config.TimeoutScale = 1.0
-	}
-
-	return errs
+	return validateConfig(config)
 }
 
 func loadConfigFromPath(path string, config interface{}) error {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -778,6 +778,30 @@ var _ = Describe("Config", func() {
 		})
 	})
 
+	Context("when including a timeout scale", func() {
+		Context("when the timeout scale is zero", func() {
+			BeforeEach(func() {
+				testCfg.TimeoutScale = ptrToFloat(0.0)
+			})
+
+			It("returns an error", func() {
+				_, err := cfg.NewCatsConfig(tmpFilePath)
+				Expect(err).To(MatchError("* 'timeout_scale' must be greater than zero"))
+			})
+		})
+
+		Context("when the timeout scale is less than zero", func() {
+			BeforeEach(func() {
+				testCfg.TimeoutScale = ptrToFloat(-1.0)
+			})
+
+			It("returns an error", func() {
+				_, err := cfg.NewCatsConfig(tmpFilePath)
+				Expect(err).To(MatchError("* 'timeout_scale' must be greater than zero"))
+			})
+		})
+	})
+
 	Describe("error aggregation", func() {
 		BeforeEach(func() {
 			testCfg.AdminPassword = nil


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Error out on invalid timeout scale rather than quietly correcting it to one. This is a breaking change.

I think this is useful to provide clarity to operators that their configuration is incorrect rather than silently choosing some value. If operators don't want to overwrite the timeout scale value, then they can remove the field from the JSON altogether, as there's a default value of 2.

### Please provide contextual information.

None

### What version of cf-deployment have you run this cf-acceptance-test change against?

v26.4.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None