### PR TITLE
Add percent-encoded characters to Routing Transparency test

### DIFF
--- a/apps/routing_transparency.go
+++ b/apps/routing_transparency.go
@@ -35,11 +35,11 @@ var _ = AppsDescribe("Routing Transparency", func() {
 	})
 
 	It("appropriately handles URLs with percent-encoded characters", func() {
-		curlResponse := helpers.CurlApp(Config, appName, "/requesturi/%21%7E%5E%24%20%27%28%29?foo=bar+baz%20bing")
+		curlResponse := helpers.CurlApp(Config, appName, "/requesturi/%20%21%22%23%24%25%27%28%29%3C%3E%5E%7C%7E?foo=bar+baz%20bing")
 		Expect(curlResponse).To(ContainSubstring("Request"))
 
 		By("preserving all characters")
-		Expect(curlResponse).To(ContainSubstring("/requesturi/%21%7E%5E%24%20%27%28%29"))
+		Expect(curlResponse).To(ContainSubstring("/requesturi/%20%21%22%23%24%25%27%28%29%3C%3E%5E%7C%7E"))
 		Expect(curlResponse).To(ContainSubstring("Query String is [foo=bar+baz%20bing]"))
 	})
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._

### What is this change about?

Update the "Routing Transparency" percent-encoded test with the following characters:
`%22 %23 %25 %3C %3E %7C`

Source:  https://developers.google.com/maps/url-encoding

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._
https://github.com/cloudfoundry/cf-acceptance-tests/issues/1276

### What version of cf-deployment have you run this cf-acceptance-test change against?

v44.4.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
