### PR TITLE
v3 suite: use CfPushTimeotDuration where appropriate

### DIFF
--- a/v3/buildpacks.go
+++ b/v3/buildpacks.go
@@ -172,7 +172,7 @@ var _ = V3Describe("buildpack", func() {
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, webProcess.Name)
-			}).Should(ContainSubstring("The bundler version is"))
+			}, Config.CfPushTimeoutDuration()).Should(ContainSubstring("The bundler version is"))
 		})
 	})
 })

--- a/v3/deployment.go
+++ b/v3/deployment.go
@@ -67,7 +67,7 @@ var _ = V3Describe("deployment", func() {
 			guid := GetProcessGuidForType(appGuid, "web")
 			Expect(guid).ToNot(BeEmpty())
 			return GetRunningInstancesStats(guid)
-		}).Should(Equal(instances))
+		}, Config.CfPushTimeoutDuration()).Should(Equal(instances))
 
 		By("Creating a second droplet for the app")
 		makeStaticFileZip()
@@ -103,7 +103,7 @@ var _ = V3Describe("deployment", func() {
 			deploymentGuid := CreateDeployment(appGuid)
 			Expect(deploymentGuid).ToNot(BeEmpty())
 
-			Eventually(func() int { return len(GetProcessGuidsForType(appGuid, "web")) }).
+			Eventually(func() int { return len(GetProcessGuidsForType(appGuid, "web")) }, Config.CfPushTimeoutDuration()).
 				Should(BeNumerically(">", 1))
 
 			intermediateProcessGuid := GetProcessGuidsForType(appGuid, "web")[1]
@@ -111,7 +111,7 @@ var _ = V3Describe("deployment", func() {
 			secondDeploymentGuid := CreateDeployment(appGuid)
 			Expect(secondDeploymentGuid).ToNot(BeEmpty())
 
-			Eventually(func() int { return GetRunningInstancesStats(originalProcessGuid) }).
+			Eventually(func() int { return GetRunningInstancesStats(originalProcessGuid) }, Config.CfPushTimeoutDuration()).
 				Should(BeNumerically("<", instances))
 
 			Eventually(func() []string {
@@ -158,7 +158,7 @@ var _ = V3Describe("deployment", func() {
 			Expect(deploymentGuid).ToNot(BeEmpty())
 
 			By("waiting until there is a second web process  with instances before canceling")
-			Eventually(func() int { return len(GetProcessGuidsForType(appGuid, "web")) }).
+			Eventually(func() int { return len(GetProcessGuidsForType(appGuid, "web")) }, Config.CfPushTimeoutDuration()).
 				Should(BeNumerically(">", 1))
 
 			intermediateProcessGuid := GetProcessGuidsForType(appGuid, "web")[1]

--- a/v3/droplet.go
+++ b/v3/droplet.go
@@ -84,7 +84,7 @@ var _ = V3Describe("droplet features", func() {
 			StartApp(destinationAppGuid)
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, webProcess.Name)
-			}).Should(ContainSubstring("Hi, I'm Dora!"))
+			}, Config.CfPushTimeoutDuration()).Should(ContainSubstring("Hi, I'm Dora!"))
 		})
 
 		It("creates an audit.app.droplet.create event for the copied droplet", func() {

--- a/v3/healthcheck.go
+++ b/v3/healthcheck.go
@@ -62,7 +62,7 @@ var _ = V3Describe("Healthcheck", func() {
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, appName)
-			}).Should(ContainSubstring("Hi, I'm Dora!"))
+			}, Config.CfPushTimeoutDuration()).Should(ContainSubstring("Hi, I'm Dora!"))
 		})
 	})
 
@@ -79,7 +79,7 @@ var _ = V3Describe("Healthcheck", func() {
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, appName)
-			}).Should(ContainSubstring("Hi, I'm Dora!"))
+			}, Config.CfPushTimeoutDuration()).Should(ContainSubstring("Hi, I'm Dora!"))
 		})
 	})
 
@@ -96,7 +96,7 @@ var _ = V3Describe("Healthcheck", func() {
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, appName)
-			}).Should(ContainSubstring("Hi, I'm Dora!"))
+			}, Config.CfPushTimeoutDuration()).Should(ContainSubstring("Hi, I'm Dora!"))
 		})
 	})
 })

--- a/v3/process.go
+++ b/v3/process.go
@@ -72,7 +72,7 @@ var _ = V3Describe("process", func() {
 
 			Eventually(func() string {
 				return helpers.CurlAppRoot(Config, webProcess.Name)
-			}).Should(ContainSubstring("Hi, I'm Dora!"))
+			}, Config.CfPushTimeoutDuration()).Should(ContainSubstring("Hi, I'm Dora!"))
 
 			Expect(string(cf.Cf("apps").Wait().Out.Contents())).To(MatchRegexp(fmt.Sprintf("(v3-)?(%s)*(-web)?(\\s)+(started)", webProcess.Name)))
 		})
@@ -104,7 +104,7 @@ var _ = V3Describe("process", func() {
 					statsBodyAfter := cf.Cf("curl", statsUrl).Wait().Out.Contents()
 					json.Unmarshal(statsBodyAfter, &statsJSON)
 					return statsJSON.Instance[0].State
-				}, V3_PROCESS_TIMEOUT, 1*time.Second).Should(Equal("RUNNING"))
+				}, Config.CfPushTimeoutDuration(), 1*time.Second).Should(Equal("RUNNING"))
 			})
 		})
 
@@ -135,7 +135,7 @@ var _ = V3Describe("process", func() {
 					statsBodyAfter := cf.Cf("curl", statsUrl).Wait().Out.Contents()
 					json.Unmarshal(statsBodyAfter, &statsJSON)
 					return statsJSON.Instance[0].State
-				}, V3_PROCESS_TIMEOUT, 1*time.Second).Should(Equal("RUNNING"))
+				}, Config.CfPushTimeoutDuration(), 1*time.Second).Should(Equal("RUNNING"))
 			})
 		})
 	})


### PR DESCRIPTION
### What is this change about?

There are several tests that start an app, stage an app, or trigger CF to restart an app. In all of these cases, we should use the CfPushTimeoutDuration, because that duration is set aside specifically for events like these


### What version of cf-deployment have you run this cf-acceptance-test change against?
N/A


### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
This test changes some timeouts from 30 seconds to 240 seconds (or 4 minutes). There are 12 `Eventually`s changed in this commit. As such, in the worst case scenario, this could add up to (240-30)*12 = 2,520 seconds (or 42 minutes).

In all likelihood, this will not increase run time much for most consumers of CATs. In fact, it will only increase the runtime in cases where the tests were failing due to a timeout. So this is a trade between run time and robustness of the test suite to flakiness.


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
