### PR TITLE
Rework cats pipeline

### DIFF
--- a/ci/cats.md
+++ b/ci/cats.md
@@ -1,4 +1,4 @@
-# CATs
+# cats
 
 ## Purpose
 
@@ -8,7 +8,7 @@ This pipeline validates changes to `cf-acceptance-tests` for compatibility with 
 
 ### Unit Testing
 
-As a blocking step before running acceptance test suites, we run a separate suite of unit tests to validate the configuration interface and cf cli integration. Currently, the suites are located in the `helpers/config`, `helpers/download` and `helpers/cli_version_check` directories.
+As a blocking step before running acceptance test suites, we run a separate suite of unit tests to validate the configuration interface and cf cli integration. Currently, the suites are located in the `helpers/config` and `helpers/cli_version_check` directories.
 
 ### Acceptance Testing
 
@@ -17,6 +17,7 @@ We validate every test suite but windows, using the following config to enable t
 ```
   "include_apps": true,
   "include_backend_compatibility": true,
+  "include_capi_no_bridge": true,
   "include_container_networking": true,
   "include_detect": true,
   "include_docker": true,
@@ -57,7 +58,7 @@ This pipeline claims infrastructure provisioned by other pipelines through conco
 
 For CF on VMs, we deploy the latest [cf-deployment](https://github.com/cloudfoundry/cf-deployment) release with an isolation segment enabled. The Bosh director is provisioned by a separate infrastructure pipeline that uses the bosh-bootloader utility.
 
-The deployment is managed by the `deploy-cf` and `delete-cf` jobs which deploy and clean up cf-deployment respectively.
+The deployment is managed by the `deploy-cf` and `cleanup-cats` jobs which deploy and clean up cf-deployment respectively.
 
 ### Kubernetes
 
@@ -65,7 +66,17 @@ For CF on Kubernetes, we deploy the latest [cf-for-k8s](https://github.com/cloud
 
 ## Release Management
 
-See the `CATS-release` team wiki page for the full release management documentation: https://github.com/cloudfoundry/cf-acceptance-tests/wiki/Releasing
+Release management is a manual process and consists of the following steps:
+
+1. Manually generate release notes based on the current diff between the `release-candidate` and `main` branches
+1. Choose whether the next release is going to be a major, minor or patch
+   release.
+1. Run the corresponding `ship-it-*` job based on the release type identified in the previous step to promote the changes on the `release-candidate` branch and create a new release tag on the `main` branch.
+1. Use the newly created release tag and your release notes to create a new github release
+
+See the `CATS-release` team wiki page for more details on release notes conventions.
+
+Note that at the time of writing, when a new version of cf-acceptance-tests is released, a [job in the cf-deployment pipeline](https://release-integration.ci.cf-app.com/teams/main/pipelines/cf-deployment/jobs/stable-update-cats-cfd-branch) also creates a new branch at the release tag that freezes the versions of cf-deployment and cf-acceptance-tests.
 
 ## Pipeline management
 

--- a/ci/cats.md
+++ b/ci/cats.md
@@ -1,4 +1,4 @@
-# cats
+# CATs
 
 ## Purpose
 
@@ -8,7 +8,7 @@ This pipeline validates changes to `cf-acceptance-tests` for compatibility with 
 
 ### Unit Testing
 
-As a blocking step before running acceptance test suites, we run a separate suite of unit tests to validate the configuration interface and cf cli integration. Currently, the suites are located in the `helpers/config` and `helpers/cli_version_check` directories.
+As a blocking step before running acceptance test suites, we run a separate suite of unit tests to validate the configuration interface and cf cli integration. Currently, the suites are located in the `helpers/config`, `helpers/download` and `helpers/cli_version_check` directories.
 
 ### Acceptance Testing
 
@@ -17,7 +17,6 @@ We validate every test suite but windows, using the following config to enable t
 ```
   "include_apps": true,
   "include_backend_compatibility": true,
-  "include_capi_no_bridge": true,
   "include_container_networking": true,
   "include_detect": true,
   "include_docker": true,
