### PR TITLE
remove unnneeded global rand.Seed logic

### DIFF
--- a/assets/pora/server.go
+++ b/assets/pora/server.go
@@ -297,13 +297,7 @@ func env(res http.ResponseWriter, req *http.Request) {
 	}
 }
 
-var isSeeded = false
-
 func randomString(n int) string {
-	if !isSeeded {
-		rand.Seed(time.Now().UnixNano())
-		isSeeded = true
-	}
 	runes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 	b := make([]rune, n)


### PR DESCRIPTION
since go 1.20 rand has been automatically seeded

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Calling rand.Seed globally is no longer needed. Since go 1.20 rand has been automatically seeded. go 1.20 was released in Feb 2022 and is no longer supported.

### Please provide contextual information.

* https://pkg.go.dev/math/rand@go1.20#Seed

### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

n/a

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
micoseconds faster!


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
