### PR TITLE
Fix: 404 expectations for custom router error pages

### DIFF
--- a/apps/readiness_healthcheck.go
+++ b/apps/readiness_healthcheck.go
@@ -69,7 +69,7 @@ var _ = AppsDescribe("Readiness Healthcheck", func() {
 			By("verifying the app is removed from the routing table")
 			Eventually(func() string {
 				return helpers.CurlApp(Config, appName, "/ready")
-			}, readinessHealthCheckTimeout).Should(ContainSubstring("404 Not Found"))
+			}, readinessHealthCheckTimeout).Should(ContainSubstring("404"))
 
 			By("verifying that the app hasn't restarted")
 			Consistently(cf.Cf("events", appName)).ShouldNot(Say("audit.app.process.crash"))

--- a/apps/rolling_deploy.go
+++ b/apps/rolling_deploy.go
@@ -58,7 +58,7 @@ var _ = AppsDescribe("Rolling deploys", func() {
 					return
 				case <-tickerChannel:
 					appResponse := helpers.CurlAppRoot(Config, appName)
-					Expect(appResponse).ToNot(ContainSubstring("404 Not Found"))
+					Expect(appResponse).ToNot(ContainSubstring("404"))
 					Expect(appResponse).To(ContainSubstring("Hi, I'm Dora!"))
 				}
 			}

--- a/v3/deployment.go
+++ b/v3/deployment.go
@@ -208,7 +208,7 @@ func checkAppRemainsAlive(appName string) (chan<- bool, <-chan bool) {
 				appCheckerIsDone <- true
 				return
 			case <-tickerChannel:
-				Expect(helpers.CurlAppRoot(Config, appName)).ToNot(ContainSubstring("404 Not Found"))
+				Expect(helpers.CurlAppRoot(Config, appName)).ToNot(ContainSubstring("404"))
 			}
 		}
 	}()

--- a/windows/readiness_healthcheck.go
+++ b/windows/readiness_healthcheck.go
@@ -70,7 +70,7 @@ var _ = WindowsDescribe("Readiness Healthcheck", func() {
 			By("verifying the app is removed from the routing table")
 			Eventually(func() string {
 				return helpers.CurlApp(Config, appName, "/ready")
-			}, readinessHealthCheckTimeout).Should(ContainSubstring("404 Not Found"))
+			}, readinessHealthCheckTimeout).Should(ContainSubstring("404"))
 
 			By("verifying that the app hasn't restarted")
 			Consistently(cf.Cf("events", appName)).ShouldNot(Say("audit.app.process.crash"))


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Our helpers only return response bodies, not response statuses. This means that if we want to check for a 404 error, for instance, we need to check the body for a 404 error. However, some operators override their router's error pages, which break our expectations, if they're too specific.

This makes our 404 expectations less specific by reducing our assumptions about the error page returned from "it contains `404 Not Found`", to "it contains `404`". The latter seems like a pretty safe assumption to make.

### Please provide contextual information.

Closes #929 

### What version of cf-deployment have you run this cf-acceptance-test change against?

None yet

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None