### PR TITLE
Add Option for  Volume Service Broker name

### DIFF
--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -95,6 +95,7 @@ type CatsConfig interface {
 	GetVolumeServicePlanName() string
 	GetVolumeServiceCreateConfig() string
 	GetVolumeServiceBindConfig() string
+	GetVolumeServiceBrokerName() string
 
 	GetReporterConfig() reporterConfig
 

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -69,6 +69,7 @@ type config struct {
 	VolumeServicePlanName     *string `json:"volume_service_plan_name"`
 	VolumeServiceCreateConfig *string `json:"volume_service_create_config"`
 	VolumeServiceBindConfig   *string `json:"volume_service_bind_config"`
+	VolumeServiceBrokerName   *string `json:"volume_service_broker_name"`
 
 	IncludeAppSyslogTCP             *bool `json:"include_app_syslog_tcp"`
 	IncludeApps                     *bool `json:"include_apps"`
@@ -206,6 +207,7 @@ func getDefaults() config {
 	defaults.VolumeServicePlanName = ptrToString("")
 	defaults.VolumeServiceCreateConfig = ptrToString("")
 	defaults.VolumeServiceBindConfig = ptrToString("")
+	defaults.VolumeServiceBrokerName = ptrToString("")
 
 	defaults.ReporterConfig = &reporterConfig{}
 
@@ -1139,6 +1141,10 @@ func (c *config) GetVolumeServiceCreateConfig() string {
 
 func (c *config) GetVolumeServiceBindConfig() string {
 	return *c.VolumeServiceBindConfig
+}
+
+func (c *config) GetVolumeServiceBrokerName() string {
+	return *c.VolumeServiceBrokerName
 }
 
 func (c *config) GetAdminClient() string {

--- a/volume_services/volume_services.go
+++ b/volume_services/volume_services.go
@@ -58,7 +58,7 @@ var _ = VolumeServicesDescribe("Volume Services", func() {
 		})
 
 		workflowhelpers.AsUser(TestSetup.AdminUserContext(), TestSetup.ShortTimeout(), func() {
-			session := cf.Cf("enable-service-access", serviceName, "-o", TestSetup.RegularUserContext().Org).Wait()
+			session := cf.Cf("enable-service-access", serviceName, "-b", Config.GetVolumeServiceBrokerName(), "-o", TestSetup.RegularUserContext().Org).Wait()
 			Expect(session).To(Exit(0), "cannot enable nfs service access")
 		})
 

--- a/volume_services/volume_services.go
+++ b/volume_services/volume_services.go
@@ -58,7 +58,11 @@ var _ = VolumeServicesDescribe("Volume Services", func() {
 		})
 
 		workflowhelpers.AsUser(TestSetup.AdminUserContext(), TestSetup.ShortTimeout(), func() {
-			session := cf.Cf("enable-service-access", serviceName, "-b", Config.GetVolumeServiceBrokerName(), "-o", TestSetup.RegularUserContext().Org).Wait()
+			args := []string{"enable-service-access", serviceName, "-o", TestSetup.RegularUserContext().Org}
+			if Config.GetVolumeServiceBrokerName() != "" {
+				args = append(args, "-b", Config.GetVolumeServiceBrokerName())
+			}
+			session := cf.Cf(args...).Wait()
 			Expect(session).To(Exit(0), "cannot enable nfs service access")
 		})
 
@@ -74,11 +78,16 @@ var _ = VolumeServicesDescribe("Volume Services", func() {
 
 		By("creating a service")
 		var createServiceSession *Session
-		if Config.GetVolumeServiceCreateConfig() == "" {
-			createServiceSession = cf.Cf("create-service", serviceName, Config.GetVolumeServicePlanName(), serviceInstanceName, "-b", Config.GetVolumeServiceBrokerName(), "-c", fmt.Sprintf(`{"share": "%s/"}`, tcpDomain))
-		} else {
-			createServiceSession = cf.Cf("create-service", serviceName, Config.GetVolumeServicePlanName(), serviceInstanceName, "-b", Config.GetVolumeServiceBrokerName(), "-c", Config.GetVolumeServiceCreateConfig())
+		args := []string{"create-service", serviceName, Config.GetVolumeServicePlanName(), serviceInstanceName}
+		if Config.GetVolumeServiceBrokerName() != "" {
+			args = append(args, "-b", Config.GetVolumeServiceBrokerName())
 		}
+		if Config.GetVolumeServiceCreateConfig() == "" {
+			args = append(args, "-c", fmt.Sprintf(`{"share": "%s/"}`, tcpDomain))
+		} else {
+			args = append(args, "-c", Config.GetVolumeServiceCreateConfig())
+		}
+		createServiceSession = cf.Cf(args...)
 		Expect(createServiceSession.Wait(TestSetup.ShortTimeout())).To(Exit(0), "cannot create an nfs service instance")
 
 		By("binding the service")

--- a/volume_services/volume_services.go
+++ b/volume_services/volume_services.go
@@ -75,9 +75,9 @@ var _ = VolumeServicesDescribe("Volume Services", func() {
 		By("creating a service")
 		var createServiceSession *Session
 		if Config.GetVolumeServiceCreateConfig() == "" {
-			createServiceSession = cf.Cf("create-service", serviceName, Config.GetVolumeServicePlanName(), serviceInstanceName, "-c", fmt.Sprintf(`{"share": "%s/"}`, tcpDomain))
+			createServiceSession = cf.Cf("create-service", serviceName, Config.GetVolumeServicePlanName(), serviceInstanceName, "-b", Config.GetVolumeServiceBrokerName(), "-c", fmt.Sprintf(`{"share": "%s/"}`, tcpDomain))
 		} else {
-			createServiceSession = cf.Cf("create-service", serviceName, Config.GetVolumeServicePlanName(), serviceInstanceName, "-c", Config.GetVolumeServiceCreateConfig())
+			createServiceSession = cf.Cf("create-service", serviceName, Config.GetVolumeServicePlanName(), serviceInstanceName, "-b", Config.GetVolumeServiceBrokerName(), "-c", Config.GetVolumeServiceCreateConfig())
 		}
 		Expect(createServiceSession.Wait(TestSetup.ShortTimeout())).To(Exit(0), "cannot create an nfs service instance")
 


### PR DESCRIPTION
### What is this change about?

Add Option for  Volume Service Broker name

### Please provide contextual information.

If VolumeService Service broker is configured with a different broker-name, cats will fail. With this change, it'll be required to provide a `volume_service_broker_name` only when running volume-services tests

### What version of cf-deployment have you run this cf-acceptance-test change against?

main

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [x] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work (our pipeline's are currently broken)
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
