### PR TITLE
Add overall test timeout setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,19 @@ To see verbose output from `ginkgo`, use the `-v` flag.
 
 You can of course combine the `-v` flag with the `--procs=N` flag.
 
+##### Overall Test Timeout Setting
+From Ginkgo 2.0, the default timeout for the entire test has been changed to 1 hour (refer to: [Ginkgo 2.0 Migration Guide - Timeout Behavior](https://onsi.github.io/ginkgo/MIGRATING_TO_V2#timeout-behavior)).
+
+Tests may run longer than an hour depending on their environment and parallelism, with the possibility of failure.
+
+Adjust the test timeout as needed with the `--timeout` flag:
+
+```bash
+./bin/test --timeout=24h
+```
+
+For individual timeouts, such as the timeout for `cf push`, refer to [Test Configuration](#test-configuration).
+
 ## Explanation of Test Groups
 
 Test Group Name| Description


### PR DESCRIPTION
### What is this change about?

From Ginkgo 1.0 to 2.0, the default timeout for the entire test changed from `24h` to `1h` (refer to: [Ginkgo 2.0 Migration Guide - Timeout Behavior](https://onsi.github.io/ginkgo/MIGRATING_TO_V2#timeout-behavior)).

Depending on the environment in which the test is run, the execution time of the test may exceed 1h, which may cause the test to fail.

Therefore, I have added an explanation regarding the timeout setting for the entire test.