### PR TITLE
Fix for PR https://github.com/cloudfoundry/cf-acceptance-tests/pull/1312

### DIFF
--- a/security_groups/comma_delmited_asgs.go
+++ b/security_groups/comma_delmited_asgs.go
@@ -44,7 +44,7 @@ var _ = CommaDelimitedSecurityGroupsDescribe("Comma Delimited ASGs", func() {
 	})
 
 	It("manages whether apps can reach certain IP addresses per ASG configuration with commas", func() {
-		proxyRequestURL := fmt.Sprintf("%s%s.%s/https_proxy/cloud-controller-ng.service.cf.internal:9024/v2/info", Config.Protocol(), appName, Config.GetAppsDomain())
+		proxyRequestURL := fmt.Sprintf("%s%s.%s/https_proxy/cloud-controller-ng.service.cf.internal:9024/", Config.Protocol(), appName, Config.GetAppsDomain())
 
 		client := &http.Client{
 			Transport: &http.Transport{


### PR DESCRIPTION
### Please provide contextual information.

Fix for PR https://github.com/cloudfoundry/cf-acceptance-tests/pull/1312

Remove `/v2/info` endpoint also in comma-delimited security groups test.

### What version of cf-deployment have you run this cf-acceptance-test change against?

v44.6.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Same as before.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

