### PR TITLE
update default suite timeout to 24h, as ginkgov2 changed it to 1h

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -18,5 +18,5 @@ export RUN_ID
 
 pushd "${CATS_ROOT}" > /dev/null
   echo "Using $(go run github.com/onsi/ginkgo/v2/ginkgo version)"
-  go run github.com/onsi/ginkgo/v2/ginkgo --randomize-all --keep-going "$@"
+  go run github.com/onsi/ginkgo/v2/ginkgo --randomize-all --keep-going --timeout=24h "$@"
 popd > /dev/null


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes i did it right this time!

### What is this change about?

Ginkgo v2 changed the default suite timeout to 1hr which is too short for cats.

### Please provide contextual information.

We recommend people set it to 24h in the readme

### What version of cf-deployment have you run this cf-acceptance-test change against?

cats ref 562033f1  + cf-d v44.9.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
