### PR TITLE
chore: Remove duplicated cf CLI version output

### DIFF
--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -70,7 +70,10 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	installedVersion, err := GetInstalledCliVersionString()
 
 	Expect(err).ToNot(HaveOccurred(), "Error trying to determine CF CLI version")
+
+	PauseOutputInterception()
 	fmt.Println("Running CATs with CF CLI version ", installedVersion)
+	ResumeOutputInterception()
 
 	Expect(ParseRawCliVersionString(installedVersion).AtLeast(ParseRawCliVersionString(minCliVersion))).To(BeTrue(), "CLI version "+minCliVersion+" is required")
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Stops output interception from also outputting the result of the `fmt.Println` statement.

### Please provide contextual information.

Old output:
```
$ ./bin/test -p
Printing sanitized $CONFIG
...
Running CATs with CF CLI version  cf version 8.7.7+583a09a.2023-12-26
...
[SynchronizedBeforeSuite] PASSED [26.126 seconds]
[SynchronizedBeforeSuite]
/Users/lcarson/workspace/cf-acceptance-tests/cats_suite_test.go:69

  Captured StdOut/StdErr Output >>
  Running CATs with CF CLI version  cf version 8.7.7+583a09a.2023-12-26

  << Captured StdOut/StdErr Output
------------------------------
...
```

### What version of cf-deployment have you run this cf-acceptance-test change against?

v37.0.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None