### PR TITLE
fix(assets): Bump minimum Go version to 1.23

### DIFF
--- a/assets/binary/go.mod
+++ b/assets/binary/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/binary
 
-go 1.22
+go 1.23
 
-toolchain go1.22.0
+toolchain go1.23.7

--- a/assets/catnip/go.mod
+++ b/assets/catnip/go.mod
@@ -1,7 +1,8 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/catnip
 
-go 1.22
-toolchain go1.22.5
+go 1.23
+
+toolchain go1.23.7
 
 require (
 	code.cloudfoundry.org/clock v1.28.0

--- a/assets/credhub-service-broker/go.mod
+++ b/assets/credhub-service-broker/go.mod
@@ -1,8 +1,8 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/credhub-service-broker
 
-go 1.22
+go 1.23
 
-toolchain go1.22.0
+toolchain go1.23.7
 
 require (
 	code.cloudfoundry.org/credhub-cli v0.0.0-20230320130818-a7d5420b283b

--- a/assets/go_calls_ruby/go.mod
+++ b/assets/go_calls_ruby/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/go_calls_ruby
 
-go 1.22
+go 1.23
 
-toolchain go1.22.0
+toolchain go1.23.7

--- a/assets/golang/go.mod
+++ b/assets/golang/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/golang
 
-go 1.22
+go 1.23
 
-toolchain go1.22.0
+toolchain go1.23.7

--- a/assets/golang/manifest.yml
+++ b/assets/golang/manifest.yml
@@ -2,4 +2,4 @@
 applications:
   - env:
       GOPACKAGENAME: go-online
-      GOVERSION: go1.22
+      GOVERSION: go1.23

--- a/assets/grpc/go.mod
+++ b/assets/grpc/go.mod
@@ -1,7 +1,8 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/grpc
 
-go 1.22
-toolchain go1.22.9
+go 1.23
+
+toolchain go1.23.7
 
 require (
 	google.golang.org/grpc v1.71.0

--- a/assets/http2/go.mod
+++ b/assets/http2/go.mod
@@ -1,8 +1,8 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/http2
 
-go 1.22
+go 1.23
 
-toolchain go1.22.0
+toolchain go1.23.7
 
 require golang.org/x/net v0.35.0
 

--- a/assets/logging-route-service/go.mod
+++ b/assets/logging-route-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry-samples/logging-route-service
 
-go 1.22
+go 1.23
 
-toolchain go1.22.0
+toolchain go1.23.7

--- a/assets/logging-route-service/manifest.yml
+++ b/assets/logging-route-service/manifest.yml
@@ -3,5 +3,5 @@ applications:
   - buildpacks:
       - go_buildpack
     env:
-      GOVERSION: go1.22
+      GOVERSION: go1.23
       GOPACKAGENAME: github.com/cloudfoundry-samples/logging-route-service

--- a/assets/multi-port-app/go.mod
+++ b/assets/multi-port-app/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/multi-port-app
 
-go 1.22
+go 1.23
 
-toolchain go1.22.0
+toolchain go1.23.7

--- a/assets/multi-port-app/manifest.yml
+++ b/assets/multi-port-app/manifest.yml
@@ -1,4 +1,4 @@
 ---
 applications:
   - env:
-      GOVERSION: go1.22
+      GOVERSION: go1.23

--- a/assets/pora/go.mod
+++ b/assets/pora/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/pora
 
-go 1.22
+go 1.23
 
-toolchain go1.22.0
+toolchain go1.23.7

--- a/assets/pora/manifest.yml
+++ b/assets/pora/manifest.yml
@@ -5,4 +5,4 @@ applications:
       - go_buildpack
     env:
       GOPACKAGENAME: pora
-      GOVERSION: go1.22
+      GOVERSION: go1.23

--- a/assets/proxy/go.mod
+++ b/assets/proxy/go.mod
@@ -1,5 +1,5 @@
 module example-apps/proxy
 
-go 1.22
+go 1.23
 
-toolchain go1.22.0
+toolchain go1.23.7

--- a/assets/proxy/internal-route-manifest.yml
+++ b/assets/proxy/internal-route-manifest.yml
@@ -6,6 +6,6 @@ applications:
     buildpack: go_buildpack
     env:
       GOPACKAGENAME: example-apps/proxy
-      GOVERSION: go1.22
+      GOVERSION: go1.23
     routes:
       - route: app-smoke.apps.internal

--- a/assets/proxy/manifest.yml
+++ b/assets/proxy/manifest.yml
@@ -7,4 +7,4 @@ applications:
       - go_buildpack
     env:
       GOPACKAGENAME: example-apps/proxy
-      GOVERSION: go1.22
+      GOVERSION: go1.23

--- a/assets/syslog-drain-listener/go.mod
+++ b/assets/syslog-drain-listener/go.mod
@@ -1,6 +1,7 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/syslog-drain-listener
 
-go 1.22
-toolchain go1.23.6
+go 1.23.0
+
+toolchain go1.23.7
 
 require code.cloudfoundry.org/tlsconfig v0.20.0

--- a/assets/syslog-drain-listener/manifest.yml
+++ b/assets/syslog-drain-listener/manifest.yml
@@ -3,4 +3,4 @@ applications:
   - name: syslog-drain-listener
     env:
       GOPACKAGENAME: main
-      GOVERSION: go1.22
+      GOVERSION: go1.23

--- a/assets/tcp-listener/go.mod
+++ b/assets/tcp-listener/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/tcp-listener
 
-go 1.22
+go 1.23
 
-toolchain go1.22.0
+toolchain go1.23.7

--- a/assets/tcp-listener/manifest.yml
+++ b/assets/tcp-listener/manifest.yml
@@ -2,4 +2,4 @@
 applications:
   - env:
       GOPACKAGENAME: tcp-listener
-      GOVERSION: go1.22
+      GOVERSION: go1.23

--- a/assets/worker/go.mod
+++ b/assets/worker/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/worker
 
-go 1.22
+go 1.23
 
-toolchain go1.22.0
+toolchain go1.23.7


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Bumps the minimum Go versions of all the Go assets to `1.23`, omitting the patch version due to handling issues with the Go buildpack in certain edge cases.

### Please provide contextual information.

- https://github.com/cloudfoundry/cf-acceptance-tests/commit/043a63ff66b5a67c36a14876edf9095d74b62783#commitcomment-145272348
- https://github.com/cloudfoundry/cf-acceptance-tests/pull/1195

### What version of cf-deployment have you run this cf-acceptance-test change against?

v48.4.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

None

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

None