### PR TITLE
Ensure proxy app uses golang 1.21 for FIPS 140-3 compatiblity

### DIFF
--- a/assets/proxy/internal-route-manifest.yml
+++ b/assets/proxy/internal-route-manifest.yml
@@ -6,5 +6,6 @@ applications:
     buildpack: go_buildpack
     env:
       GOPACKAGENAME: example-apps/proxy
+      GOVERSION: go1.21
     routes:
       - route: app-smoke.apps.internal

--- a/assets/proxy/manifest.yml
+++ b/assets/proxy/manifest.yml
@@ -7,3 +7,4 @@ applications:
     - go_buildpack
     env:
       GOPACKAGENAME: example-apps/proxy
+      GOVERSION: go1.21


### PR DESCRIPTION
### What is this change about?
https://github.com/cloudfoundry/cf-acceptance-tests/issues/1045

### Please provide contextual information.

When running CATS against a CF deployed using a FIPS stemcell the following failiure can be observed:
```
  [FAILED] Timed out after 180.000s.
  Expected
      <string>: request failed: Get "https://cloud-controller-ng.service.cf.internal:9024/v2/info": remote error: tls: internal error
  to match regular expression
      <string>: api_version
  In [It] at: /__w/tas/tas/.test/cats/security_groups/dynamic_asgs.go:149 @ 01/29/24 11:24:09.807
```

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**
