### PR TITLE
Refactor: HTTP/2 routing suite

### DIFF
--- a/http2_routing/grpc_routing.go
+++ b/http2_routing/grpc_routing.go
@@ -1,0 +1,51 @@
+package http2_routing
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	protobuff "github.com/cloudfoundry/cf-acceptance-tests/helpers/assets/test"
+	. "github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers"
+	"google.golang.org/grpc"
+
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = HTTP2RoutingDescribe("gRPC apps", func() {
+	var appName string
+
+	BeforeEach(func() {
+		appName = random_name.CATSRandomName("APP")
+
+		pushArgs := app_helpers.GRPCWithArgs(appName, "--no-route", "-m", DEFAULT_MEMORY_LIMIT)
+		Expect(cf.Cf(pushArgs...).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+		domain := Config.GetAppsDomain()
+		Expect(cf.Cf("map-route", domain, "--hostname", appName, "--app-protocol", "http2").Wait()).To(Exit(0))
+	})
+
+	It("can serve gRPC traffic (requires HTTP/2 for all hops)", func() {
+		domain := Config.GetAppsDomain()
+		target := fmt.Sprintf("%s.%s:443", appName, domain)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		conn, err := grpc.DialContext(ctx, target, grpc.WithBlock(), grpc.FailOnNonTempDialError(true))
+		Expect(err).ToNot(HaveOccurred())
+		defer conn.Close()
+
+		tc := protobuff.NewTestClient(conn)
+
+		resp, err := tc.Run(ctx, &protobuff.Request{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.GetBody()).To(Equal("Hello"))
+	})
+})

--- a/http2_routing/http2_routing.go
+++ b/http2_routing/http2_routing.go
@@ -1,14 +1,7 @@
 package http2_routing
 
 import (
-	"context"
-	"crypto/tls"
-	"time"
-
-	protobuff "github.com/cloudfoundry/cf-acceptance-tests/helpers/assets/test"
 	. "github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
@@ -20,81 +13,20 @@ import (
 	. "github.com/onsi/gomega/gexec"
 )
 
-var _ = HTTP2RoutingDescribe("HTTP/2 Routing", func() {
-	Context("when a destination only supports HTTP/2", func() {
-		It("routes traffic to that destination over HTTP/2", func() {
-			appName := random_name.CATSRandomName("APP")
+var _ = HTTP2RoutingDescribe("HTTP/2 apps", func() {
+	var appName string
 
-			Expect(cf.Cf(app_helpers.HTTP2WithArgs(
-				appName,
-				"--no-route",
-				"-m", DEFAULT_MEMORY_LIMIT)...).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+	BeforeEach(func() {
+		appName = random_name.CATSRandomName("APP")
 
-			appGUID := app_helpers.GetAppGuid(appName)
+		pushArgs := app_helpers.HTTP2WithArgs(appName, "--no-route", "-m", DEFAULT_MEMORY_LIMIT)
+		Expect(cf.Cf(pushArgs...).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
-			Expect(cf.Cf("create-route", Config.GetAppsDomain(),
-				"--hostname", appName,
-			).Wait()).To(Exit(0))
-
-			destination := Destination{
-				App: App{
-					GUID: appGUID,
-				},
-				Protocol: "http2",
-			}
-			InsertDestinations(GetRouteGuid(appName), []Destination{destination})
-
-			Eventually(func() string {
-				return helpers.CurlAppRoot(Config, appName)
-			}).Should(ContainSubstring("Hello"))
-		})
+		domain := Config.GetAppsDomain()
+		Expect(cf.Cf("map-route", domain, "--hostname", appName, "--app-protocol", "http2").Wait()).To(Exit(0))
 	})
 
-	Context("when a destination serves gRPC", func() {
-		It("successfully routes the gRPC traffic (requires HTTP/2 for all hops)", func() {
-			appName := random_name.CATSRandomName("APP")
-
-			Expect(cf.Cf(app_helpers.GRPCWithArgs(
-				appName,
-				"--no-route",
-				"-m", DEFAULT_MEMORY_LIMIT)...).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-
-			appGUID := app_helpers.GetAppGuid(appName)
-
-			appsDomain := Config.GetAppsDomain()
-			Expect(cf.Cf("create-route", appsDomain,
-				"--hostname", appName,
-			).Wait()).To(Exit(0))
-
-			destination := Destination{
-				App: App{
-					GUID: appGUID,
-				},
-				Protocol: "http2",
-			}
-			InsertDestinations(GetRouteGuid(appName), []Destination{destination})
-
-			appURI := appName + "." + appsDomain + ":443"
-
-			tlsConfig := tls.Config{InsecureSkipVerify: true}
-			creds := credentials.NewTLS(&tlsConfig)
-
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			conn, err := grpc.DialContext(
-				ctx,
-				appURI,
-				grpc.WithTransportCredentials(creds),
-				grpc.WithBlock(),
-				grpc.FailOnNonTempDialError(true),
-			)
-			Expect(err).ToNot(HaveOccurred())
-			defer conn.Close()
-
-			client := protobuff.NewTestClient(conn)
-			response, err := client.Run(ctx, &protobuff.Request{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(response.GetBody()).To(Equal("Hello"))
-		})
+	It("receive routed traffic over HTTP/2", func() {
+		Eventually(helpers.CurlAppRoot).WithArguments(Config, appName).Should(ContainSubstring("Hello"))
 	})
 })


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

### What is this change about?

- Reword descriptions for clarity.
- Use `cf map-route` with new `--app-protocol` flag to create an HTTP/2 route for the apps.

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
