### PR TITLE
Use 1.22 as the go directive instead of 1.22.0

### DIFF
--- a/assets/binary/go.mod
+++ b/assets/binary/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/binary
 
-go 1.22.0
+go 1.22

--- a/assets/catnip/go.mod
+++ b/assets/catnip/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/catnip
 
-go 1.22.0
+go 1.22
 
 require (
 	code.cloudfoundry.org/clock v1.2.0

--- a/assets/credhub-service-broker/go.mod
+++ b/assets/credhub-service-broker/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/credhub-service-broker
 
-go 1.22.0
+go 1.22
 
 require (
 	code.cloudfoundry.org/credhub-cli v0.0.0-20230320130818-a7d5420b283b

--- a/assets/go_calls_ruby/go.mod
+++ b/assets/go_calls_ruby/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/go_calls_ruby
 
-go 1.22.0
+go 1.22

--- a/assets/golang/go.mod
+++ b/assets/golang/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/golang
 
-go 1.22.0
+go 1.22

--- a/assets/grpc/go.mod
+++ b/assets/grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/grpc
 
-go 1.22.0
+go 1.22
 
 require (
 	google.golang.org/grpc v1.65.0

--- a/assets/http2/go.mod
+++ b/assets/http2/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/http2
 
-go 1.22.0
+go 1.22
 
 require golang.org/x/net v0.28.0
 

--- a/assets/logging-route-service/go.mod
+++ b/assets/logging-route-service/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry-samples/logging-route-service
 
-go 1.22.0
+go 1.22

--- a/assets/multi-port-app/go.mod
+++ b/assets/multi-port-app/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/multi-port-app
 
-go 1.22.0
+go 1.22

--- a/assets/pora/go.mod
+++ b/assets/pora/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/pora
 
-go 1.22.0
+go 1.22

--- a/assets/proxy/go.mod
+++ b/assets/proxy/go.mod
@@ -1,3 +1,3 @@
 module example-apps/proxy
 
-go 1.22.0
+go 1.22

--- a/assets/syslog-drain-listener/go.mod
+++ b/assets/syslog-drain-listener/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/syslog-drain-listener
 
-go 1.22.0
+go 1.22
 
 require code.cloudfoundry.org/tlsconfig v0.0.0-20220621140725-0e6fbd869921

--- a/assets/tcp-listener/go.mod
+++ b/assets/tcp-listener/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/tcp-listener
 
-go 1.22.0
+go 1.22

--- a/assets/worker/go.mod
+++ b/assets/worker/go.mod
@@ -1,3 +1,3 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/worker
 
-go 1.22.0
+go 1.22

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests
 
-go 1.22.0
+go 1.22
 
 require (
 	code.cloudfoundry.org/archiver v0.0.0-20230220125704-e06c77649d28


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Updates assets and base go.mod to use 1.22 as the go directive instead of 1.22.0. Some tooling in buildpacks depends upon the go directive being only in <major>.<minor> format. And it seems like the base go.mod should match.

### Please provide contextual information.

https://github.com/cloudfoundry/cf-acceptance-tests/commit/043a63ff66b5a67c36a14876edf9095d74b62783#commitcomment-145272348

### What version of cf-deployment have you run this cf-acceptance-test change against?

None

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None