### PR TITLE
Add test for comma delimited ASG destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ include_v3
 * `include_routing_isolation_segments`: Flag to include routing isolation segments tests. [See below](#routing-isolation-segments). Cannot be run together with logging isolation segments tests.
 * `include_security_groups`: Flag to include tests for security groups. [See below](#container-networking-and-application-security-groups)
 * `dynamic_asgs_enabled`: Defaults to `true`. Set to false if dynamic ASGs are disabled in the test environment.
+* `comma_delim_asgs_enabled`: Defaults to `false`. Set to true if comma delimited ASG destinations are enabled in the test environment.
 * `include_services`: Flag to include test for the services API.
 * `include_service_instance_sharing`: Flag to include tests for service instance sharing between spaces. `include_services` must be set for these tests to run. The `service_instance_sharing` feature flag must also be enabled for these tests to pass.
 * `include_ssh`: Flag to include tests for Diego container ssh feature.

--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -189,6 +189,17 @@ func SecurityGroupsDescribe(description string, callback func()) bool {
 	})
 }
 
+func CommaDelimitedSecurityGroupsDescribe(description string, callback func()) bool {
+	return Describe("[comma_delimited_security_groups]", func() {
+		BeforeEach(func() {
+			if !Config.GetCommaDelimitedASGsEnabled() {
+				Skip(skip_messages.SkipCommaDelimitedSecurityGroupsMessage)
+			}
+		})
+		Describe(description, callback)
+	})
+}
+
 func ServiceDiscoveryDescribe(description string, callback func()) bool {
 	return Describe("[service discovery]", func() {
 		BeforeEach(func() {

--- a/example-cats-config.json
+++ b/example-cats-config.json
@@ -13,6 +13,7 @@ IN DEVELOPMENT
   "use_http": true,
   "include_app_syslog_tcp": true,
   "include_apps": true,
+  "comma_delim_asgs_enabled": false,
   "dynamic_asgs_enabled": true,
   "readiness_health_check_enabled": true,
   "include_container_networking": true,

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -78,6 +78,7 @@ type CatsConfig interface {
 	GetUnallocatedIPForSecurityGroup() string
 	GetRequireProxiedAppTraffic() bool
 	GetDynamicASGsEnabled() bool
+	GetCommaDelimitedASGsEnabled() bool
 	GetReadinessHealthChecksEnabled() bool
 	Protocol() string
 

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -112,6 +112,7 @@ type config struct {
 	RequireProxiedAppTraffic      *bool   `json:"require_proxied_app_traffic"`
 
 	DynamicASGsEnabled           *bool `json:"dynamic_asgs_enabled"`
+	CommaDelimitedASGsEnabled    *bool `json:"comma_delim_asgs_enabled"`
 	ReadinessHealthChecksEnabled *bool `json:"readiness_health_checks_enabled"`
 
 	NamePrefix *string `json:"name_prefix"`
@@ -229,6 +230,7 @@ func getDefaults() config {
 	defaults.RequireProxiedAppTraffic = ptrToBool(false)
 
 	defaults.DynamicASGsEnabled = ptrToBool(true)
+	defaults.CommaDelimitedASGsEnabled = ptrToBool(true)
 	defaults.ReadinessHealthChecksEnabled = ptrToBool(true)
 
 	defaults.NamePrefix = ptrToString("CATS")
@@ -931,6 +933,10 @@ func (c *config) GetIncludeSecurityGroups() bool {
 
 func (c *config) GetDynamicASGsEnabled() bool {
 	return *c.DynamicASGsEnabled
+}
+
+func (c *config) GetCommaDelimitedASGsEnabled() bool {
+	return *c.CommaDelimitedASGsEnabled
 }
 
 func (c *config) GetReadinessHealthChecksEnabled() bool {

--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -25,6 +25,8 @@ const SkipHTTP2RoutingMessage = `Skipping this test because config.IncludeHTTP2R
 const SkipTCPRoutingMessage = `Skipping this test because config.IncludeTCPRouting is set to 'false'.`
 const SkipSecurityGroupsMessage = `Skipping this test because config.IncludeSecurityGroups is set to 'false'.
 NOTE: Ensure that your platform restricts internal network traffic by default in order to run this test.`
+const SkipCommaDelimitedSecurityGroupsMessage = `Skipping this test because config.CommaDelimitedASGsEnabled is set to 'false'.
+NOTE: Ensure that your platform restricts internal network traffic by default in order to run this test.`
 const SkipServicesMessage = `Skipping this test because config.IncludeServices is set to 'false'.`
 const SkipUserProvidedServicesMessage = `Skipping this test because config.IncludeUserProvidedServices is set to 'false'.`
 const SkipSSHMessage = `Skipping this test because config.IncludeSsh is set to 'false'.

--- a/security_groups/comma_delmited_asgs.go
+++ b/security_groups/comma_delmited_asgs.go
@@ -1,0 +1,94 @@
+package security_groups_test
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
+)
+
+var _ = CommaDelimitedSecurityGroupsDescribe("Comma Delimited ASGs", func() {
+	var (
+		orgName           string
+		spaceName         string
+		appName           string
+		securityGroupName string
+	)
+
+	BeforeEach(func() {
+		orgName = TestSetup.RegularUserContext().Org
+		spaceName = TestSetup.RegularUserContext().Space
+		appName = random_name.CATSRandomName("APP")
+
+		By("pushing a proxy app")
+		Expect(cf.Cf(
+			"push", appName,
+			"-b", Config.GetGoBuildpackName(),
+			"-p", assets.NewAssets().Proxy,
+			"-f", assets.NewAssets().Proxy+"/manifest.yml",
+		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+	})
+
+	AfterEach(func() {
+		Expect(cf.Cf("delete", appName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+		deleteSecurityGroup(securityGroupName)
+	})
+
+	It("manages whether apps can reach certain IP addresses per ASG configuration with commas", func() {
+		proxyRequestURL := fmt.Sprintf("%s%s.%s/https_proxy/cloud-controller-ng.service.cf.internal:9024/v2/info", Config.Protocol(), appName, Config.GetAppsDomain())
+
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: Config.GetSkipSSLValidation(),
+				},
+			},
+		}
+
+		By("checking that our app can't initially reach cloud controller over internal address")
+		assertAppCannotConnect(client, proxyRequestURL)
+
+		By("binding a new security group with commas")
+		securityGroupName = bindCCSecurityGroupWithCommas(orgName, spaceName)
+
+		if Config.GetDynamicASGsEnabled() {
+			By("checking that our app can eventually reach cloud controller over internal address")
+			assertEventuallyAppCanConnect(client, proxyRequestURL)
+		} else {
+			By("because dynamic asgs are not enabled, validating an app restart is required")
+			assertAppRestartRequiredForConnect(client, proxyRequestURL, appName)
+		}
+
+		By("unbinding the security group")
+		unbindSecurityGroup(securityGroupName, orgName, spaceName)
+
+		if Config.GetDynamicASGsEnabled() {
+			By("checking that our app eventually cannot reach cloud controller over internal address")
+			assertEventuallyAppCannotConnect(client, proxyRequestURL)
+		} else {
+			By("because dynamic asgs are not enabled, validating an app restart is required")
+			assertAppRestartRequiredForDisconnect(client, proxyRequestURL, appName)
+		}
+	})
+})
+
+func bindCCSecurityGroupWithCommas(orgName, spaceName string) string {
+	destinations := []Destination{{
+		IP:       "10.0.0.0/8,192.168.0.0/16,172.16.0.0/12",
+		Ports:    "9024", // internal cc port
+		Protocol: "tcp",
+	}}
+	securityGroupName := createSecurityGroup(destinations...)
+	bindSecurityGroup(securityGroupName, orgName, spaceName)
+
+	return securityGroupName
+}


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

✅

### What is this change about?

Adds a test to validate that ASGs with comma delimited destinations function, when configured to do so.

### Please provide contextual information.

CAPI must be configured to enable this and it is off by default, so the test is also off by default.

### What version of cf-deployment have you run this cf-acceptance-test change against?

Latest.

### Please check all that apply for this PR:

- [x] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

The functionality requires a combination of CAPI, Diego, cf-networking, and silk to function. This is an integration test across across all the components.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

60-200? The time taken to push an app and validate ASG changes to it. 

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
