### PR TITLE
Add X-CF-PROCESS-INSTANCE header tests for routing

### DIFF
--- a/routing/process_routing.go
+++ b/routing/process_routing.go
@@ -1,0 +1,120 @@
+package routing
+
+import (
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	. "github.com/cloudfoundry/cf-acceptance-tests/helpers/v3_helpers"
+	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
+	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = RoutingDescribe("Process Routing", func() {
+	var (
+		appName              string
+		exisitingProcessGuid string
+		canaryProcessGuid    string
+		consistentlyDuration = "1s"
+	)
+
+	BeforeEach(func() {
+		By("Pushing an application")
+		appName = random_name.CATSRandomName("APP")
+		Expect(cf.Cf("push", appName, "-i", "2", "-b", Config.GetRubyBuildpackName(), "-p", assets.NewAssets().DoraZip).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+		By("Waiting until all instances are running")
+		Eventually(func(g Gomega) {
+			session := cf.Cf("app", appName).Wait()
+			g.Expect(session).Should(Say(`instances:\s+3/3`))
+		})
+		Eventually(func() string {
+			return helpers.CurlAppRoot(Config, appName)
+		}).Should(ContainSubstring("Hi, I'm Dora"))
+
+		By("Pushing a canary deployment")
+		Expect(cf.Cf("push", appName, "--strategy", "canary", "--no-wait", "-b", Config.GetStaticFileBuildpackName(), "-p", assets.NewAssets().Staticfile).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+		By("Waiting until canary is paused")
+		Eventually(func(g Gomega) {
+			session := cf.Cf("app", appName).Wait()
+			g.Expect(session).Should(Say("Active deployment with status PAUSED"))
+		}).Should(Succeed())
+
+		appGuid := GetApp(appName).GUID
+		processGuids := GetProcessGuidsForType(appGuid, "web")
+		Expect(processGuids).To(HaveLen(2))
+		exisitingProcessGuid = processGuids[0]
+		canaryProcessGuid = processGuids[1]
+	})
+
+	AfterEach(func() {
+		app_helpers.AppReport(appName)
+		Expect(cf.Cf("delete", appName, "-f").Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+	})
+
+	Describe("the X-CF-PROCESS-INSTANCE header", func() {
+		It("can be used to route requests to the correct process and instance", func() {
+
+			By("verifying that without the header, requests are routed randomly to either process")
+			Eventually(func() string {
+				return helpers.CurlAppRoot(Config, appName)
+			}).Should(ContainSubstring("Hello from a staticfile"))
+
+			Eventually(func() string {
+				return helpers.CurlAppRoot(Config, appName)
+			}).Should(ContainSubstring("Hi, I'm Dora"))
+
+			By("verifying that with X-CF-PROCESS-INSTANCE set without an instance id, requests are routed to the correct process")
+			existingProcessRoutingHeader := []string{"-H", "X-CF-PROCESS-INSTANCE:" + exisitingProcessGuid}
+			canaryProcessRoutingHeader := []string{"-H", "X-CF-PROCESS-INSTANCE:" + canaryProcessGuid}
+
+			By("checking that we can exclusively route to the existing process")
+			Consistently(func() string {
+				return helpers.CurlApp(Config, appName, "/", existingProcessRoutingHeader...)
+			}, consistentlyDuration).Should(ContainSubstring("Hi, I'm Dora"))
+
+			Consistently(func() string {
+				return helpers.CurlApp(Config, appName, "/", existingProcessRoutingHeader...)
+			}, consistentlyDuration).ShouldNot(ContainSubstring("Hello from a staticfile"))
+
+			By("checking that we can exclusively route to the canary process")
+			Consistently(func() string {
+				return helpers.CurlApp(Config, appName, "/", canaryProcessRoutingHeader...)
+			}, consistentlyDuration).Should(ContainSubstring("Hello from a staticfile"))
+
+			Consistently(func() string {
+				return helpers.CurlApp(Config, appName, "/", canaryProcessRoutingHeader...)
+			}, consistentlyDuration).ShouldNot(ContainSubstring("Hi, I'm Dora"))
+
+			By("verifying that with X-CF-PROCESS-INSTANCE set with an instance id, requests are routed to the correct process instance")
+			routingHeaderFirstInstance := []string{"-H", "X-CF-PROCESS-INSTANCE:" + exisitingProcessGuid + ":0"}
+			routingHeaderSecondInstance := []string{"-H", "X-CF-PROCESS-INSTANCE:" + exisitingProcessGuid + ":1"}
+			firstInstanceId := helpers.CurlApp(Config, appName, "/id", routingHeaderFirstInstance...)
+
+			By("checking that we can exclusively route to the first existing process")
+			Consistently(func() string {
+				return helpers.CurlApp(Config, appName, "/", routingHeaderFirstInstance...)
+			}, consistentlyDuration).Should(ContainSubstring("Hi, I'm Dora"))
+
+			Consistently(func() string {
+				return helpers.CurlApp(Config, appName, "/id", routingHeaderFirstInstance...)
+			}, consistentlyDuration).Should(Equal(firstInstanceId))
+
+			secondInstanceId := helpers.CurlApp(Config, appName, "/id", routingHeaderSecondInstance...)
+
+			By("checking that we can exclusively route to the second existing process")
+			Consistently(func() string {
+				return helpers.CurlApp(Config, appName, "/", routingHeaderSecondInstance...)
+			}, consistentlyDuration).Should(ContainSubstring("Hi, I'm Dora"))
+
+			Consistently(func() string {
+				return helpers.CurlApp(Config, appName, "/id", routingHeaderSecondInstance...)
+			}, consistentlyDuration).Should(Equal(secondInstanceId))
+		})
+	})
+})


### PR DESCRIPTION
* X-CF-PROCESS-INSTANCE:<process_guid>
* X-CF-PROCESS-INSTANCE:<process_guid>:<instance_index>

**note** This should not be merged until the work has been complete in GoRouter and released in cfd.

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?
Yes

### What is this change about?

Add CATs test for ability to route to a specific process and process instance.

### Please provide contextual information.

* https://github.com/cloudfoundry/gorouter/pull/467/files

### What version of cf-deployment have you run this cf-acceptance-test change against?

* https://github.com/cloudfoundry/cf-deployment/releases/tag/v48.7.0

### Please check all that apply for this PR:

- [x] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

```

Ran 1 of 250 Specs in 136.660 seconds
SUCCESS! -- 1 Passed | 0 Failed | 2 Pending | 247 Skipped
PASS | FOCUSED
```

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**