@@ -58,7 +57,7 @@ This pipeline claims infrastructure provisioned by other pipelines through conco
 
 For CF on VMs, we deploy the latest [cf-deployment](https://github.com/cloudfoundry/cf-deployment) release with an isolation segment enabled. The Bosh director is provisioned by a separate infrastructure pipeline that uses the bosh-bootloader utility.
 
-The deployment is managed by the `deploy-cf` and `cleanup-cats` jobs which deploy and clean up cf-deployment respectively.
+The deployment is managed by the `deploy-cf` and `delete-cf` jobs which deploy and clean up cf-deployment respectively.
 
 ### Kubernetes
 
@@ -66,17 +65,7 @@ For CF on Kubernetes, we deploy the latest [cf-for-k8s](https://github.com/cloud
 
 ## Release Management
 
-Release management is a manual process and consists of the following steps:
-
-1. Manually generate release notes based on the current diff between the `release-candidate` and `main` branches
-1. Choose whether the next release is going to be a major, minor or patch
-   release.
-1. Run the corresponding `ship-it-*` job based on the release type identified in the previous step to promote the changes on the `release-candidate` branch and create a new release tag on the `main` branch.
-1. Use the newly created release tag and your release notes to create a new github release
-
-See the `CATS-release` team wiki page for more details on release notes conventions.
-
-Note that at the time of writing, when a new version of cf-acceptance-tests is released, a [job in the cf-deployment pipeline](https://release-integration.ci.cf-app.com/teams/main/pipelines/cf-deployment/jobs/stable-update-cats-cfd-branch) also creates a new branch at the release tag that freezes the versions of cf-deployment and cf-acceptance-tests.
+See the `CATS-release` team wiki page for the full release management documentation: https://github.com/cloudfoundry/cf-acceptance-tests/wiki/Releasing
 
 ## Pipeline management
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -90,25 +90,19 @@ jobs:
     - get: cf-acceptance-tests-develop
       trigger: true
     - get: runtime-ci
-    - get: cf-deployment-main
-      passed:
-      - smoke-tests
-      trigger: true
 
   - task: run-cats-unit-tests
     file: runtime-ci/tasks/run-cats-unit-tests/task.yml
     input_mapping:
       cf-acceptance-tests: cf-acceptance-tests-develop
 
-  - put: cats-pool
-    params:
-      claim: cats
-
-- name: acquire-pool-deploy
+- name: acquire-pool-cats
   public: true
   serial: true
   plan:
-  - get: cf-deployment-main
+  - get: cf-acceptance-tests-develop
+    passed:
+      - run-unit-tests
     trigger: true
 
   - put: cats-pool
@@ -131,14 +125,23 @@ jobs:
   - in_parallel:
     - get: cats-pool
       passed:
-      - acquire-pool-deploy
+        - acquire-pool-cats
       trigger: true
+    - get: cf-acceptance-tests-develop
+      passed:
+        - acquire-pool-cats
     - get: runtime-ci
     - get: cf-deployment-concourse-tasks
     - get: cf-deployment-main
-      passed:
-      - acquire-pool-deploy
     - get: relint-envs
+
+  - task: guarantee-no-existing-cf-deployment
+    file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
+    input_mapping:
+      bbl-state: relint-envs
+    params:
+      BBL_STATE_DIR: environments/test/cats/bbl-state
+      IGNORE_ERRORS: true
 
   - task: bosh-deploy-cf
     file: cf-deployment-concourse-tasks/bosh-deploy/task.yml
@@ -156,13 +159,6 @@ jobs:
         operations/windows2019-cell.yml
         operations/use-online-windows2019fs.yml
         operations/experimental/use-compiled-releases-windows.yml
-
-  - task: run-bosh-cleanup
-    file: cf-deployment-concourse-tasks/bosh-cleanup/task.yml
-    input_mapping:
-      bbl-state: relint-envs
-    params:
-      BBL_STATE_DIR: environments/test/cats/bbl-state
 
   - task: update-integration-configs
     file: cf-deployment-concourse-tasks/update-integration-configs/task.yml
@@ -184,12 +180,14 @@ jobs:
   - in_parallel:
     - get: cats-pool
       passed:
-      - deploy-cf
+        - deploy-cf
       trigger: true
-    - get: relint-envs
-    - get: cf-deployment-main
+    - get: cf-acceptance-tests-develop
       passed:
-      - deploy-cf
+        - deploy-cf
+    - get: relint-envs
+      passed:
+        - deploy-cf
     - get: cf-deployment-concourse-tasks
 
   - task: bosh-run-errand-smoke-tests
@@ -200,10 +198,6 @@ jobs:
       BBL_STATE_DIR: environments/test/cats/bbl-state
       ERRAND_NAME: smoke_tests
 
-  - put: cats-pool
-    params:
-      release: cats-pool
-
 - name: run-cats-vms
   serial: true
   public: true
@@ -211,16 +205,15 @@ jobs:
   - in_parallel:
     - get: cats-pool
       passed:
-      - run-unit-tests
+        - smoke-tests
       trigger: true
-    - get: cf-deployment-concourse-tasks
     - get: cf-acceptance-tests-develop
       passed:
-      - run-unit-tests
+        - smoke-tests
+    - get: cf-deployment-concourse-tasks
     - get: relint-envs
-    - get: cf-deployment-main
       passed:
-      - run-unit-tests
+        - smoke-tests
 
   - task: enable-docker-and-tasks
     file: cf-deployment-concourse-tasks/set-feature-flags/task.yml
@@ -252,12 +245,9 @@ jobs:
     - get: runtime-ci
     - get: cf-acceptance-tests-develop
       passed:
-      - run-cats-vms
+        - run-cats-vms
       trigger: true
     - get: cf-deployment-main
-      passed:
-      - run-cats-vms
-      trigger: true
 
   - put: cf-acceptance-tests-rc
     params:
@@ -279,10 +269,12 @@ jobs:
   - in_parallel:
     - get: cats-pool
       passed:
-      - run-cats-vms
+        - run-cats-vms
       trigger: true
     - get: runtime-ci
     - get: relint-envs
+      passed:
+        - run-cats-vms
 
   - task: cleanup-cats
     file: runtime-ci/tasks/cleanup-after-cats/task.yml
@@ -291,9 +283,40 @@ jobs:
     params:
       CONFIG_FILE_PATH: environments/test/cats/integration_config.json
 
-  - put: cats-pool
-    params:
-      release: cats-pool
+- name: delete-cf
+  serial: true
+  public: true
+  plan:
+    - timeout: 4h
+      do:
+      - in_parallel:
+        - get: cats-pool
+          trigger: true
+          passed:
+            - cleanup-cats
+        - get: cf-deployment-concourse-tasks
+        - get: relint-envs
+          passed:
+            - cleanup-cats
+
+    - task: delete-deployment-cf
+      file: cf-deployment-concourse-tasks/bosh-delete-deployment/task.yml
+      input_mapping:
+        bbl-state: relint-envs
+      params:
+        BBL_STATE_DIR: environments/test/cats/bbl-state
+        IGNORE_ERRORS: true
+
+    - task: run-bosh-cleanup
+      file: cf-deployment-concourse-tasks/bosh-cleanup/task.yml
+      input_mapping:
+        bbl-state: relint-envs
+      params:
+        BBL_STATE_DIR: environments/test/cats/bbl-state
+
+    - put: cats-pool
+      params:
+        release: cats-pool
 
 - name: ship-it-patch
   public: true


### PR DESCRIPTION
### What is this change about?

As discussed in the ARD WG meeting from Jul 27th, we want to rework the CATs release pipeline:

* use cats-develop branch as main trigger
* first run unit tests as sanity check
* then deploy cf from cf-deployment "main" branch
* run smoke-tests and then the actual CATs tests
* finally, cleanup CATs and destroy cf again to save cost

Note that the smoke-tests pipeline already uses a separate bbl infrastructure (was shared with CATs before).

As the pipeline.yml diff is likely not easy to read, I've uploaded the new pipeline (in paused state) here:
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cats-new

### What version of cf-deployment have you run this cf-acceptance-test change against?

(not relevant)

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
