### PR TITLE
Use Server struct to address gosec G114

### DIFF
--- a/assets/binary/site.go
+++ b/assets/binary/site.go
@@ -12,17 +12,21 @@ func main() {
 	http.HandleFunc("/", hello)
 	http.HandleFunc("/env", env)
 	fmt.Println("listening...")
-	err := http.ListenAndServe(":"+os.Getenv("PORT"), nil)
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%s", os.Getenv("PORT")),
+		Handler: nil,
+	}
+	err := server.ListenAndServe()
 	if err != nil {
 		panic(err)
 	}
 }
 
-func hello(res http.ResponseWriter, req *http.Request) {
+func hello(res http.ResponseWriter, _ *http.Request) {
 	fmt.Fprintln(res, "Hello from a binary")
 }
 
-func env(res http.ResponseWriter, req *http.Request) {
+func env(res http.ResponseWriter, _ *http.Request) {
 	envVariables := make(map[string]string)
 	for _, envKeyValue := range os.Environ() {
 		keyValue := strings.Split(envKeyValue, "=")

--- a/assets/catnip/main.go
+++ b/assets/catnip/main.go
@@ -12,6 +12,11 @@ import (
 )
 
 func main() {
-	fmt.Printf("listening on port %s...\n", os.Getenv("PORT"))
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", os.Getenv("PORT")), router.New(os.Stdout, clock.NewClock())))
+	port := os.Getenv("PORT")
+	fmt.Printf("listening on port %s...\n", port)
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%s", port),
+		Handler: router.New(os.Stdout, clock.NewClock()),
+	}
+	log.Fatal(server.ListenAndServe())
 }

--- a/assets/credhub-service-broker/main.go
+++ b/assets/credhub-service-broker/main.go
@@ -49,5 +49,9 @@ func main() {
 
 	// Start the HTTP server
 	log.Printf("Server starting, listening on port %d...", cfg.Port)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", cfg.Port), router))
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%d", cfg.Port),
+		Handler: router,
+	}
+	log.Fatal(server.ListenAndServe())
 }

--- a/assets/go_calls_ruby/site.go
+++ b/assets/go_calls_ruby/site.go
@@ -11,7 +11,12 @@ import (
 func main() {
 	http.HandleFunc("/", hello)
 	fmt.Println("listening...")
-	err := http.ListenAndServe(":"+os.Getenv("PORT"), nil)
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%s", os.Getenv("PORT")),
+		Handler: nil,
+	}
+	err := server.ListenAndServe()
 	if err != nil {
 		panic(err)
 	}

--- a/assets/golang/site.go
+++ b/assets/golang/site.go
@@ -10,7 +10,12 @@ func main() {
 	http.HandleFunc("/", hello)
 	http.HandleFunc("/requesturi/", echo)
 	fmt.Println("listening...")
-	err := http.ListenAndServe(":"+os.Getenv("PORT"), nil)
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%s", os.Getenv("PORT")),
+		Handler: nil,
+	}
+	err := server.ListenAndServe()
 	if err != nil {
 		panic(err)
 	}

--- a/assets/logging-route-service/main.go
+++ b/assets/logging-route-service/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -30,7 +31,11 @@ func main() {
 	roundTripper := NewLoggingRoundTripper(skipSslValidation)
 	proxy := NewProxy(roundTripper, skipSslValidation)
 
-	log.Fatal(http.ListenAndServe(":"+port, proxy))
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%s", port),
+		Handler: proxy,
+	}
+	log.Fatal(server.ListenAndServe())
 }
 
 func NewProxy(transport http.RoundTripper, skipSslValidation bool) http.Handler {

--- a/assets/loggregator-load-generator-go/loggregator-load-generator.go
+++ b/assets/loggregator-load-generator-go/loggregator-load-generator.go
@@ -28,7 +28,11 @@ func main() {
 	http.HandleFunc("/log/stop", logStop)
 	http.HandleFunc("/", help)
 	port := os.Getenv("PORT")
-	log.Fatal(http.ListenAndServe(":"+port, nil))
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%s", port),
+		Handler: nil,
+	}
+	log.Fatal(server.ListenAndServe())
 }
 
 func help(w http.ResponseWriter, r *http.Request) {

--- a/assets/multi-port-app/main.go
+++ b/assets/multi-port-app/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -24,10 +25,14 @@ func main() {
 		go func(wg *sync.WaitGroup, port string) {
 			defer wg.Done()
 
-			log.Fatal(http.ListenAndServe(":"+port, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				w.Header().Set("Content-Type", "text/plain")
-				w.Write([]byte(port + "\n"))
-			})))
+			server := &http.Server{
+				Addr: fmt.Sprintf(":%s", port),
+				Handler: http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+					responseWriter.Header().Set("Content-Type", "text/plain")
+					responseWriter.Write([]byte(port + "\n"))
+				}),
+			}
+			log.Fatal(server.ListenAndServe())
 		}(&wg, port)
 	}
 	println("Listening on ports ", strings.Join(ports, ", "))

--- a/assets/pora/server.go
+++ b/assets/pora/server.go
@@ -33,9 +33,12 @@ func main() {
 	errCh := make(chan error)
 
 	for _, port := range portArray {
-		println(port)
 		go func(port string) {
-			errCh <- http.ListenAndServe(":"+port, nil)
+			server := &http.Server{
+				Addr:    fmt.Sprintf(":%s", port),
+				Handler: nil,
+			}
+			errCh <- server.ListenAndServe()
 		}(port)
 	}
 

--- a/assets/proxy/main.go
+++ b/assets/proxy/main.go
@@ -26,7 +26,11 @@ func main() {
 	mux.HandleFunc("/https_proxy/", httpsProxyHandler)
 	mux.HandleFunc("/", infoHandler(systemPort))
 
-	_ = http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", systemPort), mux)
+	server := &http.Server{
+		Addr:    fmt.Sprintf("0.0.0.0:%d", systemPort),
+		Handler: mux,
+	}
+	_ = server.ListenAndServe()
 }
 
 func infoHandler(port int) http.HandlerFunc {

--- a/assets/webapp/webapp.go
+++ b/assets/webapp/webapp.go
@@ -18,5 +18,9 @@ func main() {
 	fmt.Println("ENV", os.Environ())
 	port := os.Getenv("PORT")
 	fmt.Println("Listening on port: ", port)
-	log.Fatal(http.ListenAndServe(":"+port, nil))
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%s", port),
+		Handler: nil,
+	}
+	log.Fatal(server.ListenAndServe())
 }


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Using `Server` struct, which allows specifying a timeout, to create a server in order to address gosec G114

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

No change to runtime

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
