### PR TITLE
Fix: log fetching

### DIFF
--- a/helpers/logs/logs_helper.go
+++ b/helpers/logs/logs_helper.go
@@ -17,7 +17,7 @@ import (
 func RecentEnvelopes(appGuid, oauthToken string, config config.CatsConfig) *logcache.ReadResponse {
 	GinkgoHelper()
 	endpoint := getLogCacheEndpoint()
-	reqURL := fmt.Sprintf("%s/api/v1/read/%s?envelope_type=LOG&limit=1000", endpoint, appGuid)
+	reqURL := fmt.Sprintf("%s/api/v1/read/%s?envelope_type=LOG&limit=1000&descending=true", endpoint, appGuid)
 	session := helpers.CurlRedact(oauthToken, config, reqURL, "-H", fmt.Sprintf("Authorization: %s", oauthToken))
 	Expect(session.Wait()).To(gexec.Exit(0))
 	var resp logcache.ReadResponse


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Fix failing [app renaming tests](https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cats/jobs/run-cats-vms/builds/39) by fetching the latest 1000 envelopes from Log Cache rather than the eldest 1000 envelopes.

### Please provide contextual information.

Unless [descending=true](https://github.com/cloudfoundry/go-log-cache/blob/b2a3593e6ad7a66e451e3c67b067a064a20a5a1c/api/v1/egress.proto#L30) is included in the Log Cache request, then Log Cache purposefully returns the eldest envelopes in Log Cache from the [start_time](https://github.com/cloudfoundry/go-log-cache/blob/b2a3593e6ad7a66e451e3c67b067a064a20a5a1c/api/v1/egress.proto#L26).

In the case of our tests that utilize `logs.RecentEnvelopes()` we would like to fetch the most recent envelopes.

### What version of cf-deployment have you run this cf-acceptance-test change against?

v27.1.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@acrmp 