### PR TITLE
fix(helpers): Remove unnecessary tools import

### DIFF
--- a/helpers/assets/tools.go
+++ b/helpers/assets/tools.go
@@ -1,7 +1,0 @@
-// +build tools
-
-package tools
-
-import (
-	_ "github.com/onsi/ginkgo/v2/ginkgo"
-)


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

### What is this change about?

Ginkgo v2 has a dependency on it's own CLI now, eliminating the need to manually import the CLi as a tool.

### Please provide contextual information.

https://github.com/onsi/ginkgo/releases/tag/v2.8.2

### What version of cf-deployment have you run this cf-acceptance-test change against?

v29.1.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None