### PR TITLE
Update minimum go version to 1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ in such a way as to impact other tests.
 
 ## Test Setup
 ### Prerequisites for running CATS
-- Install golang >= `1.11`. Set up your golang development environment, per
+- Install golang >= `1.20`. Set up your golang development environment, per
   [golang.org](http://golang.org/doc/install).
 - Install the [`cf CLI`](https://github.com/cloudfoundry/cli).
   Make sure that it is accessible in your `$PATH`.
@@ -60,7 +60,7 @@ in such a way as to impact other tests.
 All `go` dependencies required by CATs
 are vendored in the `vendor` directory.
 
-Make sure to have Golang 1.11+
+Make sure to have Golang 1.20+
 
 In order to update a current dependency to a specific version,
 do the following:


### PR DESCRIPTION
As stated in the [Go Modules Reference](https://go.dev/ref/mod#go-mod-file-go), it must be at least the version declared in the go directive.
So, I have matched the minimum version of go in the README to the version defined in go.mod.
