### PR TITLE
fix: Delete service brokers after tests

### DIFF
--- a/credhub/service_bindings.go
+++ b/credhub/service_bindings.go
@@ -98,6 +98,7 @@ var _ = CredhubDescribe("service bindings", func() {
 
 			Expect(cf.Cf("purge-service-instance", instanceName, "-f").Wait()).To(Exit(0))
 			Expect(cf.Cf("delete-service-broker", chBrokerAppName, "-f").Wait()).To(Exit(0))
+			Expect(cf.Cf("delete", chBrokerAppName, "-f", "-r").Wait()).To(Exit(0))
 		})
 	})
 

--- a/credhub/service_keys.go
+++ b/credhub/service_keys.go
@@ -85,6 +85,7 @@ var _ = CredhubDescribe("service keys", func() {
 			Expect(cf.Cf("delete-service-key", instanceName, serviceKeyName, "-f").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 			Expect(cf.Cf("purge-service-instance", instanceName, "-f").Wait()).To(Exit(0))
 			Expect(cf.Cf("delete-service-broker", chBrokerAppName, "-f").Wait()).To(Exit(0))
+			Expect(cf.Cf("delete", chBrokerAppName, "-f", "-r").Wait()).To(Exit(0))
 		})
 	})
 

--- a/docker/credhub_enabled.go
+++ b/docker/credhub_enabled.go
@@ -85,6 +85,7 @@ var _ = DockerDescribe("Docker App Lifecycle CredHub Integration", func() {
 				Expect(cf.Cf("delete-service", instanceName, "-f").Wait()).To(Exit(0))
 				Expect(cf.Cf("purge-service-offering", chServiceName, "-f").Wait()).To(Exit(0))
 				Expect(cf.Cf("delete-service-broker", chBrokerName, "-f").Wait()).To(Exit(0))
+				Expect(cf.Cf("delete", chBrokerName, "-f", "-r").Wait()).To(Exit(0))
 			})
 		})
 

--- a/route_services/route_services.go
+++ b/route_services/route_services.go
@@ -273,8 +273,8 @@ func createServiceBroker(brokerName, brokerAppName, serviceName string) {
 
 func deleteServiceBroker(brokerName string) {
 	workflowhelpers.AsUser(TestSetup.AdminUserContext(), TestSetup.ShortTimeout(), func() {
-		responseBuffer := cf.Cf("delete-service-broker", brokerName, "-f")
-		Expect(responseBuffer.Wait()).To(Exit(0))
+		Expect(cf.Cf("delete-service-broker", brokerName, "-f").Wait()).To(Exit(0))
+		Expect(cf.Cf("delete", brokerName, "-f", "-r").Wait()).To(Exit(0))
 	})
 }
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Fixes an inconsistency in the credhub, docker, and route_services test suites (vs other suites) where apps were not get deleted after tests. Specifically, some service brokers that were pushed as apps were not getting deleted, only unregistered as service brokers.

I ran through some of the steps manually and saw that the delete-service-broker command did not also delete the service broker app.

### Please provide contextual information.

Spot-checking the credhub suite, I couldn't find any reasons in git or tracker stories for the delete command to not to be originally included. Possibly, it was believed that the delete-service-broker command would delete the app...

### What version of cf-deployment have you run this cf-acceptance-test change against?

v33.4.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

About the same.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None