### PR TITLE
Remove two problematic characters from Routing Transparency test

### DIFF
--- a/apps/routing_transparency.go
+++ b/apps/routing_transparency.go
@@ -44,11 +44,11 @@ var _ = AppsDescribe("Routing Transparency", func() {
 	})
 
 	It("appropriately handles certain reserved/unsafe characters", func() {
-		curlResponse := helpers.CurlApp(Config, appName, "/requesturi/!~^'()$\"?!'()$#!'")
+		curlResponse := helpers.CurlApp(Config, appName, "/requesturi/!~^'()$?!'()$#!'")
 		Expect(curlResponse).To(ContainSubstring("Request"))
 
 		By("preserving all characters")
-		Expect(curlResponse).To(ContainSubstring("/requesturi/!~^'()$\""))
+		Expect(curlResponse).To(ContainSubstring("/requesturi/!~^'()$"))
 		Expect(curlResponse).To(ContainSubstring("Query String is [!'()$]"))
 	})
 })

--- a/apps/routing_transparency.go
+++ b/apps/routing_transparency.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
 	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
 )
@@ -20,10 +19,6 @@ var _ = AppsDescribe("Routing Transparency", func() {
 	var appName string
 
 	BeforeEach(func() {
-		if !Config.GetIncludeHTTP2Routing() {
-			Skip(skip_messages.SkipHTTP2RoutingMessage)
-		}
-
 		appName = random_name.CATSRandomName("APP")
 		Expect(cf.Cf("push",
 			appName,
@@ -49,11 +44,17 @@ var _ = AppsDescribe("Routing Transparency", func() {
 	})
 
 	It("appropriately handles certain reserved/unsafe characters", func() {
-		curlResponse := helpers.CurlApp(Config, appName, "/requesturi/!~^'()$\"?!'()$#!'")
+		curlResponse := helpers.CurlApp(Config, appName, "/requesturi/!~^'()$?!'()$#!'")
 		Expect(curlResponse).To(ContainSubstring("Request"))
 
 		By("preserving all characters")
-		Expect(curlResponse).To(ContainSubstring("/requesturi/!~^'()$\""))
+		Expect(curlResponse).To(ContainSubstring("/requesturi/!~^'()$"))
 		Expect(curlResponse).To(ContainSubstring("Query String is [!'()$]"))
+
+		By("preserving double quotes (not for HTTP/2)")
+		if !Config.GetIncludeHTTP2Routing() {
+			curlResponse = helpers.CurlApp(Config, appName, "/requesturi/\"")
+			Expect(curlResponse).To(ContainSubstring("/requesturi/\""))
+		}
 	})
 })


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._

### What is this change about?

Remove the two problematic characters from Routing Transparency test that should appropriately handles certain reserved/unsafe characters but its not the case.

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._
https://github.com/cloudfoundry/cf-acceptance-tests/issues/1276

### What version of cf-deployment have you run this cf-acceptance-test change against?

v44.0.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
