### PR TITLE
chore(assets/logging-route-service): Remove unnecessary Dependabot config

### DIFF
--- a/assets/logging-route-service/.github/dependabot.yml
+++ b/assets/logging-route-service/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: "gomod"
-  directory: "/"
-  schedule:
-    interval: "daily"


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

### What is this change about?

Removes unnecessary Dependabot config from the logging-route-service since it's already included in the Dependabot config at the base of the repo.

This is just a carry-over from when we used to vendir in this asset from another repo.

### Please provide contextual information.

https://github.com/cloudfoundry/logging-route-service

### What version of cf-deployment have you run this cf-acceptance-test change against?

None

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None