### PR TITLE
fix: Bump the minimum required version of Go to go1.23.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ in such a way as to impact other tests.
 
 ## Test Setup
 ### Prerequisites for running CATS
-- Install golang >= `1.22`. Set up your golang development environment, per
+- Install golang >= `1.23.0`. Set up your golang development environment, per
   [golang.org](http://golang.org/doc/install).
 - Install the [`cf CLI`](https://github.com/cloudfoundry/cli) >= `8.5.0`. Make
   sure that it is accessible in your `$PATH`.
@@ -53,7 +53,7 @@ in such a way as to impact other tests.
 All `go` dependencies required by CATs
 are vendored in the `vendor` directory.
 
-Make sure to have Golang 1.22+
+Make sure to have Golang 1.23+
 
 In order to update a current dependency to a specific version,
 do the following:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/cloudfoundry/cf-acceptance-tests
 
-go 1.22
-toolchain go1.23.6
+go 1.23.0
+
+toolchain go1.24.0
 
 require (
 	code.cloudfoundry.org/archiver v0.26.0


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Updating the minimum required version of Go to go1.23.0.

### Please provide contextual information.

If any dependencies of a module require a minimum version of Go that is greater than the minimum version of Go required by the module, then `go mod tidy` will update the minimum version of the module. This is what was happening when I ran `go mod tidy`. I've simply committed the result of that command.

### What version of cf-deployment have you run this cf-acceptance-test change against?

v48.3.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None