### PR TITLE
Fix test flakiness resulting from credhub-service-broker asset's improper error handling

### DIFF
--- a/assets/credhub-service-broker/handlers.go
+++ b/assets/credhub-service-broker/handlers.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"code.cloudfoundry.org/credhub-cli/credhub"
+	"code.cloudfoundry.org/credhub-cli/credhub/credentials/values"
+	"github.com/go-chi/chi/v5"
+	uuid "github.com/satori/go.uuid"
+)
+
+var (
+	SERVICE_NAME string
+	SERVICE_UUID string
+	PLAN_UUID    string
+)
+
+func init() {
+	SERVICE_NAME = os.Getenv("SERVICE_NAME")
+	if SERVICE_NAME == "" {
+		SERVICE_NAME = "credhub-read"
+	}
+	SERVICE_UUID = uuid.NewV4().String()
+	PLAN_UUID = uuid.NewV4().String()
+}
+
+func catalogHandler(w http.ResponseWriter, r *http.Request) {
+	// Create a new catalog response
+	type Plans struct {
+		Name        string `json:"name"`
+		ID          string `json:"id"`
+		Description string `json:"description"`
+	}
+	type Services struct {
+		Name        string  `json:"name"`
+		ID          string  `json:"id"`
+		Description string  `json:"description"`
+		Bindable    bool    `json:"bindable"`
+		Plans       []Plans `json:"plans"`
+	}
+	catalog := struct {
+		Services []Services `json:"services"`
+	}{
+		Services: []Services{
+			{
+				Name:        SERVICE_NAME,
+				ID:          SERVICE_UUID,
+				Description: "credhub read service for tests",
+				Bindable:    true,
+				Plans: []Plans{
+					{
+						Name:        "credhub-read-plan",
+						ID:          PLAN_UUID,
+						Description: "credhub read plan for tests",
+					},
+				},
+			},
+		},
+	}
+
+	// Marshal the catalog response to JSON
+	catalogJSON, err := json.Marshal(catalog)
+	if err != nil {
+		log.Println("Failed to marshal catalog response: ", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Write the catalog response to the response writer
+	w.WriteHeader(http.StatusOK)
+	w.Write(catalogJSON) //nolint:errcheck
+}
+
+func bindHandler(ch *credhub.CredHub, bindings map[string]string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Parse URL parameters
+		sbGUID := chi.URLParam(r, "service_binding_guid")
+		if sbGUID == "" {
+			log.Println("Missing service binding GUID")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// Parse the request body
+		var bindRequest struct {
+			AppGuid string `json:"app_guid"`
+		}
+		err := json.NewDecoder(r.Body).Decode(&bindRequest)
+		if err != nil {
+			log.Println("Failed to parse bind request: ", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// Set a credential in CredHub
+		name := strconv.FormatInt(time.Now().UnixNano(), 10)
+		value := values.JSON{
+			"user-name": "pinkyPie",
+			"password":  "rainbowDash",
+		}
+		cred, err := ch.SetJSON(name, value)
+		if err != nil {
+			log.Println("Failed to set credential: ", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// Add the binding to the bindings map
+		bindings[sbGUID] = cred.Name
+
+		// Give app access to the credential, if AppGuid is provided
+		if bindRequest.AppGuid != "" {
+			_, err = ch.AddPermission(cred.Name, "mtls-app:"+bindRequest.AppGuid, []string{"read"})
+			if err != nil {
+				log.Println("Failed to add permission: ", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		}
+
+		// Create a new binding response
+		type Credentials struct {
+			CredHubRef string `json:"credhub-ref"`
+		}
+		binding := struct {
+			Credentials Credentials `json:"credentials"`
+		}{
+			Credentials: Credentials{
+				CredHubRef: cred.Name,
+			},
+		}
+
+		// Marshal the binding response to JSON
+		bindingJSON, err := json.Marshal(binding)
+		if err != nil {
+			log.Println("Failed to marshal binding response: ", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// Write the binding response to the response writer
+		w.WriteHeader(http.StatusCreated)
+		w.Write(bindingJSON) //nolint:errcheck
+	}
+}
+
+func unBindHandler(ch *credhub.CredHub, bindings map[string]string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Parse URL parameters
+		sbGUID := chi.URLParam(r, "service_binding_guid")
+		if sbGUID == "" {
+			log.Println("Missing service binding GUID")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// Get the credential name from the bindings map
+		credentialName, ok := bindings[sbGUID]
+		if !ok {
+			log.Println("Failed to find credential name for service binding GUID: ", sbGUID)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// Delete the credential from CredHub
+		err := ch.Delete(credentialName)
+		if err != nil {
+			log.Println("Failed to delete credential: ", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// Delete the binding from the bindings map
+		delete(bindings, sbGUID)
+
+		// Write an empty JSON object to the response writer
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}")) //nolint:errcheck
+	}
+}

--- a/assets/credhub-service-broker/main.go
+++ b/assets/credhub-service-broker/main.go
@@ -1,177 +1,58 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"strconv"
-	"time"
 
 	"code.cloudfoundry.org/credhub-cli/credhub"
 	"code.cloudfoundry.org/credhub-cli/credhub/auth"
-	"code.cloudfoundry.org/credhub-cli/credhub/credentials/values"
 	"code.cloudfoundry.org/credhub-cli/util"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	uuid "github.com/satori/go.uuid"
 )
 
 func main() {
-	var server Server
+	// Create a new CredHub client
+	ch, err := credhub.New(
+		util.AddDefaultSchemeIfNecessary(os.Getenv("CREDHUB_API")),
+		credhub.SkipTLSValidation(true),
+		credhub.Auth(auth.UaaClientCredentials(os.Getenv("CREDHUB_CLIENT"), os.Getenv("CREDHUB_SECRET"))),
+	)
+	if err != nil {
+		log.Fatal("Failed to create CredHub client: ", err)
+	}
 
-	server.Start()
-}
+	// Create a map of service binding GUIDs to track the registered service instances
+	bindings := make(map[string]string)
 
-type Server struct {
-	sb *ServiceBroker
-}
-
-type bindRequest struct {
-	AppGuid      string `json:"app_guid"`
-	BindResource struct {
-		CredentialClientId string `json:"credential_client_id"`
-	} `json:"bind_resource"`
-}
-
-func (s *Server) Start() {
+	// Create a router and register the service broker handlers
 	router := chi.NewRouter()
 	router.Use(middleware.Recoverer)
 
-	s.sb = &ServiceBroker{
-		NameMap: make(map[string]string),
-	}
-
-	router.Get("/v2/catalog", s.sb.Catalog)
-
+	router.Get("/v2/catalog", catalogHandler)
 	router.Route("/v2/service_instances", func(r chi.Router) {
-		r.Put("/{service_instance_guid}", s.sb.CreateServiceInstance)
-		r.Delete("/{service_instance_guid}", s.sb.RemoveServiceInstance)
-
+		r.Put("/{service_instance_guid}", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("{}"))
+		})
+		r.Delete("/{service_instance_guid}", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("{}"))
+		})
 		r.Route("/{service_instance_guid}/service_bindings", func(r chi.Router) {
-			r.Put("/{service_binding_guid}", s.sb.Bind)
-			r.Delete("/{service_binding_guid}", s.sb.UnBind)
+			r.Put("/{service_binding_guid}", bindHandler(ch, bindings))
+			r.Delete("/{service_binding_guid}", unBindHandler(ch, bindings))
 		})
 	})
 
-	http.Handle("/", router)
-
-	cfPort := os.Getenv("PORT")
-
-	fmt.Println("Server started, listening on port " + cfPort + "...")
-	fmt.Println("CTL-C to break out of broker")
-	fmt.Println(http.ListenAndServe(":"+cfPort, nil))
-}
-
-type ServiceBroker struct {
-	NameMap map[string]string
-}
-
-func WriteResponse(w http.ResponseWriter, code int, response string) {
-	w.WriteHeader(code)
-	fmt.Fprint(w, string(response))
-}
-
-func (s *ServiceBroker) Catalog(w http.ResponseWriter, r *http.Request) {
-	serviceUUID := uuid.NewV4().String()
-	planUUID := uuid.NewV4().String()
-
-	serviceName := "credhub-read"
-	if os.Getenv("SERVICE_NAME") != "" {
-		serviceName = os.Getenv("SERVICE_NAME")
-	}
-
-	catalog := `{
-	"services": [{
-		"name": "` + serviceName + `",
-		"id": "` + serviceUUID + `",
-		"description": "credhub read service for tests",
-		"bindable": true,
-		"plans": [{
-			"name": "credhub-read-plan",
-			"id": "` + planUUID + `",
-			"description": "credhub read service for tests"
-		}]
-	}]
-}`
-
-	WriteResponse(w, http.StatusOK, catalog)
-}
-
-func (s *ServiceBroker) CreateServiceInstance(w http.ResponseWriter, r *http.Request) {
-	WriteResponse(w, http.StatusCreated, "{}")
-}
-
-func (s *ServiceBroker) RemoveServiceInstance(w http.ResponseWriter, r *http.Request) {
-	WriteResponse(w, http.StatusOK, "{}")
-}
-
-func (s *ServiceBroker) Bind(w http.ResponseWriter, r *http.Request) {
-	ch, err := credhub.New(
-		util.AddDefaultSchemeIfNecessary(os.Getenv("CREDHUB_API")),
-		credhub.SkipTLSValidation(true),
-		credhub.Auth(auth.UaaClientCredentials(os.Getenv("CREDHUB_CLIENT"), os.Getenv("CREDHUB_SECRET"))),
-	)
-
+	// Retrieve the port to listen on from the environment
+	port, err := strconv.Atoi(os.Getenv("PORT"))
 	if err != nil {
-		fmt.Println("credhub client configuration failed: " + err.Error())
+		log.Fatal("Failed to parse PORT: ", err)
 	}
 
-	body := bindRequest{}
-	err = json.NewDecoder(r.Body).Decode(&body)
-
-	if err != nil {
-		fmt.Println(err)
-	}
-
-	name := strconv.FormatInt(time.Now().UnixNano(), 10)
-	storedJson := values.JSON{}
-	storedJson["user-name"] = "pinkyPie"
-	storedJson["password"] = "rainbowDash"
-
-	cred, err := ch.SetJSON(name, storedJson)
-	handleError(err)
-
-	s.NameMap[chi.URLParam(r, "service_binding_guid")] = name
-
-	if body.AppGuid != "" {
-		_, err = ch.AddPermission(cred.Name, "mtls-app:"+body.AppGuid, []string{"read"})
-		handleError(err)
-	}
-
-	credentials := `{
-  "credentials": {
-    "credhub-ref": "` + cred.Name + `"
-  }
-}`
-
-	WriteResponse(w, http.StatusCreated, credentials)
-}
-
-func (s *ServiceBroker) UnBind(w http.ResponseWriter, r *http.Request) {
-	ch, err := credhub.New(
-		util.AddDefaultSchemeIfNecessary(os.Getenv("CREDHUB_API")),
-		credhub.SkipTLSValidation(true),
-		credhub.Auth(auth.UaaClientCredentials(os.Getenv("CREDHUB_CLIENT"), os.Getenv("CREDHUB_SECRET"))),
-	)
-
-	if err != nil {
-		fmt.Println("credhub client configuration failed: " + err.Error())
-	}
-
-	name := s.NameMap[chi.URLParam(r, "service_binding_guid")]
-
-	err = ch.Delete(name)
-
-	handleError(err)
-
-	WriteResponse(w, http.StatusOK, "{}")
-}
-
-func handleError(err error) {
-	if err != nil {
-		fmt.Println(err)
-		log.Fatal("Fatal", err)
-	}
+	// Start the HTTP server
+	log.Printf("Server starting, listening on port %d...", port)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), router))
 }

--- a/assets/credhub-service-broker/manifest.yml
+++ b/assets/credhub-service-broker/manifest.yml
@@ -1,4 +1,0 @@
----
-applications:
-  - env:
-      GOPACKAGENAME: go-online

--- a/credhub/service_bindings.go
+++ b/credhub/service_bindings.go
@@ -42,10 +42,10 @@ var _ = CredhubDescribe("service bindings", func() {
 
 		Expect(cf.Cf(
 			"push", chBrokerAppName,
+			"--no-start",
 			"-b", Config.GetGoBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().CredHubServiceBroker,
-			"-f", assets.NewAssets().CredHubServiceBroker+"/manifest.yml",
 		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed pushing credhub-enabled service broker")
 
 		existingEnvVar := string(cf.Cf("running-environment-variable-group").Wait().Out.Contents())
@@ -74,8 +74,8 @@ var _ = CredhubDescribe("service bindings", func() {
 		).Wait()).To(Exit(0), "failed setting CREDHUB_SECRET env var on credhub-enabled service broker")
 
 		Expect(cf.Cf(
-			"restart", chBrokerAppName,
-		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed restarting credhub-enabled service broker")
+			"start", chBrokerAppName,
+		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed starting credhub-enabled service broker")
 
 		workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
 			serviceUrl := "https://" + chBrokerAppName + "." + Config.GetAppsDomain()

--- a/credhub/service_keys.go
+++ b/credhub/service_keys.go
@@ -32,10 +32,10 @@ var _ = CredhubDescribe("service keys", func() {
 
 		Expect(cf.Cf(
 			"push", chBrokerAppName,
+			"--no-start",
 			"-b", Config.GetGoBuildpackName(),
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().CredHubServiceBroker,
-			"-f", assets.NewAssets().CredHubServiceBroker+"/manifest.yml",
 		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed pushing credhub-enabled service broker")
 
 		existingEnvVar := string(cf.Cf("running-environment-variable-group").Wait().Out.Contents())
@@ -64,8 +64,8 @@ var _ = CredhubDescribe("service keys", func() {
 		).Wait()).To(Exit(0), "failed setting CREDHUB_SECRET env var on credhub-enabled service broker")
 
 		Expect(cf.Cf(
-			"restart", chBrokerAppName,
-		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed restarting credhub-enabled service broker")
+			"start", chBrokerAppName,
+		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed starting credhub-enabled service broker")
 
 		serviceUrl := "https://" + chBrokerAppName + "." + Config.GetAppsDomain()
 		createServiceBroker := cf.Cf("create-service-broker", chBrokerAppName, "a-user", "a-password", serviceUrl, "--space-scoped").Wait()

--- a/docker/credhub_enabled.go
+++ b/docker/credhub_enabled.go
@@ -30,10 +30,10 @@ var _ = DockerDescribe("Docker App Lifecycle CredHub Integration", func() {
 			chBrokerName = random_name.CATSRandomName("BRKR-CH")
 
 			pushBroker := cf.Cf("push", chBrokerName,
+				"--no-start",
 				"-b", Config.GetGoBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().CredHubServiceBroker,
-				"-f", assets.NewAssets().CredHubServiceBroker+"/manifest.yml",
 			).Wait(Config.CfPushTimeoutDuration())
 			Expect(pushBroker).To(Exit(0), "failed pushing credhub-enabled service broker")
 
@@ -60,8 +60,8 @@ var _ = DockerDescribe("Docker App Lifecycle CredHub Integration", func() {
 			setServiceName := cf.Cf("set-env", chBrokerName, "SERVICE_NAME", chServiceName).Wait()
 			Expect(setServiceName).To(Exit(0), "failed setting SERVICE_NAME env var on credhub-enabled service broker")
 
-			restartBroker := cf.Cf("restart", chBrokerName).Wait(Config.CfPushTimeoutDuration())
-			Expect(restartBroker).To(Exit(0), "failed restarting credhub-enabled service broker")
+			startBroker := cf.Cf("start", chBrokerName).Wait(Config.CfPushTimeoutDuration())
+			Expect(startBroker).To(Exit(0), "failed starting credhub-enabled service broker")
 
 			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
 				serviceUrl := "https://" + chBrokerName + "." + Config.GetAppsDomain()

--- a/windows/credhub_assist.go
+++ b/windows/credhub_assist.go
@@ -36,10 +36,10 @@ var _ = WindowsCredhubDescribe("CredHub Integration", func() {
 
 		Expect(cf.Cf(
 			"push", chBrokerAppName,
+			"--no-start",
 			"-b", Config.GetGoBuildpackName(),
 			"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
 			"-p", assets.NewAssets().CredHubServiceBroker,
-			"-f", assets.NewAssets().CredHubServiceBroker+"/manifest.yml",
 		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed pushing credhub-enabled service broker")
 
 		existingEnvVar := string(cf.Cf("running-environment-variable-group").Wait().Out.Contents())
@@ -68,8 +68,8 @@ var _ = WindowsCredhubDescribe("CredHub Integration", func() {
 		).Wait()).To(Exit(0), "failed setting CREDHUB_SECRET env var on credhub-enabled service broker")
 
 		Expect(cf.Cf(
-			"restart", chBrokerAppName,
-		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed restarting credhub-enabled service broker")
+			"start", chBrokerAppName,
+		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed starting credhub-enabled service broker")
 
 		workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
 			serviceUrl := "https://" + chBrokerAppName + "." + Config.GetAppsDomain()


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Refactors the credhub-service-broker asset for clarity, and to handle errors better. We were seeing a good amount of pipeline flakes recently that were resulting from the app going into a panic off one-time failures to connect to CredHub.

### Please provide contextual information.

https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/upgrade-cats/builds/340

### What version of cf-deployment have you run this cf-acceptance-test change against?

v29.1.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Actually knocks about 2 seconds off the runtime per test using this app because of the switch from restarting to starting. Not including the windows suite this amounts to about 16 seconds total.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None