### PR TITLE
Fix v3 list service instances test

### DIFF
--- a/v3/service_instances.go
+++ b/v3/service_instances.go
@@ -78,6 +78,6 @@ var _ = V3Describe("service instances", func() {
 		err := json.Unmarshal(listService.Out.Contents(), &res)
 		Expect(err).To(BeNil())
 
-		Expect(res.Resources).To(ConsistOf(expectedResources))
+		Expect(res.Resources).To(ContainElements(expectedResources))
 	})
 })


### PR DESCRIPTION
### What is this change about?

The v3 test "Lists the service instances" failed two times in a row because 3 instances were returned, but only 2 expected. Given the current test setup (space is shared between different tests), we cannot guarantee that exactly 2 instances are returned -> use "contain" matcher to relax assertion.

Another possible fix would be to use a separate space for that test.

### Please provide contextual information.

Failing test runs:
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/fresh-cats/builds/1842
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/fresh-cats/builds/1841

### What version of cf-deployment have you run this cf-acceptance-test change against?

(none)

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

No change in runtime.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
