### PR TITLE
Add python buildpack variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ include_app_syslog_tcp
 * `r_buildpack_name` [See below](#buildpack-names)
 * `binary_buildpack_name` [See below](#buildpack-names)
 * `cnb_nodejs_buildpack_name` [See below](#buildpack-names)
+* `python_buildpack_name: python_buildpack` [See below](#buildpack-names)
 
 * `include_windows`: Flag to include the tests that run against Windows cells.
 * `use_windows_test_task`: Flag to include the tasks tests on Windows cells. Default is `false`.
@@ -203,6 +204,7 @@ Many tests specify a buildpack when pushing an app, so that on diego the app sta
 * `r_buildpack_name: r_buildpack`
 * `binary_buildpack_name: binary_buildpack`
 * `hwc_buildpack_name: hwc_buildpack`
+* `python_buildpack_name: python_buildpack`
 
 For the Cloud Native Buildpacks lifecycle, you can override them by setting different names:
 

--- a/apps/crashing.go
+++ b/apps/crashing.go
@@ -3,6 +3,8 @@ package apps
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
@@ -13,7 +15,6 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
-	"time"
 )
 
 func hasOneInstanceInState(processPath, desiredState string) bool {
@@ -78,7 +79,7 @@ var _ = AppsDescribe("Crashing", func() {
 			By("Pushing the app with three instances")
 			Expect(cf.Cf(
 				"push", appName,
-				"-b", "python_buildpack",
+				"-b", Config.GetPythonBuildpackName(),
 				"-m", DEFAULT_MEMORY_LIMIT,
 				"-p", assets.NewAssets().PythonCrashApp,
 				"-i", "3", // Setting three instances

--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -128,6 +128,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		Expect(buildpacks).To(ContainSubstring(Config.GetJavaBuildpackName()), "Missing the java buildpack specified in the integration_config.json. There may be other missing buildpacks as well; please double-check your configuration against the buildpacks listed below.")
 		Expect(buildpacks).To(ContainSubstring(Config.GetNodejsBuildpackName()), "Missing the NodeJS buildpack specified in the integration_config.json. There may be other missing buildpacks as well; please double-check your configuration against the buildpacks listed below.")
 		Expect(buildpacks).To(ContainSubstring(Config.GetRubyBuildpackName()), "Missing the ruby buildpack specified in the integration_config.json. There may be other missing buildpacks as well; please double-check your configuration against the buildpacks listed below.")
+		Expect(buildpacks).To(ContainSubstring(Config.GetPythonBuildpackName()), "Missing the python buildpack specified in the integration_config.json. There may be other missing buildpacks as well; please double-check your configuration against the buildpacks listed below.")
 	})
 
 	TestSetup.Setup()

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -76,6 +76,7 @@ type CatsConfig interface {
 	GetNodejsBuildpackName() string
 	GetCNBGoBuildpackName() string
 	GetCNBNodejsBuildpackName() string
+	GetPythonBuildpackName() string
 	GetPrivateDockerRegistryImage() string
 	GetPrivateDockerRegistryUsername() string
 	GetPrivateDockerRegistryPassword() string

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -62,6 +62,7 @@ type config struct {
 	RBuildpackName          *string `json:"r_buildpack_name"`
 	RubyBuildpackName       *string `json:"ruby_buildpack_name"`
 	StaticFileBuildpackName *string `json:"staticfile_buildpack_name"`
+	PythonBuildpackName     *string `json:"python_buildpack_name"`
 
 	CNBGoBuildpackName     *string `json:"cnb_go_buildpack_name"`
 	CNBNodejsBuildpackName *string `json:"cnb_nodejs_buildpack_name"`
@@ -166,6 +167,7 @@ func getDefaults() config {
 	defaults.RBuildpackName = ptrToString("r_buildpack")
 	defaults.RubyBuildpackName = ptrToString("ruby_buildpack")
 	defaults.StaticFileBuildpackName = ptrToString("staticfile_buildpack")
+	defaults.PythonBuildpackName = ptrToString("python_buildpack")
 
 	defaults.CNBGoBuildpackName = ptrToString("docker://gcr.io/paketo-buildpacks/go:latest")
 	defaults.CNBNodejsBuildpackName = ptrToString("docker://gcr.io/paketo-buildpacks/nodejs:latest")
@@ -428,6 +430,9 @@ func validateConfig(config *config) error {
 	}
 	if config.CNBNodejsBuildpackName == nil {
 		errs = errors.Join(errs, fmt.Errorf("* 'cnb_nodejs_buildpack_name' must not be null"))
+	}
+	if config.PythonBuildpackName == nil {
+		errs = errors.Join(errs, fmt.Errorf("* 'python_buildpack_name' must not be null"))
 	}
 	if config.IncludeAppSyslogTCP == nil {
 		errs = errors.Join(errs, fmt.Errorf("* 'include_app_syslog_tcp' must not be null"))
@@ -1122,6 +1127,10 @@ func (c *config) GetCNBGoBuildpackName() string {
 
 func (c *config) GetCNBNodejsBuildpackName() string {
 	return *c.CNBNodejsBuildpackName
+}
+
+func (c *config) GetPythonBuildpackName() string {
+	return *c.PythonBuildpackName
 }
 
 func (c *config) GetPrivateDockerRegistryImage() string {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -98,6 +98,7 @@ type testConfig struct {
 	RBuildpackName          *string `json:"r_buildpack_name,omitempty"`
 	RubyBuildpackName       *string `json:"ruby_buildpack_name,omitempty"`
 	StaticFileBuildpackName *string `json:"staticfile_buildpack_name,omitempty"`
+	PythonBuildpackName     *string `json:"python_buildpack_name,omitempty"`
 }
 
 type nullConfig struct {
@@ -144,6 +145,7 @@ type nullConfig struct {
 	RBuildpackName          *string `json:"r_buildpack_name"`
 	RubyBuildpackName       *string `json:"ruby_buildpack_name"`
 	StaticFileBuildpackName *string `json:"staticfile_buildpack_name"`
+	PythonBuildpackName     *string `json:"python_buildpack_name"`
 
 	ReporterConfig *testReporterConfig `json:"reporter_config"`
 
@@ -358,6 +360,7 @@ var _ = Describe("Config", func() {
 		Expect(config.GetRBuildpackName()).To(Equal("r_buildpack"))
 		Expect(config.GetRubyBuildpackName()).To(Equal("ruby_buildpack"))
 		Expect(config.GetStaticFileBuildpackName()).To(Equal("staticfile_buildpack"))
+		Expect(config.GetPythonBuildpackName()).To(Equal("python_buildpack"))
 	})
 
 	Context("when all values are null", func() {
@@ -404,6 +407,7 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(ContainSubstring("'nodejs_buildpack_name' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'ruby_buildpack_name' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'staticfile_buildpack_name' must not be null"))
+			Expect(err.Error()).To(ContainSubstring("'python_buildpack_name' must not be null"))
 
 			Expect(err.Error()).To(ContainSubstring("'include_apps' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_detect' must not be null"))
@@ -500,6 +504,7 @@ var _ = Describe("Config", func() {
 			testCfg.RBuildpackName = ptrToString("r_buildpack_override")
 			testCfg.RubyBuildpackName = ptrToString("ruby_buildpack_override")
 			testCfg.StaticFileBuildpackName = ptrToString("staticfile_buildpack_override")
+			testCfg.PythonBuildpackName = ptrToString("python_buildpack_override")
 
 			// These values are set so as not to trigger validation errors associated with the overrides provided above
 			testCfg.PrivateDockerRegistryImage = ptrToString("avoid-validation-errors-by-setting-dummy-value")
@@ -563,6 +568,7 @@ var _ = Describe("Config", func() {
 			Expect(config.GetRBuildpackName()).To(Equal("r_buildpack_override"))
 			Expect(config.GetRubyBuildpackName()).To(Equal("ruby_buildpack_override"))
 			Expect(config.GetStaticFileBuildpackName()).To(Equal("staticfile_buildpack_override"))
+			Expect(config.GetPythonBuildpackName()).To(Equal("python_buildpack_override"))
 		})
 	})
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._

### What is this change about?

This change removes the hard coded python buildpack and introduces a configuration variable for it, so it is possible to specify a custom one. As the default stays the same as the currently hardcoded, there should be no compatibility issues.

### Please provide contextual information.

As stated in the readme, all buildpack names should be customizable and the python buildpack was missing.

### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
