### PR TITLE
Specify the minimum version of cf cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ in such a way as to impact other tests.
 ### Prerequisites for running CATS
 - Install golang >= `1.21`. Set up your golang development environment, per
   [golang.org](http://golang.org/doc/install).
-- Install the [`cf CLI`](https://github.com/cloudfoundry/cli).
+- Install the [`cf CLI`](https://github.com/cloudfoundry/cli) >= `8.5.0`.
   Make sure that it is accessible in your `$PATH`.
 - Install the `log-cache` plugin with:
 


### PR DESCRIPTION
### What is this change about?

I have documented the minimum version of cf cli defined by [`minCliVersion` in `cats_suite_test.go`](https://github.com/cloudfoundry/cf-acceptance-tests/blob/96df8fb4a2c672b3e39eea4dd0a77db99443c6ef/cats_suite_test.go#L47).