### PR TITLE
Fix flakiness for readiness health check event test

### DIFF
--- a/apps/readiness_healthcheck.go
+++ b/apps/readiness_healthcheck.go
@@ -51,18 +51,16 @@ var _ = AppsDescribe("Readiness Healthcheck", func() {
 				return helpers.CurlApp(Config, appName, "/ready")
 			}, Config.DefaultTimeoutDuration()).Should(ContainSubstring("200 - ready"))
 
-			Eventually(cf.Cf("events", appName)).Should(Say("app.process.ready"))
-
 			Expect(logs.Recent(appName).Wait()).To(Say("Container passed the readiness health check"))
+
+			Eventually(cf.Cf("events", appName)).Should(Say("app.process.ready"))
 
 			By("triggering the app to make the /ready endpoint fail")
 			helpers.CurlApp(Config, appName, "/ready/false")
 
 			By("verifying the app is marked as not ready")
-
-			Eventually(cf.Cf("events", appName)).Should(Say("app.process.not-ready"))
-
 			Eventually(func() BufferProvider { return logs.Recent(appName).Wait() }, readinessHealthCheckTimeout).Should(Say("Container failed the readiness health check"))
+			Eventually(cf.Cf("events", appName)).Should(Say("app.process.not-ready"))
 
 			By("verifying the app is removed from the routing table")
 			Eventually(func() string {

--- a/windows/readiness_healthcheck.go
+++ b/windows/readiness_healthcheck.go
@@ -52,9 +52,9 @@ var _ = WindowsDescribe("Readiness Healthcheck", func() {
 				return helpers.CurlApp(Config, appName, "/ready")
 			}, Config.DefaultTimeoutDuration()).Should(ContainSubstring("200 - ready"))
 
-			Eventually(cf.Cf("events", appName)).Should(Say("app.process.ready"))
-
 			Expect(logs.Recent(appName).Wait()).To(Say("Container passed the readiness health check"))
+
+			Eventually(cf.Cf("events", appName)).Should(Say("app.process.ready"))
 
 			By("triggering the app to make the /ready endpoint fail")
 			helpers.CurlApp(Config, appName, "/ready/false")


### PR DESCRIPTION


### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._

### What is this change about?
[The new CATs readiness health check test is somewhat flaky](https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/upgrade-cats/builds/937)

### Please provide contextual information.
* Move the check of the cf eve for readiness health checks until AFTER a different check that has a long timeout.
* We should wait to see that the app is marked ready/not-ready BEFORE we test cf events

### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
none!


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
