### PR TITLE
Update CF_INSTANCE_PORT and CF_INSTANCE_ADDR tests so they pass regar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,6 @@ include_app_syslog_tcp
 * `private_docker_registry_password`: Password to access the private docker repository. [See below](#private-docker)
 * `unallocated_ip_for_security_group`: An unused IP address in the private network used by CF. Defaults to 10.0.244.255. [See below](#container-networking-and-application-security-groups)
 
-* `require_proxied_app_traffic`: Set this to `true` if Diego was configured to require proxied port mappings, i.e. if `containers.proxy.enable_unproxied_port_mappings` is set to `false`.
-
 * `staticfile_buildpack_name` [See below](#buildpack-names)
 * `java_buildpack_name` [See below](#buildpack-names)
 * `ruby_buildpack_name` [See below](#buildpack-names)

--- a/apps/default_environment_variables.go
+++ b/apps/default_environment_variables.go
@@ -136,16 +136,11 @@ exit 1
 				"VCAP_APP_PORT",
 			)
 
-			if Config.GetRequireProxiedAppTraffic() {
-				assertNotPresent(env,
-					"CF_INSTANCE_ADDR",
-					"CF_INSTANCE_PORT",
-				)
-			} else {
-				assertPresent(env,
-					"CF_INSTANCE_ADDR",
-					"CF_INSTANCE_PORT",
-				)
+			if v, ok := env["CF_INSTANCE_PORT"]; ok && v != "" {
+				Expect(v).To(MatchRegexp(`[0-9]+`))
+			}
+			if v, ok := env["CF_INSTANCE_ADDR"]; ok && v != "" {
+				Expect(v).To(MatchRegexp(`[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+`))
 			}
 
 			if Config.GetIncludeTasks() {

--- a/apps/lifecycle.go
+++ b/apps/lifecycle.go
@@ -304,12 +304,10 @@ var _ = AppsDescribe("Application Lifecycle", func() {
 				Expect(len(ports)).NotTo(BeZero())
 				Expect(ports[0].Internal).NotTo(BeZero())
 
-				if Config.GetRequireProxiedAppTraffic() {
-					Expect(ports[0].External).To(BeNil())
+				if ports[0].External == nil {
 					Expect(envValues.Port).To(BeZero())
 					Expect(envValues.Addr).To(BeZero())
 				} else {
-					Expect(ports[0].External).NotTo(BeNil())
 					Expect(*ports[0].External).NotTo(BeZero())
 					Expect(envValues.Port).To(MatchRegexp(`[0-9]+`))
 					Expect(envValues.Addr).To(MatchRegexp(`[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+`))

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -78,7 +78,6 @@ type CatsConfig interface {
 	GetRBuildpackName() string
 	GetRubyBuildpackName() string
 	GetUnallocatedIPForSecurityGroup() string
-	GetRequireProxiedAppTraffic() bool
 	GetDynamicASGsEnabled() bool
 	GetCommaDelimitedASGsEnabled() bool
 	GetReadinessHealthChecksEnabled() bool

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -112,7 +112,6 @@ type config struct {
 	PublicDockerAppImage          *string `json:"public_docker_app_image"`
 
 	UnallocatedIPForSecurityGroup *string `json:"unallocated_ip_for_security_group"`
-	RequireProxiedAppTraffic      *bool   `json:"require_proxied_app_traffic"`
 
 	DynamicASGsEnabled           *bool `json:"dynamic_asgs_enabled"`
 	CommaDelimitedASGsEnabled    *bool `json:"comma_delim_asgs_enabled"`
@@ -233,7 +232,6 @@ func getDefaults() config {
 	defaults.PublicDockerAppImage = ptrToString("cloudfoundry/diego-docker-app:latest")
 
 	defaults.UnallocatedIPForSecurityGroup = ptrToString("10.0.244.255")
-	defaults.RequireProxiedAppTraffic = ptrToBool(false)
 
 	defaults.DynamicASGsEnabled = ptrToBool(true)
 	defaults.CommaDelimitedASGsEnabled = ptrToBool(false)
@@ -1093,10 +1091,6 @@ func (c *config) GetPublicDockerAppImage() string {
 
 func (c *config) GetUnallocatedIPForSecurityGroup() string {
 	return *c.UnallocatedIPForSecurityGroup
-}
-
-func (c *config) GetRequireProxiedAppTraffic() bool {
-	return *c.RequireProxiedAppTraffic
 }
 
 func (c *config) GetStacks() []string {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -47,7 +47,6 @@ type testConfig struct {
 	IsolationSegmentDomain *string `json:"isolation_segment_domain,omitempty"`
 
 	UnallocatedIPForSecurityGroup *string `json:"unallocated_ip_for_security_group"`
-	RequireProxiedAppTraffic      *bool   `json:"require_proxied_app_traffic"`
 
 	UseWindowsTestTask    *bool   `json:"use_windows_test_task,omitempty"`
 	UseWindowsContextPath *bool   `json:"use_windows_context_path,omitempty"`
@@ -188,7 +187,6 @@ type nullConfig struct {
 	Stacks *[]string `json:"stacks"`
 
 	UnallocatedIPForSecurityGroup *string `json:"unallocated_ip_for_security_group"`
-	RequireProxiedAppTraffic      *bool   `json:"require_proxied_app_traffic"`
 	UseWindowsContextPath         *bool   `json:"use_windows_context_path"`
 	UseWindowsTestTask            *bool   `json:"use_windows_test_task"`
 }
@@ -345,8 +343,6 @@ var _ = Describe("Config", func() {
 		Expect(config.GetCredHubBrokerClientCredential()).To(Equal("credhub_admin_client"))
 		Expect(config.GetCredHubLocation()).To(Equal("https://credhub.service.cf.internal:8844"))
 
-		Expect(config.GetRequireProxiedAppTraffic()).To(BeFalse())
-
 		Expect(config.GetStacks()).To(ConsistOf("cflinuxfs4"))
 
 		Expect(config.GetBinaryBuildpackName()).To(Equal("binary_buildpack"))
@@ -441,7 +437,6 @@ var _ = Describe("Config", func() {
 
 			// These values are allowed to be null
 			Expect(err.Error()).NotTo(ContainSubstring("unallocated_ip_for_security_group"))
-			Expect(err.Error()).NotTo(ContainSubstring("require_proxied_app_traffic"))
 			Expect(err.Error()).NotTo(ContainSubstring("use_windows_context_path"))
 			Expect(err.Error()).NotTo(ContainSubstring("reporter_config"))
 			Expect(err.Error()).NotTo(ContainSubstring("use_windows_test_task"))
@@ -461,7 +456,6 @@ var _ = Describe("Config", func() {
 			testCfg.SleepTimeout = ptrToInt(101)
 			testCfg.TimeoutScale = ptrToFloat(1.0)
 			testCfg.UnallocatedIPForSecurityGroup = ptrToString("192.168.0.1")
-			testCfg.RequireProxiedAppTraffic = ptrToBool(true)
 
 			testCfg.IncludeAppSyslogTcp = ptrToBool(false)
 			testCfg.IncludeApps = ptrToBool(false)
@@ -524,7 +518,6 @@ var _ = Describe("Config", func() {
 			Expect(config.SleepTimeoutDuration()).To(Equal(101 * time.Second))
 			Expect(config.SleepTimeoutDuration()).To(Equal(101 * time.Second))
 			Expect(config.GetUnallocatedIPForSecurityGroup()).To(Equal("192.168.0.1"))
-			Expect(config.GetRequireProxiedAppTraffic()).To(BeTrue())
 
 			Expect(config.GetIncludeAppSyslogTcp()).To(BeFalse())
 			Expect(config.GetIncludeApps()).To(BeFalse())


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

yes
### What is this change about?

Adjusts env var tests related to CF_INSTANCE_PORT and CF_INSTANCE_ADDR to pass regardless of how unproxied ports are configured for app containers.

### Please provide contextual information.

Allows https://github.com/cloudfoundry/cf-deployment/pull/1195 to no longer need changes to CATs  configs

### What version of cf-deployment have you run this cf-acceptance-test change against?

Latest.

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

no change

### What is the level of urgency for publishing this change?

- [] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
