### PR TITLE
asg timeout

### DIFF
--- a/security_groups/dynamic_asgs.go
+++ b/security_groups/dynamic_asgs.go
@@ -110,15 +110,15 @@ var _ = Describe("Dynamic ASGs", func() {
 
 		if !Config.GetDynamicASGsEnabled() {
 			By("if dynamic asgs are not enabled, validating an app restart is required")
-			Consistently(func() string {
-				resp, err = http.Get(proxyRequestURL)
-				Expect(err).NotTo(HaveOccurred())
+			time.Sleep(10 * time.Second)
+			resp, err = http.Get(proxyRequestURL)
+			Expect(err).NotTo(HaveOccurred())
 
-				respBytes, err = io.ReadAll(resp.Body)
-				Expect(err).ToNot(HaveOccurred())
-				resp.Body.Close()
-				return string(respBytes)
-			}, 2*time.Minute).Should(MatchRegexp("api_version"))
+			respBytes, err = io.ReadAll(resp.Body)
+			Expect(err).ToNot(HaveOccurred())
+			resp.Body.Close()
+			response := string(respBytes)
+			Expect(response).To(MatchRegexp("api_version"))
 
 			Expect(cf.Cf("restart", appName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 		}


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Change test for non-dynamic ASGs to use a sleep instead of Consistently because of intermittent connectivity issues.

### Please provide contextual information.

While running `acceptance-tests` for `cf-networking-release` in ci, the `cats` section would error saying `connection refused`.  When we ran the tests manually we were unable to reproduce.  When repeating the test at 0.1s, we saw intermittent connection issues with ASGs. This new timeout should help prevent the connection error.

### What version of cf-deployment have you run this cf-acceptance-test change against?

I believe v27.6.0.  It was a toolsmiths environment using the cf-deployment pool.

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Hopefully no changes, but should make the test less flaky so we won't have to do multiple runs.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@reneighbor @geofffranks  @cloudfoundry/wg-app-runtime-interfaces 