### PR TITLE
Bump to go1.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ in such a way as to impact other tests.
 
 ## Test Setup
 ### Prerequisites for running CATS
-- Install golang >= `1.21`. Set up your golang development environment, per
+- Install golang >= `1.22`. Set up your golang development environment, per
   [golang.org](http://golang.org/doc/install).
 - Install the [`cf CLI`](https://github.com/cloudfoundry/cli) >= `8.5.0`. Make
   sure that it is accessible in your `$PATH`.
@@ -53,7 +53,7 @@ in such a way as to impact other tests.
 All `go` dependencies required by CATs
 are vendored in the `vendor` directory.
 
-Make sure to have Golang 1.21+
+Make sure to have Golang 1.22+
 
 In order to update a current dependency to a specific version,
 do the following:

--- a/assets/binary/go.mod
+++ b/assets/binary/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/binary
 
-go 1.21
+go 1.22.0

--- a/assets/catnip/go.mod
+++ b/assets/catnip/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/catnip
 
-go 1.21
+go 1.22.0
 
 require (
 	code.cloudfoundry.org/clock v1.2.0

--- a/assets/credhub-service-broker/go.mod
+++ b/assets/credhub-service-broker/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/credhub-service-broker
 
-go 1.21
+go 1.22.0
 
 require (
 	code.cloudfoundry.org/credhub-cli v0.0.0-20230320130818-a7d5420b283b

--- a/assets/go_calls_ruby/go.mod
+++ b/assets/go_calls_ruby/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/go_calls_ruby
 
-go 1.21
+go 1.22.0

--- a/assets/golang/go.mod
+++ b/assets/golang/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/golang
 
-go 1.21
+go 1.22.0

--- a/assets/golang/manifest.yml
+++ b/assets/golang/manifest.yml
@@ -1,5 +1,5 @@
 ---
 applications:
-- env:
-    GOPACKAGENAME: go-online
-    GOVERSION: go1.21
+  - env:
+      GOPACKAGENAME: go-online
+      GOVERSION: go1.22

--- a/assets/grpc/go.mod
+++ b/assets/grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/grpc
 
-go 1.21
+go 1.22.0
 
 require (
 	google.golang.org/grpc v1.65.0

--- a/assets/http2/go.mod
+++ b/assets/http2/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/http2
 
-go 1.21
+go 1.22.0
 
 require golang.org/x/net v0.27.0
 

--- a/assets/logging-route-service/go.mod
+++ b/assets/logging-route-service/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry-samples/logging-route-service
 
-go 1.21
+go 1.22.0

--- a/assets/logging-route-service/manifest.yml
+++ b/assets/logging-route-service/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
-- buildpacks:
-  - go_buildpack
-  env:
-    GOVERSION: go1.21
-    GOPACKAGENAME: github.com/cloudfoundry-samples/logging-route-service
+  - buildpacks:
+      - go_buildpack
+    env:
+      GOVERSION: go1.22
+      GOPACKAGENAME: github.com/cloudfoundry-samples/logging-route-service

--- a/assets/multi-port-app/go.mod
+++ b/assets/multi-port-app/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/multi-port-app
 
-go 1.21
+go 1.22.0

--- a/assets/multi-port-app/manifest.yml
+++ b/assets/multi-port-app/manifest.yml
@@ -1,4 +1,4 @@
 ---
 applications:
-- env:
-    GOVERSION: go1.21
+  - env:
+      GOVERSION: go1.22

--- a/assets/pora/go.mod
+++ b/assets/pora/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/pora
 
-go 1.21
+go 1.22.0

--- a/assets/pora/manifest.yml
+++ b/assets/pora/manifest.yml
@@ -1,8 +1,8 @@
 ---
 applications:
-- name: pora
-  buildpacks:
-  - go_buildpack
-  env:
-    GOPACKAGENAME: pora
-    GOVERSION: go1.21
+  - name: pora
+    buildpacks:
+      - go_buildpack
+    env:
+      GOPACKAGENAME: pora
+      GOVERSION: go1.22

--- a/assets/proxy/go.mod
+++ b/assets/proxy/go.mod
@@ -1,3 +1,3 @@
 module example-apps/proxy
 
-go 1.21
+go 1.22.0

--- a/assets/proxy/internal-route-manifest.yml
+++ b/assets/proxy/internal-route-manifest.yml
@@ -6,6 +6,6 @@ applications:
     buildpack: go_buildpack
     env:
       GOPACKAGENAME: example-apps/proxy
-      GOVERSION: go1.21
+      GOVERSION: go1.22
     routes:
       - route: app-smoke.apps.internal

--- a/assets/proxy/manifest.yml
+++ b/assets/proxy/manifest.yml
@@ -4,7 +4,7 @@ applications:
     memory: 32M
     disk_quota: 32M
     buildpacks:
-    - go_buildpack
+      - go_buildpack
     env:
       GOPACKAGENAME: example-apps/proxy
-      GOVERSION: go1.21
+      GOVERSION: go1.22

--- a/assets/syslog-drain-listener/go.mod
+++ b/assets/syslog-drain-listener/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/syslog-drain-listener
 
-go 1.21
+go 1.22.0
 
 require code.cloudfoundry.org/tlsconfig v0.0.0-20220621140725-0e6fbd869921

--- a/assets/syslog-drain-listener/manifest.yml
+++ b/assets/syslog-drain-listener/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: syslog-drain-listener
-  env:
-    GOPACKAGENAME: main
-    GOVERSION: go1.21
+  - name: syslog-drain-listener
+    env:
+      GOPACKAGENAME: main
+      GOVERSION: go1.22

--- a/assets/tcp-listener/go.mod
+++ b/assets/tcp-listener/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/tcp-listener
 
-go 1.21
+go 1.22.0

--- a/assets/tcp-listener/manifest.yml
+++ b/assets/tcp-listener/manifest.yml
@@ -1,5 +1,5 @@
 ---
 applications:
-- env:
-    GOPACKAGENAME: tcp-listener
-    GOVERSION: go1.21
+  - env:
+      GOPACKAGENAME: tcp-listener
+      GOVERSION: go1.22

--- a/assets/worker/go.mod
+++ b/assets/worker/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/worker
 
-go 1.21
+go 1.22.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests
 
-go 1.21
+go 1.22.0
 
 require (
 	code.cloudfoundry.org/archiver v0.0.0-20230220125704-e06c77649d28


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

* Bump the min Go version required by this module to go1.22.0.
* Bump the min Go version required by Go assets to go1.22.0.
* Bump the Go version specified in Go asset manifests to go1.22.

### Please provide contextual information.

None

### What version of cf-deployment have you run this cf-acceptance-test change against?

None

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None