### PR TITLE
chore: Remove log-cache cf CLI plugin references

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,13 @@ in such a way as to impact other tests.
 ### Prerequisites for running CATS
 - Install golang >= `1.21`. Set up your golang development environment, per
   [golang.org](http://golang.org/doc/install).
-- Install the [`cf CLI`](https://github.com/cloudfoundry/cli) >= `8.5.0`.
-  Make sure that it is accessible in your `$PATH`.
-- Install the `log-cache` plugin with:
-
-  ```bash
-  cf install-plugin -r CF-Community "log-cache"
-  ```
-
+- Install the [`cf CLI`](https://github.com/cloudfoundry/cli) >= `8.5.0`. Make
+  sure that it is accessible in your `$PATH`.
 - Install [curl](http://curl.haxx.se/)
-- Check out a copy of `cf-acceptance-tests`. It uses Go modules, so there is no need to put it in `$GOPATH`.
-
-- Install a running Cloud Foundry deployment
-  to run these acceptance tests against.
-  For example, bosh-lite.
+- Check out a copy of `cf-acceptance-tests`. It uses Go modules, so there is no
+  need to put it in `$GOPATH`.
+- Install a running Cloud Foundry deployment to run these acceptance tests
+  against. For example, bosh-lite.
 
 ### Updating `go` dependencies
 All `go` dependencies required by CATs

--- a/bin/test
+++ b/bin/test
@@ -16,8 +16,6 @@ export CATS_ROOT
 RUN_ID=$(openssl rand -hex 16)
 export RUN_ID
 
-export CF_PLUGIN_HOME=$HOME
-
 pushd "${CATS_ROOT}" > /dev/null
   echo "Using $(go run github.com/onsi/ginkgo/v2/ginkgo version)"
   go run github.com/onsi/ginkgo/v2/ginkgo --randomize-all --keep-going "$@"


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Removes references to the log-cache cf CLI plugin from the README.md, as it has not been a dependency of CATs for several years.

### Please provide contextual information.

f22c80925ae2edb2d92f2d1103cd30e02d928dff.

### What version of cf-deployment have you run this cf-acceptance-test change against?

v40.1.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None