### PR TITLE
Adapt SSO and ASGs test for disabled v2 setup

### DIFF
--- a/security_groups/dynamic_asgs.go
+++ b/security_groups/dynamic_asgs.go
@@ -46,7 +46,7 @@ var _ = SecurityGroupsDescribe("ASGs", func() {
 	})
 
 	It("manages whether apps can reach certain IP addresses per ASG configuration", func() {
-		proxyRequestURL := fmt.Sprintf("%s%s.%s/https_proxy/cloud-controller-ng.service.cf.internal:9024/v2/info", Config.Protocol(), appName, Config.GetAppsDomain())
+		proxyRequestURL := fmt.Sprintf("%s%s.%s/https_proxy/cloud-controller-ng.service.cf.internal:9024/", Config.Protocol(), appName, Config.GetAppsDomain())
 
 		client := &http.Client{
 			Transport: &http.Transport{
@@ -134,7 +134,7 @@ func assertAppCanConnect(client *http.Client, proxyRequestURL string) {
 		Expect(err).ToNot(HaveOccurred())
 		resp.Body.Close()
 		return string(respBytes)
-	}, 1*time.Minute, 1*time.Second).Should(MatchRegexp("api_version"))
+	}, 1*time.Minute, 1*time.Second).Should(MatchRegexp("cloud_controller_v3"))
 }
 
 func assertEventuallyAppCanConnect(client *http.Client, proxyRequestURL string) {
@@ -146,7 +146,7 @@ func assertEventuallyAppCanConnect(client *http.Client, proxyRequestURL string) 
 		Expect(err).ToNot(HaveOccurred())
 		resp.Body.Close()
 		return string(respBytes)
-	}, 3*time.Minute, 1*time.Second).Should(MatchRegexp("api_version"))
+	}, 3*time.Minute, 1*time.Second).Should(MatchRegexp("cloud_controller_v3"))
 }
 
 func bindCCSecurityGroup(orgName, spaceName string) string {


### PR DESCRIPTION
### What is this change about?

Adapt SSO and ASGs test for a CF deployment with disabled v2 API.

### Please provide contextual information.

Part of the v2 deprecation story: https://github.com/cloudfoundry/community/pull/941

### What version of cf-deployment have you run this cf-acceptance-test change against?

v44.5.0 with `temporary_enable_v2` set to `false`

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

No change in runtime behaviour.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
