### PR TITLE
fix(assets/service_broker): Use RewindableInput middleware

### DIFF
--- a/assets/service_broker/config.ru
+++ b/assets/service_broker/config.ru
@@ -1,4 +1,7 @@
 $: << File.expand_path("../.", __FILE__)
 
 require "service_broker"
+
+use Rack::RewindableInput::Middleware
+
 run ServiceBroker

--- a/assets/service_broker/service_broker.rb
+++ b/assets/service_broker/service_broker.rb
@@ -195,7 +195,7 @@ class ServiceBroker < Sinatra::Base
   end
 
   def cf_respond_with_api_info_location(cf_api_info_location)
-    if cf_api_info_location.empty?
+    if cf_api_info_location.nil? || cf_api_info_location.empty?
       status 503
       log_response(status, JSON.pretty_generate({
         error: true,

--- a/assets/service_broker/spec/service_broker_spec.rb
+++ b/assets/service_broker/spec/service_broker_spec.rb
@@ -320,7 +320,7 @@ describe ServiceBroker do
             Timeout::timeout(1) do
               send(action)
             end
-          end.to raise_error(TimeoutError)
+          end.to raise_error(Timeout::Error)
         end
 
         it 'can be customized on a per-plan basis' do
@@ -446,13 +446,13 @@ describe ServiceBroker do
           Timeout::timeout(1) do
             get '/v2/service_instances/fake-guid/last_operation'
           end
-        end.to raise_error(TimeoutError)
+        end.to raise_error(Timeout::Error)
 
         expect do
           Timeout::timeout(0.5) do
             get '/v2/service_instances/fake-guid/last_operation'
           end
-        end.to raise_error(TimeoutError)
+        end.to raise_error(Timeout::Error)
       end
 
       it 'honors max_fetch_service_instance_request' do


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Uses the RewindableInput middleware to recapture a Rack 2 expectation that no longer exists in Rack 3 – that the request.body is rewindable.

Resolves the following error message when curling the `/config` endpoint:
```
undefined method `rewind'
```

### Please provide contextual information.

- https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cats/jobs/run-cats-vms/builds/240.1
- https://github.com/cloudfoundry/cf-acceptance-tests/pull/1032

### What version of cf-deployment have you run this cf-acceptance-test change against?

v37.0.0

### Please check all that apply for this PR:

- [x] updates an asset
- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None