### PR TITLE
Improve TCP Route Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ include_app_syslog_tcp
 * `include_sso`: Flag to include the services tests that integrate with Single Sign On. `include_services` must also be set for tests to run.
 * `include_tasks`: Flag to include the v3 task tests. `include_v3` must also be set for tests to run. The CC API task_creation feature flag must be enabled for these tests to pass.
 * `include_tcp_routing`: Flag to include the TCP Routing tests. These tests are equivalent to the [TCP Routing tests](https://github.com/cloudfoundry/routing-acceptance-tests/blob/master/tcp_routing/tcp_routing_test.go) from the Routing Acceptance Tests.
+* `tcp_domain`: Domain that will be used for apps with TCP routes
 * `include_user_provided_services`: Flag to include test for user-provided services.
 * `include_v3`: Flag to include tests for the v3 API.
 * `include_zipkin`: Flag to include tests for Zipkin tracing. `include_routing` must also be set for tests to run. CF must be deployed with `router.tracing.enable_zipkin` set for tests to pass.
@@ -156,6 +157,8 @@ include_app_syslog_tcp
 * `timeout_scale`: Used primarily to scale default timeouts for test setup and teardown actions (e.g. creating an org) as opposed to main test actions (e.g. pushing an app).
 * `isolation_segment_name`: Name of the isolation segment to use for the isolation segments test.
 * `isolation_segment_domain`: Domain that will route to the isolated router in the isolation segments and routing isolation segments tests. [See below](#routing-isolation-segments)
+* `include_tcp_isolation_segments`: Flag to include the TCP Routing tests on Isolation Segments. These tests are equivalent to the [TCP Routing tests](https://github.com/cloudfoundry/routing-acceptance-tests/blob/master/tcp_routing/tcp_routing_test.go) from the Routing Acceptance Tests.
+* `isolation_segment_tcp_domain`: Domain that will be used for isolated apps with TCP routes
 * `private_docker_registry_image`: Name of the private docker image to use when testing private docker registries. [See below](#private-docker)
 * `private_docker_registry_username`: Username to access the private docker repository. [See below](#private-docker)
 * `private_docker_registry_password`: Password to access the private docker repository. [See below](#private-docker)

--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -1,6 +1,7 @@
 package cats_suite_helpers
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"regexp"
@@ -56,7 +57,7 @@ func AppsDescribe(description string, callback func()) bool {
 func IsolatedTCPRoutingDescribe(description string, callback func()) bool {
 	return Describe("[isolated tcp routing]", func() {
 		BeforeEach(func() {
-			if Config.GetIncludeRoutingIsolationSegments() || !Config.GetIncludeTCPIsolationSegments() {
+			if !Config.GetIncludeTCPIsolationSegments() {
 				Skip(skip_messages.SkipIsolatedTCPRoutingMessage)
 			}
 		})
@@ -377,6 +378,17 @@ func WindowsDescribe(description string, callback func()) bool {
 	})
 }
 
+func WindowsTCPRoutingDescribe(description string, callback func()) bool {
+	return Describe("[windows routing]", func() {
+		BeforeEach(func() {
+			if !Config.GetIncludeTCPRouting() || !Config.GetIncludeWindows() {
+				Skip(skip_messages.SkipTCPRoutingMessage)
+			}
+		})
+		Describe(description, callback)
+	})
+}
+
 func VolumeServicesDescribe(description string, callback func()) bool {
 	return Describe("[volume_services]", func() {
 		BeforeEach(func() {
@@ -451,5 +463,12 @@ func SendAndReceive(addr string, externalPort string) (string, error) {
 		return "", err
 	}
 
-	return string(buff), nil
+	// only grab up to the first null byte of a message since we have a predefined slice length that may not be full
+	i := len(buff)
+
+	if j := bytes.IndexByte(buff, 0); j > 0 {
+		i = j
+	}
+
+	return string(buff[:i]), nil
 }

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -47,6 +47,7 @@ type CatsConfig interface {
 	GetAdminClientSecret() string
 	GetApiEndpoint() string
 	GetAppsDomain() string
+	GetTCPDomain() string
 	GetArtifactsDirectory() string
 	GetBinaryBuildpackName() string
 	GetStaticFileBuildpackName() string
@@ -67,6 +68,7 @@ type CatsConfig interface {
 	GetHwcBuildpackName() string
 	GetIsolationSegmentName() string
 	GetIsolationSegmentDomain() string
+	GetIsolationSegmentTCPDomain() string
 	GetJavaBuildpackName() string
 	GetNamePrefix() string
 	GetNginxBuildpackName() string

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -19,6 +19,7 @@ const (
 type config struct {
 	ApiEndpoint *string `json:"api"`
 	AppsDomain  *string `json:"apps_domain"`
+	TCPDomain   *string `json:"tcp_domain"`
 	UseHttp     *bool   `json:"use_http"`
 
 	AdminPassword *string `json:"admin_password"`
@@ -34,8 +35,9 @@ type config struct {
 
 	ConfigurableTestPassword *string `json:"test_password"`
 
-	IsolationSegmentName   *string `json:"isolation_segment_name"`
-	IsolationSegmentDomain *string `json:"isolation_segment_domain"`
+	IsolationSegmentName      *string `json:"isolation_segment_name"`
+	IsolationSegmentDomain    *string `json:"isolation_segment_domain"`
+	IsolationSegmentTCPDomain *string `json:"isolation_segment_tcp_domain"`
 
 	SkipSSLValidation *bool `json:"skip_ssl_validation"`
 
@@ -811,6 +813,14 @@ func (c *config) GetAppsDomain() string {
 	return *c.AppsDomain
 }
 
+func (c *config) GetTCPDomain() string {
+	if c.TCPDomain == nil || *c.TCPDomain == "" {
+		return fmt.Sprintf("tcp.%s", *c.AppsDomain)
+	}
+
+	return *c.TCPDomain
+}
+
 func (c *config) GetSkipSSLValidation() bool {
 	return *c.SkipSSLValidation
 }
@@ -825,6 +835,10 @@ func (c *config) GetIsolationSegmentName() string {
 
 func (c *config) GetIsolationSegmentDomain() string {
 	return *c.IsolationSegmentDomain
+}
+
+func (c *config) GetIsolationSegmentTCPDomain() string {
+	return *c.IsolationSegmentTCPDomain
 }
 
 func (c *config) GetNamePrefix() string {

--- a/isolation_segments/isolation_segments.go
+++ b/isolation_segments/isolation_segments.go
@@ -241,7 +241,7 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 		var domainName string
 
 		BeforeEach(func() {
-			domainName = fmt.Sprintf("tcp.%s", isoSegDomain)
+			domainName = Config.GetIsolationSegmentTCPDomain()
 			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
 				v3_helpers.EntitleOrgToIsolationSegment(orgGuid, isoSegGuid)
 				session := cf.Cf("curl", fmt.Sprintf("/v3/spaces?names=%s", spaceName))
@@ -346,10 +346,13 @@ var _ = IsolationSegmentsDescribe("IsolationSegments", func() {
 				})
 
 				It("maps single external port to both applications", func() {
-					serverResponses, err := GetNServerResponses(10, domainName, externalPort1)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(serverResponses).To(ContainElement(ContainSubstring(serverId1)))
-					Expect(serverResponses).To(ContainElement(ContainSubstring(serverId2)))
+					getServerResponses := func() []string {
+						serverResponses, err := GetNServerResponses(10, domainName, externalPort1)
+						Expect(err).ToNot(HaveOccurred())
+						return serverResponses
+					}
+					Eventually(getServerResponses, 30).Should(ContainElement(ContainSubstring(serverId1)))
+					Eventually(getServerResponses, 30).Should(ContainElement(ContainSubstring(serverId2)))
 				})
 			})
 


### PR DESCRIPTION

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

- Make it easier to configure TCP route testing by separating the TCP domains from the apps domain.
- Make it possible to run isolation_segment_routing tests alongside isolation_segment_tcp_routing tests
- Add TCP routing tests for windows
- Improve the output returned by SendAndReceive so that text fits in gomega/ginkgo string length constraints

### Please provide contextual information.

We discovered issues with tcp routes on cross-deployment scenarios where links weren't properly being configured, and this slipped through testing because of strange nuances to how isolation segment + tcp routes work. Additionally there were no windows tcp route tests

### What version of cf-deployment have you run this cf-acceptance-test change against?

Latest

### Please check all that apply for this PR:

- [x] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

^^ adds opt-in configuration to cats?

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

CATs should test the same app/route workloads on windows as it does on isolation segments + primary diego cells

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

up to two cf push timeouts

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
