### PR TITLE
Set go toolchain explicitly

### DIFF
--- a/assets/binary/go.mod
+++ b/assets/binary/go.mod
@@ -1,3 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/binary
 
 go 1.22
+
+toolchain go1.22.0

--- a/assets/catnip/go.mod
+++ b/assets/catnip/go.mod
@@ -2,6 +2,8 @@ module github.com/cloudfoundry/cf-acceptance-tests/assets/catnip
 
 go 1.22
 
+toolchain go1.22.0
+
 require (
 	code.cloudfoundry.org/clock v1.2.0
 	github.com/go-chi/chi/v5 v5.1.0

--- a/assets/credhub-service-broker/go.mod
+++ b/assets/credhub-service-broker/go.mod
@@ -2,6 +2,8 @@ module github.com/cloudfoundry/cf-acceptance-tests/assets/credhub-service-broker
 
 go 1.22
 
+toolchain go1.22.0
+
 require (
 	code.cloudfoundry.org/credhub-cli v0.0.0-20230320130818-a7d5420b283b
 	github.com/go-chi/chi/v5 v5.1.0

--- a/assets/go_calls_ruby/go.mod
+++ b/assets/go_calls_ruby/go.mod
@@ -1,3 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/go_calls_ruby
 
 go 1.22
+
+toolchain go1.22.0

--- a/assets/golang/go.mod
+++ b/assets/golang/go.mod
@@ -1,3 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/golang
 
 go 1.22
+
+toolchain go1.22.0

--- a/assets/grpc/go.mod
+++ b/assets/grpc/go.mod
@@ -2,6 +2,8 @@ module github.com/cloudfoundry/cf-acceptance-tests/assets/grpc
 
 go 1.22
 
+toolchain go1.22.0
+
 require (
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2

--- a/assets/http2/go.mod
+++ b/assets/http2/go.mod
@@ -2,6 +2,8 @@ module github.com/cloudfoundry/cf-acceptance-tests/assets/http2
 
 go 1.22
 
+toolchain go1.22.0
+
 require golang.org/x/net v0.28.0
 
 require golang.org/x/text v0.17.0 // indirect

--- a/assets/logging-route-service/go.mod
+++ b/assets/logging-route-service/go.mod
@@ -1,3 +1,5 @@
 module github.com/cloudfoundry-samples/logging-route-service
 
 go 1.22
+
+toolchain go1.22.0

--- a/assets/multi-port-app/go.mod
+++ b/assets/multi-port-app/go.mod
@@ -1,3 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/multi-port-app
 
 go 1.22
+
+toolchain go1.22.0

--- a/assets/pora/go.mod
+++ b/assets/pora/go.mod
@@ -1,3 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/pora
 
 go 1.22
+
+toolchain go1.22.0

--- a/assets/proxy/go.mod
+++ b/assets/proxy/go.mod
@@ -1,3 +1,5 @@
 module example-apps/proxy
 
 go 1.22
+
+toolchain go1.22.0

--- a/assets/syslog-drain-listener/go.mod
+++ b/assets/syslog-drain-listener/go.mod
@@ -2,4 +2,6 @@ module github.com/cloudfoundry/cf-acceptance-tests/assets/syslog-drain-listener
 
 go 1.22
 
+toolchain go1.22.0
+
 require code.cloudfoundry.org/tlsconfig v0.1.0

--- a/assets/tcp-listener/go.mod
+++ b/assets/tcp-listener/go.mod
@@ -1,3 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/tcp-listener
 
 go 1.22
+
+toolchain go1.22.0

--- a/assets/worker/go.mod
+++ b/assets/worker/go.mod
@@ -1,3 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/worker
 
 go 1.22
+
+toolchain go1.22.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/cloudfoundry/cf-acceptance-tests
 
 go 1.22
 
+toolchain go1.22.0
+
 require (
 	code.cloudfoundry.org/archiver v0.0.0-20230220125704-e06c77649d28
 	code.cloudfoundry.org/go-log-cache/v3 v3.0.2


### PR DESCRIPTION
### What is this change about?

It seems like theres an issue with using `go 1.22.0` with buildpacks as per this commit https://github.com/cloudfoundry/cf-acceptance-tests/commit/a0e5ea36d59c6d7ba56767391ab05bcabe2ca81b .However, the directive `go 1.22` this is not a valid toolchain and so builind the app will result in
```
$ pwd
/Users/sgunaratne/workspace/cf-acceptance-tests/assets/worker
$ go mod tidy
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available
```

This adds the toolchain explicitly so work around this issue.

```
$ git diff go.mod
diff --git a/assets/worker/go.mod b/assets/worker/go.mod
index d1180cc5..d3a08650 100644
--- a/assets/worker/go.mod
+++ b/assets/worker/go.mod
@@ -1,3 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/worker

 go 1.22
+
+toolchain go1.22.0
$ go mod tidy
$ echo $?
0
```

See https://github.com/golang/go/issues/62278#issuecomment-1693538776 for more context on why this is required in more recent go versions.

This is failing in the cf-cli pipeline https://github.com/cloudfoundry/cli/actions/runs/10423472162/job/28875001824?pr=3113
```
     2024-08-16T20:01:58.74+0000 [STG/0] OUT **WARNING** go 1.21.x will no longer be available in new buildpacks released after 2024-08-15.
     2024-08-16T20:01:58.74+0000 [STG/0] OUT See: https://golang.org/doc/devel/release.html
     2024-08-16T20:02:03.66+0000 [STG/0] OUT **ERROR** problem retrieving main package name: go: downloading go1.22 (linux/amd64)
     2024-08-16T20:02:03.66+0000 [STG/0] OUT go: download go1.22 for linux/amd64: toolchain not available
     2024-08-16T20:02:03.66+0000 [STG/0] OUT 
     2024-08-16T20:02:03.66+0000 [STG/0] OUT **ERROR** Unable to determine import path: exit status 1
     2024-08-16T20:02:04.48+0000 [STG/0] ERR Failed to compile droplet: Failed to run finalize script: exit status 12
```

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
