### PR TITLE
update readiness health check test to test audit events

### DIFF
--- a/apps/readiness_healthcheck.go
+++ b/apps/readiness_healthcheck.go
@@ -51,8 +51,7 @@ var _ = AppsDescribe("Readiness Healthcheck", func() {
 				return helpers.CurlApp(Config, appName, "/ready")
 			}, Config.DefaultTimeoutDuration()).Should(ContainSubstring("200 - ready"))
 
-			// TODO: only include this when audit events are built
-			// Eventually(cf.Cf("events", appName)).Should(Say("app.ready"))
+			Eventually(cf.Cf("events", appName)).Should(Say("app.process.ready"))
 
 			Expect(logs.Recent(appName).Wait()).To(Say("Container passed the readiness health check"))
 
@@ -61,8 +60,7 @@ var _ = AppsDescribe("Readiness Healthcheck", func() {
 
 			By("verifying the app is marked as not ready")
 
-			// TODO: only include this when audit events are built
-			// Eventually(cf.Cf("events", appName)).Should(Say("app.notready"))
+			Eventually(cf.Cf("events", appName)).Should(Say("app.process.not-ready"))
 
 			Eventually(func() BufferProvider { return logs.Recent(appName).Wait() }, readinessHealthCheckTimeout).Should(Say("Container failed the readiness health check"))
 

--- a/windows/readiness_healthcheck.go
+++ b/windows/readiness_healthcheck.go
@@ -52,8 +52,7 @@ var _ = WindowsDescribe("Readiness Healthcheck", func() {
 				return helpers.CurlApp(Config, appName, "/ready")
 			}, Config.DefaultTimeoutDuration()).Should(ContainSubstring("200 - ready"))
 
-			// TODO: only include this when audit events are built
-			// Eventually(cf.Cf("events", appName)).Should(Say("app.ready"))
+			Eventually(cf.Cf("events", appName)).Should(Say("app.process.ready"))
 
 			Expect(logs.Recent(appName).Wait()).To(Say("Container passed the readiness health check"))
 
@@ -62,8 +61,7 @@ var _ = WindowsDescribe("Readiness Healthcheck", func() {
 
 			By("verifying the app is marked as not ready")
 
-			// TODO: only include this when audit events are built
-			// Eventually(cf.Cf("events", appName)).Should(Say("app.notready"))
+			Eventually(cf.Cf("events", appName)).Should(Say("app.process.not-ready"))
 
 			Eventually(func() BufferProvider { return logs.Recent(appName).Wait() }, readinessHealthCheckTimeout).Should(Say("Container failed the readiness health check"))
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?
✅ 

### What is this change about?
This adds a test for the new `audit.app.process.ready` and `audit.app.process.not-ready` events.

### Please provide contextual information.
* CFF RFC: https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0020-readiness-healthchecks.md
* Tracker story: https://www.pivotaltracker.com/story/show/185799545
* Issue tracking all of the PRs in this effort: https://github.com/cloudfoundry/capi-release/issues/363

### What version of cf-deployment have you run this cf-acceptance-test change against?
* This changes were tested against [capi-release 1.169.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.169.0).
* This capi version is in [cf-deployment v36.0.0](https://github.com/cloudfoundry/cf-deployment/tree/v36.0.0).


### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
Less than 1!


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
