### PR TITLE
Adjust regex for container metrics

### DIFF
--- a/apps/lifecycle.go
+++ b/apps/lifecycle.go
@@ -226,7 +226,7 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 
 			Context("is able to retrieve container metrics", func() {
 				// #0   running   2015-06-10 02:22:39 PM   0.0%   48.7M of 2G   14M of 1G     68B/s of unlimited
-				var metrics = regexp.MustCompile(`running.*(?:[\d\.]+)%\s+([\d\.]+)[KMG]? of (?:[\d\.]+)[KMG]?\s+([\d\.]+)[KMG]? of (?:[\d\.]+)[KMG]?\s+([\d\.]+)[BKMG]?/s of (?:[\d\.]+[BKMG]?/s|unlimited)`)
+				var metrics = regexp.MustCompile(`running.*(?:[\d\.]+)%\s+([\d\.]+)[BKMG]? of (?:[\d\.]+)[BKMG]?\s+([\d\.]+)[BKMG]? of (?:[\d\.]+)[BKMG]?\s+([\d\.]+)[BKMG]?/s of (?:[\d\.]+[BKMG]?/s|unlimited)`)
 				stats := func() (float64, float64, float64) {
 					app := cf.Cf("app", appName)
 					Expect(app.Wait()).To(Exit(0))

--- a/windows/lifecycle.go
+++ b/windows/lifecycle.go
@@ -47,7 +47,7 @@ var _ = WindowsDescribe("Application Lifecycle", func() {
 
 		By("verifying reported usage", func() {
 			// #0   running   2015-06-10 02:22:39 PM   0.0%   48.7M of 2G   14M of 1G     68B/s of unlimited
-			var metrics = regexp.MustCompile(`running.*(?:[\d\.]+)%\s+([\d\.]+)[KMG]? of (?:[\d\.]+)[KMG]?\s+([\d\.]+)[KMG]? of (?:[\d\.]+)[KMG]?\s+([\d\.]+)[BKMG]?/s of (?:[\d\.]+[BKMG]?/s|unlimited)`)
+			var metrics = regexp.MustCompile(`running.*(?:[\d\.]+)%\s+([\d\.]+)[BKMG]? of (?:[\d\.]+)[BKMG]?\s+([\d\.]+)[BKMG]? of (?:[\d\.]+)[BKMG]?\s+([\d\.]+)[BKMG]?/s of (?:[\d\.]+[BKMG]?/s|unlimited)`)
 			stats := func() (float64, float64, float64) {
 				helpers.CurlApp(Config, appName, "/logspew/1024")
 


### PR DESCRIPTION
Adjust regex that "extracts" container metrics from cf-cli output. Memory/disk might be shown as `0B` initially.

Output from a failed CATS run:
```
Regex did not find a match in contents 'Showing health and status for app [...]
[...]
     state     since                  cpu    memory       disk       logging        details
#0   running   2024-04-04T10:35:13Z   0.0%   0B of 256M   0B of 1G   0B/s of 0B/s   
'
```
