### PR TITLE
Refactor: credhub service broker asset

### DIFF
--- a/assets/credhub-service-broker/config.go
+++ b/assets/credhub-service-broker/config.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"log"
+	"os"
+	"strconv"
+
+	uuid "github.com/satori/go.uuid"
+)
+
+type CredhubConfig struct {
+	API    string
+	Client string
+	Secret string
+}
+
+type Config struct {
+	Port int
+
+	ServiceName string
+	ServiceUUID string
+	PlanUUID    string
+
+	Credhub CredhubConfig
+}
+
+func LoadConfig() Config {
+	cfg := Config{
+		Port:        8080,
+		ServiceName: "credhub-read",
+		ServiceUUID: uuid.NewV4().String(),
+		PlanUUID:    uuid.NewV4().String(),
+		Credhub: CredhubConfig{
+			API:    os.Getenv("CREDHUB_API"),
+			Client: os.Getenv("CREDHUB_CLIENT"),
+			Secret: os.Getenv("CREDHUB_SECRET"),
+		},
+	}
+
+	if portStr, ok := os.LookupEnv("PORT"); ok {
+		port, err := strconv.Atoi(portStr)
+		if err != nil || port < 1 || port > 65535 {
+			log.Panicf("Invalid value for PORT: %q. Please ensure the PORT environment variable is a valid integer between 1 and 65535.", portStr)
+		}
+		cfg.Port = port
+	}
+
+	if serviceName, ok := os.LookupEnv("SERVICE_NAME"); ok {
+		cfg.ServiceName = serviceName
+	}
+
+	if serviceUUID, ok := os.LookupEnv("SERVICE_UUID"); ok {
+		cfg.ServiceUUID = serviceUUID
+	}
+
+	if planUUID, ok := os.LookupEnv("PLAN_UUID"); ok {
+		cfg.PlanUUID = planUUID
+	}
+
+	if cfg.Credhub.API == "" {
+		log.Panicf("Invalid value for CREDHUB_API: %q. Please ensure the CREDHUB_API environment variable is set to a valid url.", cfg.Credhub.API)
+	}
+
+	if cfg.Credhub.Client == "" {
+		log.Panicf("Invalid value for CREDHUB_CLIENT: %q. Please ensure the CREDHUB_CLIENT environment variable is set to a valid CredHub client.", cfg.Credhub.Client)
+	}
+
+	if cfg.Credhub.Secret == "" {
+		log.Panicf("Invalid value for CREDHUB_SECRET: %q. Please ensure the CREDHUB_SECRET environment variable is set to a valid CredHub secret for the provided client.", cfg.Credhub.Secret)
+	}
+
+	return cfg
+}

--- a/assets/credhub-service-broker/config_test.go
+++ b/assets/credhub-service-broker/config_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	os.Setenv("CREDHUB_API", "https://example.com")
+	os.Setenv("CREDHUB_CLIENT", "test-client")
+	os.Setenv("CREDHUB_SECRET", "test-secret")
+
+	tests := []struct {
+		name     string
+		setup    func()
+		teardown func()
+
+		expectPort        int
+		expectServiceName string
+		expectPanic       bool
+	}{
+		{
+			name:              "default",
+			expectPort:        8080,
+			expectServiceName: "credhub-read",
+		},
+		{
+			name: "custom port and service name",
+			setup: func() {
+				os.Setenv("PORT", "9000")
+				os.Setenv("SERVICE_NAME", "my-service")
+			},
+			teardown: func() {
+				os.Unsetenv("PORT")
+			},
+			expectPort:        9000,
+			expectServiceName: "my-service",
+		},
+		{
+			name: "invalid port",
+			setup: func() {
+				os.Setenv("PORT", "invalid")
+			},
+			teardown: func() {
+				os.Unsetenv("PORT")
+			},
+			expectPanic: true,
+		},
+		{
+			name: "credhub api not set",
+			setup: func() {
+				os.Unsetenv("CREDHUB_API")
+			},
+			teardown: func() {
+				os.Setenv("CREDHUB_API", "https://example.com")
+			},
+			expectPanic: true,
+		},
+		{
+			name: "credhub client not set",
+			setup: func() {
+				os.Unsetenv("CREDHUB_CLIENT")
+			},
+			teardown: func() {
+				os.Setenv("CREDHUB_CLIENT", "test-client")
+			},
+			expectPanic: true,
+		},
+		{
+			name: "credhub secret not set",
+			setup: func() {
+				os.Unsetenv("CREDHUB_SECRET")
+			},
+			teardown: func() {
+				os.Setenv("CREDHUB_SECRET", "test-secret")
+			},
+			expectPanic: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setup != nil {
+				tc.setup()
+			}
+			if tc.teardown != nil {
+				defer tc.teardown()
+			}
+
+			if tc.expectPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("LoadConfig() should have panicked")
+					}
+				}()
+			}
+
+			got := LoadConfig()
+			if got.Port != tc.expectPort {
+				t.Errorf("LoadConfig().Port = %d, want %d", got.Port, tc.expectPort)
+			}
+			if got.ServiceName != tc.expectServiceName {
+				t.Errorf("LoadConfig().ServiceName = %s, want %s", got.ServiceName, tc.expectServiceName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Refactors `assets/credhub-service-broker` to use a config struct rather than have various `os.GetEnv` calls & global vars scattered around.

### Please provide contextual information.

None.

### What version of cf-deployment have you run this cf-acceptance-test change against?

None.

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None.