### PR TITLE
Increase memory limit for "R" buildpack test

### DIFF
--- a/detect/buildpacks.go
+++ b/detect/buildpacks.go
@@ -237,7 +237,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 			Context(fmt.Sprintf("when using %s stack", stack), func() {
 				It("makes the app reachable via its bound route", func() {
 					Expect(cf.Cf("push", appName,
-						"-m", DEFAULT_MEMORY_LIMIT,
+						"-m", "2G",
 						"-p", assets.NewAssets().R,
 						"-s", stack,
 					).Wait(Config.DetectTimeoutDuration())).To(Exit(0))


### PR DESCRIPTION
### What is this change about?

Fix "R" buildpack test. The app needs 2G for staging, lower settings result in "Exit status 223 (out of memory)"

### Please provide contextual information.

Failed build: https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/experimental-cats/builds/935.1

### What version of cf-deployment have you run this cf-acceptance-test change against?

v37.0.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?



### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
