### PR TITLE
Remove stacks from readiness manifests

### DIFF
--- a/assets/dora/readiness_manifest.yml
+++ b/assets/dora/readiness_manifest.yml
@@ -1,7 +1,6 @@
 ---
 applications:
 - name: dora
-  stack: cflinuxfs3
   processes:
   - type: web
     instances: 1

--- a/assets/nora/readiness_manifest.yml
+++ b/assets/nora/readiness_manifest.yml
@@ -1,7 +1,6 @@
 ---
 applications:
 - name: nora
-  stack: windows
   processes:
   - type: web
     instances: 1

--- a/windows/readiness_healthcheck.go
+++ b/windows/readiness_healthcheck.go
@@ -39,6 +39,7 @@ var _ = WindowsDescribe("Readiness Healthcheck", func() {
 				appName,
 				"-f", assets.NewAssets().Nora+"/../readiness_manifest.yml",
 				"-p", assets.NewAssets().Nora,
+				"-s", Config.GetWindowsStack(),
 			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 			By("verifying the app starts")


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

✅  yes.

### What is this change about?

Fixing [this failure](https://github.com/cloudfoundry/cf-acceptance-tests/issues/922) caused by [this PR](https://github.com/cloudfoundry/cf-acceptance-tests/pull/915).

### Please provide contextual information.

* [Previous PR](https://github.com/cloudfoundry/cf-acceptance-tests/pull/915)
* [CI failure](https://github.com/cloudfoundry/cf-acceptance-tests/issues/922)
* [Slack convo](https://cloudfoundry.slack.com/archives/C033ALST37V/p1692900806935289?thread_ts=1692285983.883259&cid=C033ALST37V)

### What version of cf-deployment have you run this cf-acceptance-test change against?

https://github.com/cloudfoundry/cf-deployment/releases/tag/v32.2.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Now tests will pass :) 

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
