### PR TITLE
Update pora Dockerfile to actually compile pora

### DIFF
--- a/assets/pora/Dockerfile
+++ b/assets/pora/Dockerfile
@@ -1,3 +1,13 @@
-FROM golang:onbuild
-ENV PORT 80
-EXPOSE 80
+FROM golang as pora
+WORKDIR /go/src/app
+COPY * .
+RUN go build -o /pora /go/src/app/server.go
+
+FROM ubuntu
+LABEL org.cloudfoundry.garden-rootfs.dockerfile.url="https://github.com/cloudfoundry/cf-acceptance-tests/blob/main/assets/pora/Dockerfile"
+LABEL org.cloudfoundry.garden-rootfs.notes.md="Used by code.cloudfoundry.org/cf-volume-services-acceptance-tests\
+"
+COPY --from=pora /pora /usr/local/bin/pora
+ENTRYPOINT /usr/local/bin/pora
+ENV PORT=8080
+EXPOSE 8080

--- a/assets/pora/Dockerfile
+++ b/assets/pora/Dockerfile
@@ -4,8 +4,8 @@ COPY * .
 RUN go build -o /pora /go/src/app/server.go
 
 FROM ubuntu
-LABEL org.cloudfoundry.garden-rootfs.dockerfile.url="https://github.com/cloudfoundry/cf-acceptance-tests/blob/main/assets/pora/Dockerfile"
-LABEL org.cloudfoundry.garden-rootfs.notes.md="Used by code.cloudfoundry.org/cf-volume-services-acceptance-tests\
+LABEL org.cloudfoundry.pora.dockerfile.url="https://github.com/cloudfoundry/cf-acceptance-tests/blob/main/assets/pora/Dockerfile"
+LABEL org.cloudfoundry.pora.notes.md="Used by code.cloudfoundry.org/cf-volume-services-acceptance-tests\
 "
 COPY --from=pora /pora /usr/local/bin/pora
 ENTRYPOINT /usr/local/bin/pora


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

We want to update the Dockerfile to actually work :)

### Please provide contextual information.

ARP WG is taking over volume services and revamping a few things, including this.

### What version of cf-deployment have you run this cf-acceptance-test change against?
CATs does not use this dockerfile

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

We want to keep pora where it is.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

0!


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@winkingturtlevmw
