### PR TITLE
Bump cf-test-helpers to 2.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/cloudfoundry/cf-acceptance-tests
 
 go 1.22
+
 toolchain go1.22.9
 
 require (
@@ -8,7 +9,7 @@ require (
 	code.cloudfoundry.org/go-log-cache/v3 v3.0.3
 	code.cloudfoundry.org/go-loggregator/v10 v10.0.1
 	code.cloudfoundry.org/tlsconfig v0.18.0
-	github.com/cloudfoundry/cf-test-helpers/v2 v2.10.0
+	github.com/cloudfoundry/cf-test-helpers/v2 v2.11.0
 	github.com/cloudfoundry/noaa/v2 v2.5.0
 	github.com/cloudfoundry/sonde-go v0.0.0-20230710164515-a0a43d1dbbf8
 	github.com/mholt/archiver/v3 v3.5.1

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/apoydence/eachers v0.0.0-20181020210610-23942921fe77/go.mod h1:bXvGk6
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cloudfoundry/cf-test-helpers/v2 v2.10.0 h1:gMEAzEnC56Wio/ncQfraHKwEODMR0kAKfrdt1csmBBg=
-github.com/cloudfoundry/cf-test-helpers/v2 v2.10.0/go.mod h1:+LauHE/JqubvgLl1aq0T7h64x48OzL3IQd0eB2KpkRc=
+github.com/cloudfoundry/cf-test-helpers/v2 v2.11.0 h1:XuNsx6tczSSqmNzMRHUjXFt9flCLaCjn69JRXBzzBQo=
+github.com/cloudfoundry/cf-test-helpers/v2 v2.11.0/go.mod h1:uyamUdGqzPk/foHvSo4ehIrga6rH+g8JkMr6kwu/zYQ=
 github.com/cloudfoundry/noaa/v2 v2.5.0 h1:Cl1G1U9J/5EA7wcv4Qpqd/GfznWs1MnbkhL4M9Uhr4s=
 github.com/cloudfoundry/noaa/v2 v2.5.0/go.mod h1:R33q73MnTXa549YPMHupTdQuKL3QqKQ7bNNnginQG54=
 github.com/cloudfoundry/sonde-go v0.0.0-20230710164515-a0a43d1dbbf8 h1:IpMHKJul/Wr6Rae9VXO+1K0TuORVyhKFjpqkY5ClEAM=

--- a/vendor/github.com/cloudfoundry/cf-test-helpers/v2/helpers/internal/curl.go
+++ b/vendor/github.com/cloudfoundry/cf-test-helpers/v2/helpers/internal/curl.go
@@ -11,10 +11,11 @@ func Curl(cmdStarter internal.Starter, skipSsl bool, args ...string) *gexec.Sess
 }
 
 func CurlWithCustomReporter(cmdStarter internal.Starter, reporter internal.Reporter, skipSsl bool, args ...string) *gexec.Session {
-	curlArgs := append([]string{"-s"}, args...)
-	curlArgs = append([]string{"-H", "Expect:"}, curlArgs...)
+	curlArgs := append([]string{"--silent"}, args...)
+	curlArgs = append([]string{"--show-error"}, curlArgs...)
+	curlArgs = append([]string{"--header", "Expect:"}, curlArgs...)
 	if skipSsl {
-		curlArgs = append([]string{"-k"}, curlArgs...)
+		curlArgs = append([]string{"--insecure"}, curlArgs...)
 	}
 
 	request, err := cmdStarter.Start(reporter, "curl", curlArgs...)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -22,7 +22,7 @@ filippo.io/edwards25519/field
 # github.com/andybalholm/brotli v1.0.1
 ## explicit; go 1.12
 github.com/andybalholm/brotli
-# github.com/cloudfoundry/cf-test-helpers/v2 v2.10.0
+# github.com/cloudfoundry/cf-test-helpers/v2 v2.11.0
 ## explicit; go 1.22.0
 github.com/cloudfoundry/cf-test-helpers/v2/cf
 github.com/cloudfoundry/cf-test-helpers/v2/commandreporter


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Bump cf-test-helpers to 2.11.0.

### Please provide contextual information.

https://github.com/cloudfoundry/cf-test-helpers/releases/tag/v2.11.0

### What version of cf-deployment have you run this cf-acceptance-test change against?

N/A

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
