### PR TITLE
Chore(bin): update test defaults

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -20,5 +20,5 @@ export CF_PLUGIN_HOME=$HOME
 
 pushd "${CATS_ROOT}" > /dev/null
   echo "Using $(go run github.com/onsi/ginkgo/v2/ginkgo version)"
-  go run github.com/onsi/ginkgo/v2/ginkgo "$@"
+  go run github.com/onsi/ginkgo/v2/ginkgo --randomize-all --keep-going "$@"
 popd > /dev/null


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

`./bin/test` should:
- Randomize all specs. This helps suss out spec pollution.
- Instruct Ginkgo to keep running suites even after a suite fails. This makes sure we get the full set of failures on a test run.

### Please provide contextual information.

None

### What version of cf-deployment have you run this cf-acceptance-test change against?

None

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None