### PR TITLE
DRAFT - cat for readiness health check feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,8 @@ include_v3
 `include_*` parameters are used to specify whether to skip tests based on how a deployment is configured.
 * `include_app_syslog_tcp`: Flag to include the app syslog drain over TCP test group.
 * `include_apps`: Flag to include the apps test group.
+* `readiness_health_checks_enabled`: Defaults to `true`. Set to false if you are using an environment without readiness health checks.
 * `include_container_networking`: Flag to include tests related to container networking.
-* `include_security_groups` must also be set for tests to run. [See below](#container-networking-and-application-security-groups)
-* `dynamic_asgs_enabled`: Defaults to `true`. Set to false if dynamic ASGs are disabled in the test environment.
 * `credhub_mode`: Valid values are `assisted` or `non-assisted`. [See below](#credhub-modes).
 * `credhub_location`: Location of CredHub instance; default is `https://credhub.service.cf.internal:8844`
 * `credhub_client`: UAA client credential for Service Broker write access to CredHub (required for CredHub tests); default is `credhub_admin_client`.
@@ -134,6 +133,7 @@ include_v3
 * `include_routing`: Flag to include the routing tests.
 * `include_routing_isolation_segments`: Flag to include routing isolation segments tests. [See below](#routing-isolation-segments). Cannot be run together with logging isolation segments tests.
 * `include_security_groups`: Flag to include tests for security groups. [See below](#container-networking-and-application-security-groups)
+* `dynamic_asgs_enabled`: Defaults to `true`. Set to false if dynamic ASGs are disabled in the test environment.
 * `include_services`: Flag to include test for the services API.
 * `include_service_instance_sharing`: Flag to include tests for service instance sharing between spaces. `include_services` must be set for these tests to run. The `service_instance_sharing` feature flag must also be enabled for these tests to pass.
 * `include_ssh`: Flag to include tests for Diego container ssh feature.

--- a/apps/readiness_healthcheck.go
+++ b/apps/readiness_healthcheck.go
@@ -1,0 +1,134 @@
+package apps
+
+import (
+	"fmt"
+
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
+	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
+	"github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
+)
+
+var _ = AppsDescribe("Readiness Healthcheck", func() {
+	var appName, proxyAppName string
+	var orgName string
+	var spaceName string
+	var readinessHealthCheckTimeout = "25s" // 20s route emitter sync loop + 2s hc interval + bonus
+
+	BeforeEach(func() {
+		if !Config.GetReadinessHealthChecksEnabled() {
+			Skip(skip_messages.SkipReadinessHealthChecksMessage)
+		}
+		appName = random_name.CATSRandomName("APP")
+		proxyAppName = random_name.CATSRandomName("APP")
+		orgName = TestSetup.RegularUserContext().Org
+		spaceName = TestSetup.RegularUserContext().Space
+	})
+
+	AfterEach(func() {
+		app_helpers.AppReport(appName)
+		app_helpers.AppReport(proxyAppName)
+		Eventually(cf.Cf("delete", appName, "-f")).Should(Exit(0))
+		Eventually(cf.Cf("delete", proxyAppName, "-f")).Should(Exit(0))
+	})
+
+	Describe("when the readiness healthcheck is set to http", func() {
+		FIt("registers the route only when the readiness check passes", func() {
+			By("pushing the app")
+			Expect(cf.Push(appName,
+				"-p", assets.NewAssets().Dora,
+				"--readiness-endpoint", "/ready",
+				"--readiness-health-check-type", "http",
+				"--readiness-health-check-interval", "1",
+			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+			By("verifying the app starts")
+			Eventually(func() string {
+				return helpers.CurlAppRoot(Config, appName)
+			}, Config.DefaultTimeoutDuration()).Should(ContainSubstring("Hi, I'm Dora!"))
+
+			// Get the initial overlay IP for dora app
+			overlayIP := helpers.CurlApp(Config, appName, "/myip")
+
+			By("verifying the app is marked as ready")
+			Eventually(func() string {
+				return helpers.CurlApp(Config, appName, "/ready")
+			}, Config.DefaultTimeoutDuration()).Should(ContainSubstring("200 - ready"))
+
+			// TODO: only include this when audit events are built
+			// Eventually(func() string {
+			// 	return string(cf.Cf("events", appName).Wait().Out.Contents())
+			// }).Should(MatchRegexp("app.ready"))
+
+			Expect(string(logs.Recent(appName).Wait().Out.Contents())).Should(ContainSubstring("Container passed the readiness health check"))
+
+			By("triggering the app to make the /ready endpoint fail")
+			helpers.CurlApp(Config, appName, "/ready/false")
+
+			By("verifying the app is marked as not ready")
+
+			// TODO: only include this when audit events are built
+			// Eventually(func() string {
+			// 	return string(cf.Cf("events", appName).Wait().Out.Contents())
+			// }).Should(MatchRegexp("app.notready"))
+
+			Eventually(func() string {
+				return string(logs.Recent(appName).Wait().Out.Contents())
+			}, readinessHealthCheckTimeout).Should(ContainSubstring("Container failed the readiness health check"))
+
+			By("verifying the app is removed from the routing table")
+			Eventually(func() string {
+				return helpers.CurlApp(Config, appName, "/ready")
+			}).Should(ContainSubstring("404 Not Found"))
+
+			By("using c2c to trigger the app to make the /ready endpoint succeed again")
+			// push proxy app
+			Expect(cf.Cf(
+				"push", proxyAppName,
+				"-b", Config.GetGoBuildpackName(),
+				"-m", DEFAULT_MEMORY_LIMIT,
+				"-p", assets.NewAssets().Proxy,
+				"-f", assets.NewAssets().Proxy+"/manifest.yml",
+			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+			// Make network policy for proxy to dora
+			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+				Expect(cf.Cf("target", "-o", orgName, "-s", spaceName).Wait()).To(Exit(0))
+				Expect(cf.Cf("add-network-policy", proxyAppName, appName, "--protocol", "tcp", "--port", "8080").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+				Expect(string(cf.Cf("network-policies").Wait().Out.Contents())).To(ContainSubstring(appName))
+			})
+
+			// Wait until the c2c policy is in place
+			Eventually(func() string {
+				return helpers.CurlApp(Config, proxyAppName, fmt.Sprintf("/proxy/%s:8080", overlayIP))
+			}, Config.DefaultTimeoutDuration()).Should(ContainSubstring("Dora"))
+
+			// Trigger the app to make the /ready endpoint return a 200 again
+			Eventually(func() string {
+				return helpers.CurlApp(Config, proxyAppName, fmt.Sprintf("/proxy/%s:8080/ready/true", overlayIP))
+			}).Should(ContainSubstring("true"))
+
+			By("verifying that the routing table includes the app again")
+			Eventually(func() string {
+				return helpers.CurlApp(Config, appName, "/ready")
+			}, readinessHealthCheckTimeout).Should(ContainSubstring("200 - ready"))
+
+			By("verifying that the app hasn't restarted")
+			Consistently(func() string {
+				return string(cf.Cf("events", appName).Wait().Out.Contents())
+			}).ShouldNot(MatchRegexp("audit.app.process.rescheduling"))
+
+			// Verify that the overlay IP has not changed, and thus that the app has not been restaged
+			Expect(helpers.CurlApp(Config, appName, "/myip")).To(Equal(overlayIP))
+		})
+	})
+})

--- a/assets/dora/README.md
+++ b/assets/dora/README.md
@@ -29,6 +29,8 @@ with sticky sessions in the browser.
 1. `GET /env.json` Prints out the entire environment as a JSON object
 1. `GET /largetext/:kbytes` Returns a dummy response of size `:kbytes`. For testing large payloads.
 1. `GET /health` Returns 500 the first 3 times you call it, "I'm alive" thereafter
+1. `GET /ready` Returns 200 by default. Use `GET /ready/false` to make it return 500. Use `GET /ready/true` to make it return 200 again.
+1. `GET /ready/:new_ready_state` When `new_ready_state` is false, `GET /ready` will respond with status code 500. When `new_ready_state` is true, `GET /ready` will respond with status code 200.
 1. `GET /ping/:address` Pings the given address 4 times
 1. `GET /lsb_release` Returns information about the Linux distribution of the container
 1. `GET /dpkg/:package` Returns the output of `dpkg -l` for the given packange

--- a/assets/dora/dora.rb
+++ b/assets/dora/dora.rb
@@ -17,6 +17,7 @@ $stdout.sync = true
 $stderr.sync = true
 $counter = 0
 $start_time = Time.now
+$ready = true
 
 class Dora < Sinatra::Base
   use Instances
@@ -102,12 +103,27 @@ class Dora < Sinatra::Base
     ENV.to_hash.to_s
   end
 
+  get '/ready' do
+    unless $ready == 'false'
+      status 200
+      return "200 - ready"
+    end
+
+    status 500
+    "500 - not ready"
+  end
+
+  get '/ready/:new_ready_state' do
+    $ready = params[:new_ready_state]
+  end
+
   get '/env.json' do
     ENV.to_hash.to_json
   end
 
   get '/myip' do
-    `ip route get 1 | awk '{print $NF;exit}'`
+    ip = `ip route get 1 | awk '{print $7;exit}'`
+    ip.delete("\n")
   end
 
   get '/largetext/:kbytes' do

--- a/example-cats-config.json
+++ b/example-cats-config.json
@@ -13,6 +13,8 @@ IN DEVELOPMENT
   "use_http": true,
   "include_app_syslog_tcp": true,
   "include_apps": true,
+  "dynamic_asgs_enabled": true,
+  "readiness_health_check_enabled": true,
   "include_container_networking": true,
   "include_detect": true,
   "include_docker": true,

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -78,6 +78,7 @@ type CatsConfig interface {
 	GetUnallocatedIPForSecurityGroup() string
 	GetRequireProxiedAppTraffic() bool
 	GetDynamicASGsEnabled() bool
+	GetReadinessHealthChecksEnabled() bool
 	Protocol() string
 
 	GetStacks() []string

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -111,7 +111,8 @@ type config struct {
 	UnallocatedIPForSecurityGroup *string `json:"unallocated_ip_for_security_group"`
 	RequireProxiedAppTraffic      *bool   `json:"require_proxied_app_traffic"`
 
-	DynamicASGsEnabled *bool `json:"dynamic_asgs_enabled"`
+	DynamicASGsEnabled           *bool `json:"dynamic_asgs_enabled"`
+	ReadinessHealthChecksEnabled *bool `json:"readiness_health_checks_enabled"`
 
 	NamePrefix *string `json:"name_prefix"`
 
@@ -230,6 +231,7 @@ func getDefaults() config {
 	defaults.RequireProxiedAppTraffic = ptrToBool(false)
 
 	defaults.DynamicASGsEnabled = ptrToBool(true)
+	defaults.ReadinessHealthChecksEnabled = ptrToBool(true)
 
 	defaults.NamePrefix = ptrToString("CATS")
 
@@ -942,6 +944,11 @@ func (c *config) GetIncludeSecurityGroups() bool {
 func (c *config) GetDynamicASGsEnabled() bool {
 	return *c.DynamicASGsEnabled
 }
+
+func (c *config) GetReadinessHealthChecksEnabled() bool {
+	return *c.ReadinessHealthChecksEnabled
+}
+
 func (c *config) GetIncludeServices() bool {
 	return *c.IncludeServices
 }

--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -2,6 +2,7 @@ package skip_messages
 
 const SkipAppSyslogTcpMessage = `Skipping this test because config.IncludeAppSyslogTcp is set to 'false'.`
 const SkipAppsMessage = `Skipping this test because config.IncludeApps is set to 'false'.`
+const SkipReadinessHealthChecksMessage = `Skipping this test because config.ReadinessHealthChecksEnabled is set to 'false'.`
 const SkipContainerNetworkingMessage = `Skipping this test because config.IncludeContainerNetworking is set to 'false'.`
 const SkipDetectMessage = `Skipping this test because config.IncludeDetect is set to 'false'.`
 const SkipDockerMessage = `Skipping this test because config.IncludeDocker is set to 'false'.

--- a/vendor/github.com/cloudfoundry/cf-test-helpers/v2/cf/push.go
+++ b/vendor/github.com/cloudfoundry/cf-test-helpers/v2/cf/push.go
@@ -17,13 +17,16 @@ type Manifest struct {
 }
 
 type Application struct {
-	Buildpacks []string `yaml:",omitempty"`
-	Command    string   `yaml:",omitempty"`
-	Instances  int      `yaml:",omitempty"`
-	Memory     string   `yaml:",omitempty"`
-	Name       string
-	Path       string              `yaml:",omitempty"`
-	Routes     []map[string]string `yaml:",omitempty"`
+	Buildpacks                       []string `yaml:",omitempty"`
+	Command                          string   `yaml:",omitempty"`
+	Instances                        int      `yaml:",omitempty"`
+	Memory                           string   `yaml:",omitempty"`
+	Name                             string
+	Path                             string              `yaml:",omitempty"`
+	ReadinessHealthCheckHTTPEndpoint string              `yaml:"readiness-health-check-http-endpoint,omitempty"`
+	ReadinessHealthCheckInterval     string              `yaml:"readiness-health-check-interval,omitempty"`
+	ReadinessHealthCheckType         string              `yaml:"readiness-health-check-type,omitempty"`
+	Routes                           []map[string]string `yaml:",omitempty"`
 }
 
 var Push = func(appName string, args ...string) *gexec.Session {
@@ -58,6 +61,12 @@ var Push = func(appName string, args ...string) *gexec.Session {
 				panic(err)
 			}
 			app.Path = path
+		case "--readiness-endpoint":
+			app.ReadinessHealthCheckHTTPEndpoint = args[i+1]
+		case "--readiness-health-check-type":
+			app.ReadinessHealthCheckType = args[i+1]
+		case "--readiness-health-check-interval":
+			app.ReadinessHealthCheckInterval = args[i+1]
 		}
 	}
 

--- a/windows/readiness_healthcheck.go
+++ b/windows/readiness_healthcheck.go
@@ -1,0 +1,86 @@
+package windows
+
+import (
+	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
+	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
+
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = WindowsDescribe("Readiness Healthcheck", func() {
+	var appName string
+	var readinessHealthCheckTimeout = "25s" // 20s route emitter sync loop + 2s hc interval + bonus
+
+	BeforeEach(func() {
+		if !Config.GetReadinessHealthChecksEnabled() {
+			Skip(skip_messages.SkipReadinessHealthChecksMessage)
+		}
+		appName = random_name.CATSRandomName("APP")
+	})
+
+	AfterEach(func() {
+		app_helpers.AppReport(appName)
+		Eventually(cf.Cf("delete", appName, "-f")).Should(Exit(0))
+	})
+
+	// TODO add a ready endpoint to Nora
+	Describe("when the readiness healthcheck is set to http", func() {
+		FIt("registers the route only when the readiness check passes", func() {
+			By("pushing the app")
+			Expect(cf.Cf("push",
+				appName,
+				"-s", Config.GetWindowsStack(),
+				"-b", Config.GetHwcBuildpackName(),
+				"-m", DEFAULT_WINDOWS_MEMORY_LIMIT,
+				"-p", assets.NewAssets().Nora,
+				"--readiness-health-check-type", "http",
+				"--readiness-health-check-interval", "1",
+			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+			By("verifying the app starts")
+			Eventually(func() string {
+				return helpers.CurlAppRoot(Config, appName)
+			}, Config.DefaultTimeoutDuration()).Should(ContainSubstring("Hi, I'm Nora!"))
+
+			By("verifying the app is marked as ready")
+			// TODO: only include this when audit events are built
+			// Eventually(func() string {
+			// 	return string(cf.Cf("events", appName).Wait().Out.Contents())
+			// }).Should(MatchRegexp("app.ready"))
+
+			Expect(string(logs.Recent(appName).Wait().Out.Contents())).Should(ContainSubstring("Container passed the readiness health check"))
+
+			By("triggering the app to make the /ready endpoint fail")
+			helpers.CurlApp(Config, appName, "/ready/false")
+
+			By("verifying the app is marked as not ready")
+
+			// TODO: only include this when audit events are built
+			// Eventually(func() string {
+			// 	return string(cf.Cf("events", appName).Wait().Out.Contents())
+			// }).Should(MatchRegexp("app.notready"))
+
+			Eventually(func() string {
+				return string(logs.Recent(appName).Wait().Out.Contents())
+			}, readinessHealthCheckTimeout).Should(ContainSubstring("Container failed the readiness health check"))
+
+			By("verifying the app is removed from the routing table")
+			Eventually(func() string {
+				return helpers.CurlApp(Config, appName, "/ready")
+			}).Should(ContainSubstring("404 Not Found"))
+
+			By("verifying that the app hasn't restarted")
+			Consistently(func() string {
+				return string(cf.Cf("events", appName).Wait().Out.Contents())
+			}).ShouldNot(MatchRegexp("audit.app.process.rescheduling"))
+		})
+	})
+})


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?
✅ Yes.

### What is this change about?

This PR adds a new CAT for readiness health checks, a feature that is coming out with new versions of CAPI and Diego soon.

### Please provide contextual information.

* [CFF RFC for adding readiness health checks]https://github.com/cloudfoundry/community/blob/rfc-readiness-healthchecks/toc/rfc/rfc-draft-readiness-healthchecks.md)
* [PR to add this to Cloud Controller](https://github.com/cloudfoundry/cloud_controller_ng/pull/3351)

### What version of cf-deployment have you run this cf-acceptance-test change against?

⛔️⛔️⛔️TBD⛔️⛔️⛔️


### Please check all that apply for this PR:

- [x] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

We are adding a major new feature to CF. This CAT will test one basic workflow for that feature.


### How many more (or fewer) seconds of runtime will this change introduce to CATs?
220-ish seconds. Sorry :( 


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
* @mariash 
