### PR TITLE
Fix windows readiness test

### DIFF
--- a/windows/readiness_healthcheck.go
+++ b/windows/readiness_healthcheck.go
@@ -59,11 +59,10 @@ var _ = WindowsDescribe("Readiness Healthcheck", func() {
 			By("triggering the app to make the /ready endpoint fail")
 			helpers.CurlApp(Config, appName, "/ready/false")
 
-			By("verifying the app is marked as not ready")
-
-			Eventually(cf.Cf("events", appName)).Should(Say("app.process.not-ready"))
-
 			Eventually(func() BufferProvider { return logs.Recent(appName).Wait() }, readinessHealthCheckTimeout).Should(Say("Container failed the readiness health check"))
+
+			By("verifying the app is marked as not ready")
+			Eventually(cf.Cf("events", appName)).Should(Say("app.process.not-ready"))
 
 			By("verifying the app is removed from the routing table")
 			Eventually(func() string {


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?


### What is this change about?

Fixes the build failure [seen here.](https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/windows-cats/builds/938)

### Please provide contextual information.

[Slack discussion
](https://cloudfoundry.slack.com/archives/C02FM2BPE/p1705951427266359)
### What version of cf-deployment have you run this cf-acceptance-test change against?

release-candidate

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

0

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@ameowlia 