### PR TITLE
[DRAFT] issue 809

### DIFF
--- a/assets/binary/site.go
+++ b/assets/binary/site.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func main() {
+	http.HandleFunc("/", hello)
+	http.HandleFunc("/env", env)
+	fmt.Println("listening...")
+	err := http.ListenAndServe(":"+os.Getenv("PORT"), nil)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func hello(res http.ResponseWriter, req *http.Request) {
+	fmt.Fprintln(res, "Hello from a binary")
+}
+
+func env(res http.ResponseWriter, req *http.Request) {
+	envVariables := make(map[string]string)
+	for _, envKeyValue := range os.Environ() {
+		keyValue := strings.Split(envKeyValue, "=")
+		envVariables[keyValue[0]] = keyValue[1]
+	}
+	envJsonBytes, err := json.Marshal(envVariables)
+	if err != nil {
+		http.Error(res, err.Error(), http.StatusInternalServerError)
+	}
+	fmt.Fprintln(res, string(envJsonBytes))
+}


### PR DESCRIPTION
* can't use "ruby" executable as it has been removed from cflinuxfs4 >= 1.0.0
* use a go binary instead (this commit just provides the source code)

### What is this change about?

Fix `assets/binary` test app for cflinuxfs4 >= 1.0.0

### Please provide contextual information.

https://github.com/cloudfoundry/cf-acceptance-tests/issues/809

### What version of cf-deployment have you run this cf-acceptance-test change against?

TODO

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

TODO

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
