### PR TITLE
fix: Set goversion in app manifests to Go 1.21

### DIFF
--- a/apps/lifecycle.go
+++ b/apps/lifecycle.go
@@ -278,8 +278,7 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 					appName,
 					"-m", DEFAULT_MEMORY_LIMIT)...).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
-				var envOutput string
-				envOutput = helpers.CurlApp(Config, appName, "/env.json")
+				envOutput := helpers.CurlApp(Config, appName, "/env.json")
 				Expect(envOutput).ToNot(BeEmpty())
 				type env struct {
 					Index      string `json:"CF_INSTANCE_INDEX"`
@@ -291,7 +290,7 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 				}
 				var envValues env
 				err := json.Unmarshal([]byte(envOutput), &envValues)
-				fmt.Printf("envValues: %v", envValues)
+				fmt.Fprintf(GinkgoWriter, "envValues: %v", envValues)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(envValues.Index).To(Equal("0"))
 				Expect(envValues.IP).To(MatchRegexp(`[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+`))

--- a/assets/golang/manifest.yml
+++ b/assets/golang/manifest.yml
@@ -2,3 +2,4 @@
 applications:
 - env:
     GOPACKAGENAME: go-online
+    GOVERSION: go1.21

--- a/assets/logging-route-service/main.go
+++ b/assets/logging-route-service/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/tls"
 	"io"
 	"log"
 	"net/http"
@@ -86,9 +85,8 @@ type LoggingRoundTripper struct {
 }
 
 func NewLoggingRoundTripper(skipSslValidation bool) *LoggingRoundTripper {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipSslValidation},
-	}
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSClientConfig.InsecureSkipVerify = skipSslValidation
 	return &LoggingRoundTripper{
 		transport: tr,
 	}

--- a/assets/logging-route-service/manifest.yml
+++ b/assets/logging-route-service/manifest.yml
@@ -3,5 +3,5 @@ applications:
 - buildpacks:
   - go_buildpack
   env:
-    GOVERSION: 1.x
+    GOVERSION: go1.21
     GOPACKAGENAME: github.com/cloudfoundry-samples/logging-route-service

--- a/assets/multi-port-app/README
+++ b/assets/multi-port-app/README
@@ -1,7 +1,7 @@
 # Manual Usage
 
 ```
-cf push multi-port -c 'go-online --ports=7777,8888' --no-route
+cf push multi-port -c 'multi-port-app --ports=7777,8888' --no-route
 cf curl /v2/apps/<APP-GUID> -X PUT -d '{"ports": [7777, 8888]}'
 cf create-route test <TCP-DOMAIN> --random-port
 cf curl /v2/route_mappings -X POST -d '{"app_guid": "<APP-GUID>", "route_guid": "<ROUTE-GUID1>", "app_port": 7777}'

--- a/assets/multi-port-app/go.mod
+++ b/assets/multi-port-app/go.mod
@@ -1,0 +1,3 @@
+module github.com/cloudfoundry/cf-acceptance-tests/assets/multi-port-app
+
+go 1.21

--- a/assets/multi-port-app/manifest.yml
+++ b/assets/multi-port-app/manifest.yml
@@ -1,4 +1,4 @@
 ---
 applications:
 - env:
-    GOPACKAGENAME: go-online
+    GOVERSION: go1.21

--- a/assets/pora/manifest.yml
+++ b/assets/pora/manifest.yml
@@ -5,3 +5,4 @@ applications:
   - go_buildpack
   env:
     GOPACKAGENAME: pora
+    GOVERSION: go1.21

--- a/assets/proxy/internal-route-manifest.yml
+++ b/assets/proxy/internal-route-manifest.yml
@@ -6,5 +6,6 @@ applications:
     buildpack: go_buildpack
     env:
       GOPACKAGENAME: example-apps/proxy
+      GOVERSION: go1.21
     routes:
       - route: app-smoke.apps.internal

--- a/assets/proxy/manifest.yml
+++ b/assets/proxy/manifest.yml
@@ -7,3 +7,4 @@ applications:
     - go_buildpack
     env:
       GOPACKAGENAME: example-apps/proxy
+      GOVERSION: go1.21

--- a/assets/syslog-drain-listener/manifest.yml
+++ b/assets/syslog-drain-listener/manifest.yml
@@ -3,3 +3,4 @@ applications:
 - name: syslog-drain-listener
   env:
     GOPACKAGENAME: main
+    GOVERSION: go1.21

--- a/assets/tcp-listener/manifest.yml
+++ b/assets/tcp-listener/manifest.yml
@@ -2,3 +2,4 @@
 applications:
 - env:
     GOPACKAGENAME: tcp-listener
+    GOVERSION: go1.21

--- a/routing/multiple_app_ports.go
+++ b/routing/multiple_app_ports.go
@@ -26,7 +26,7 @@ var _ = RoutingDescribe("Multiple App Ports", func() {
 
 	BeforeEach(func() {
 		appName = random_name.CATSRandomName("APP")
-		cmd := "go-online --ports=7777,8888,8080"
+		cmd := "multi-port-app --ports=7777,8888,8080"
 
 		Expect(cf.Cf("push",
 			appName,


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Specifying Go version in the assets manifests so that apps are deployed with Go 1.21.

### Please provide contextual information.

None

### What version of cf-deployment have you run this cf-acceptance-test change against?

v33.4.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [X] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@ctlong 
