### PR TITLE
fix(detect): Revert R buildpack memory limit

### DIFF
--- a/detect/buildpacks.go
+++ b/detect/buildpacks.go
@@ -237,7 +237,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 			Context(fmt.Sprintf("when using %s stack", stack), func() {
 				It("makes the app reachable via its bound route", func() {
 					Expect(cf.Cf("push", appName,
-						"-m", "2G",
+						"-m", DEFAULT_MEMORY_LIMIT,
 						"-p", assets.NewAssets().R,
 						"-s", stack,
 					).Wait(Config.DetectTimeoutDuration())).To(Exit(0))


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

This reverts commit 8d5e5f417549f2bc433d58cbf3b19602d43109e3.

The root cause is most likely a broken stemcell (kernel update caused increased memory consumption).

### Please provide contextual information.

https://github.com/cloudfoundry/cf-acceptance-tests/pull/1048#issuecomment-1943289724

### What version of cf-deployment have you run this cf-acceptance-test change against?

None

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@jochenehret @stephanme 