### PR TITLE
Correctly print CF CLI version

### DIFF
--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -72,7 +72,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).ToNot(HaveOccurred(), "Error trying to determine CF CLI version")
 
 	PauseOutputInterception()
-	fmt.Println("Running CATs with CF CLI version ", installedVersion)
+	fmt.Fprintf(GinkgoWriter, "Running CATs with CF CLI version %s\n", installedVersion)
 	ResumeOutputInterception()
 
 	Expect(ParseRawCliVersionString(installedVersion).AtLeast(ParseRawCliVersionString(minCliVersion))).To(BeTrue(), "CLI version "+minCliVersion+" is required")


### PR DESCRIPTION

### What is this change about?
STDOUT output of `fmt` is not captured by ginkgo and thus the version is not printed. When using `GinkgoWriter` the message is captured correctly.

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config
-> not  applicable

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

