### PR TITLE
Allow all stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ include_v3
 * `windows_stack`: Windows stack to run tests against. Must be `windows`.
 
 * `include_service_discovery`: Flag to include test for the service discovery. These tests use `apps.internal` domain, which is the default in `cf-networking-release`. The internal domain is currently not configurable.
-* `stacks`: An array of stacks to test against. Currently only `cflinuxfs4` is supported. Default is `[cflinuxfs4]`.
+* `stacks`: An array of stacks to test against. Default is `[cflinuxfs4]`.
 
 * `include_volume_services`: Flag to include the tests for volume services. The following requirements must be met to run this suite: tcp-routing must be deployed.
 * `volume_service_name`: The name of the volume service provided by the volume service broker.

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -722,12 +722,6 @@ func validateStacks(config *config) error {
 		return fmt.Errorf("* 'stacks' must not be null")
 	}
 
-	for _, stack := range config.GetStacks() {
-		if stack != "cflinuxfs4" {
-			return fmt.Errorf("* Invalid configuration: unknown stack '%s'. Only 'cflinuxfs4' is supported for the 'stacks' property", stack)
-		}
-	}
-
 	return nil
 }
 

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -711,27 +711,15 @@ var _ = Describe("Config", func() {
 		})
 	})
 
-	Context("when providing invalid stacks property", func() {
+	Context("when providing any set of stacks in the stacks property", func() {
 		BeforeEach(func() {
-			testCfg.Stacks = &[]string{"my-custom-stack"}
-		})
-
-		It("returns error if a stack other cflinuxfs4 is provided", func() {
-			_, err := cfg.NewCatsConfig(tmpFilePath)
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError("* Invalid configuration: unknown stack 'my-custom-stack'. Only 'cflinuxfs4' is supported for the 'stacks' property"))
-		})
-	})
-
-	Context("when providing valid stacks property", func() {
-		BeforeEach(func() {
-			testCfg.Stacks = &[]string{"cflinuxfs4"}
+			testCfg.Stacks = &[]string{"cflinuxfs4", "my-custom-stack"}
 		})
 
 		It("is loaded into the config", func() {
 			config, err := cfg.NewCatsConfig(tmpFilePath)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(config.GetStacks()).To(Equal([]string{"cflinuxfs4"}))
+			Expect(config.GetStacks()).To(Equal([]string{"cflinuxfs4", "my-custom-stack"}))
 		})
 	})
 


### PR DESCRIPTION
### What is this change about?

Allows users to specify values other than `cflinuxfs4` in the config's `stacks` field.

### Please provide contextual information.

Given recent efforts to integrate elements of the CNB ecosystem into CF -- in particular, [this proposal to integrate Paketo stacks](https://github.com/cloudfoundry/community/pull/637) -- CATs should allow operators to specify additional stacks besides cflinuxfs4.
### What version of cf-deployment have you run this cf-acceptance-test change against?

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?
N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
N/A


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@Gerg 
