### PR TITLE
app staging test: don't use "ruby" executable

### DIFF
--- a/apps/app_staging_environment.go
+++ b/apps/app_staging_environment.go
@@ -60,8 +60,8 @@ var _ = AppsDescribe("Buildpack Environment", func() {
 
 sleep 5
 
-echo RUBY_LOCATION=$(which ruby)
-echo RUBY_VERSION=$(ruby --version)
+echo APT_LOCATION=$(which apt)
+echo APT_VERSION=$(apt --version)
 
 sleep 10
 `,
@@ -120,13 +120,13 @@ EOF
 		os.RemoveAll(tmpdir)
 	})
 
-	It("uses a ruby binary for staging", func() {
+	It("uses an apt binary for staging", func() {
 		push := cf.Cf("push", appName,
 			"-b", BuildpackName,
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", appPath,
 		).Wait(Config.CfPushTimeoutDuration())
 		Expect(push).To(Exit(0))
-		Expect(push).To(Say("RUBY_LOCATION=/usr/bin/ruby"))
+		Expect(push).To(Say("APT_LOCATION=/usr/bin/apt"))
 	})
 })


### PR DESCRIPTION
cflinxufs4 does not come with ruby, so use apt instead.
See issue https://github.com/cloudfoundry/cf-acceptance-tests/issues/809 for similar issue with the binary app


### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

cflinuxfs3 comes with ruby, but cflinuxfs4 1.x does not. Hence use apt which is available on all ubuntu stacks


### What version of cf-deployment have you run this cf-acceptance-test change against?

v21.11.0


### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?


### How many more (or fewer) seconds of runtime will this change introduce to CATs?

No difference


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

