### PR TITLE
Set cflinuxfs4 as default stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ include_v3
 * `windows_stack`: Windows stack to run tests against. Must be `windows`.
 
 * `include_service_discovery`: Flag to include test for the service discovery. These tests use `apps.internal` domain, which is the default in `cf-networking-release`. The internal domain is currently not configurable.
-* `stacks`: An array of stacks to test against. Currently `cflinuxfs3` and `cflinuxfs4` stacks are supported. Default is `[cflinuxfs3]`.
+* `stacks`: An array of stacks to test against. Currently `cflinuxfs3` and `cflinuxfs4` stacks are supported. Default is `[cflinuxfs4]`.
 
 * `include_volume_services`: Flag to include the tests for volume services. The following requirements must be met to run this suite: tcp-routing must be deployed.
 * `volume_service_name`: The name of the volume service provided by the volume service broker.

--- a/apps/app_stack.go
+++ b/apps/app_stack.go
@@ -135,6 +135,8 @@ EOF
 				switch stackName {
 				case "cflinuxfs3":
 					expectedLSBRelease = "DISTRIB_CODENAME=bionic"
+				case "cflinuxfs4":
+					expectedLSBRelease = "DISTRIB_CODENAME=jammy"
 				}
 
 				push := cf.Cf("push", appName,

--- a/example-cats-config.json
+++ b/example-cats-config.json
@@ -36,6 +36,6 @@ IN DEVELOPMENT
   "include_zipkin": true,
   "include_volume_services": false,
   "stacks": [
-    "cflinuxfs3"
+    "cflinuxfs4"
   ]
 }

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -233,7 +233,7 @@ func getDefaults() config {
 
 	defaults.NamePrefix = ptrToString("CATS")
 
-	defaults.Stacks = &[]string{"cflinuxfs3"}
+	defaults.Stacks = &[]string{"cflinuxfs4"}
 
 	defaults.Infrastructure = ptrToString("vms")
 	return defaults

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -352,7 +352,7 @@ var _ = Describe("Config", func() {
 
 		Expect(config.GetRequireProxiedAppTraffic()).To(BeFalse())
 
-		Expect(config.GetStacks()).To(ConsistOf("cflinuxfs3"))
+		Expect(config.GetStacks()).To(ConsistOf("cflinuxfs4"))
 
 		Expect(config.RunningOnK8s()).To(BeFalse(), "RunningOnK8s should be false")
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?
jep

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._

### What is this change about?
set cflinuxfs4 as default stack for the tests.

_Describe the change and why it's needed._

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [X] YES
- [ ] N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
