### PR TITLE
[Issue 1173] In "SendAndReceive", wait 100ms before reading

### DIFF
--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -415,7 +415,7 @@ func SendAndReceive(addr string, externalPort string) (string, error) {
 	}
 
 	// see https://github.com/cloudfoundry/cf-acceptance-tests/issues/1173
-	time.Sleep(2 * time.Second)
+	time.Sleep(100 * time.Millisecond)
 
 	buff := make([]byte, 1024)
 	_, err = conn.Read(buff)

--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -414,6 +414,9 @@ func SendAndReceive(addr string, externalPort string) (string, error) {
 		return "", err
 	}
 
+	// see https://github.com/cloudfoundry/cf-acceptance-tests/issues/1173
+	time.Sleep(2 * time.Second)
+
 	buff := make([]byte, 1024)
 	_, err = conn.Read(buff)
 	if err != nil {


### PR DESCRIPTION
### What is this change about?

Prevents race condition when sending a test message to a backend and reading the response.

### Please provide contextual information.

https://github.com/cloudfoundry/cf-acceptance-tests/issues/1173

### What version of cf-deployment have you run this cf-acceptance-test change against?

v41.0.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Function is called 7 times -> 700ms.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
