### PR TITLE
Update file based service bindings according to updated RFC-0030

### DIFF
--- a/file_based_service_bindings/file_based_service_bindings.go
+++ b/file_based_service_bindings/file_based_service_bindings.go
@@ -59,7 +59,7 @@ var callback = func(lifecycle string) {
 		}
 		appGuid := app_helpers.GetAppGuid(appName)
 
-		appFeatureUrl := fmt.Sprintf("/v3/apps/%s/features/file-based-service-bindings", appGuid)
+		appFeatureUrl := fmt.Sprintf("/v3/apps/%s/features/service-binding-k8s", appGuid)
 		Expect(cf.Cf("curl", appFeatureUrl, "-X", "PATCH", "-d", `{"enabled": true}`).Wait()).To(Exit(0))
 
 		Expect(cf.Cf("bind-service", appName, serviceName).Wait()).To(Exit(0))

--- a/file_based_service_bindings/file_based_service_bindings.go
+++ b/file_based_service_bindings/file_based_service_bindings.go
@@ -1,38 +1,50 @@
 package file_based_service_bindings
 
 import (
-	"fmt"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/services"
+	"github.com/cloudfoundry/cf-test-helpers/v2/generator"
 
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/services"
 	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
-	"github.com/cloudfoundry/cf-test-helpers/v2/generator"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = FileBasedServiceBindingsDescribe("Enabling file based service binding for a buildpack app", BuildpackLifecycle, func() {
-	callback(BuildpackLifecycle)
+	callback(&BuildpackLifecycles{})
 })
 
 var _ = FileBasedServiceBindingsDescribe("Enabling file based service binding for a CNB app", CNBLifecycle, func() {
-	callback(CNBLifecycle)
+	callback(&CNBLifecycles{})
 })
 
 var _ = FileBasedServiceBindingsDescribe("Enabling file based service binding for a Docker app", DockerLifecycle, func() {
-	callback(DockerLifecycle)
+	callback(&DockerLifecycles{})
 })
 
-var callback = func(lifecycle string) {
+var callback = func(lifeCycle LifeCycle) {
 	var appName, serviceName string
-
 	BeforeEach(func() {
 		appName = random_name.CATSRandomName("APP")
 		serviceName = generator.PrefixedRandomName("cats", "svin") // uppercase characters are not valid
+	})
+
+	Context("When the file-based-vcap-services feature enabled", func() {
+		It("It should store the VCAP_SERVICE binding information in file in the VCAP_SERVICES_FILE_PATH", func() {
+			appGuid, serviceGuid := lifeCycle.Prepare(serviceName, appName, "file-based-vcap-services")
+			services.ValidateFileBasedVcapServices(appName, serviceName, appGuid, serviceGuid)
+
+		})
+	})
+
+	Context("When the service-binding-k8s feature enabled", func() {
+		It("It should have environment variable SERVICE_BINDING_ROOT which defines the location for the service binding", func() {
+			appGuid, serviceGuid := lifeCycle.Prepare(serviceName, appName, "service-binding-k8s")
+			services.ValidateServiceBindingK8s(appName, serviceName, appGuid, serviceGuid)
+		})
 	})
 
 	AfterEach(func() {
@@ -42,53 +54,4 @@ var callback = func(lifecycle string) {
 		Eventually(cf.Cf("delete-service", serviceName, "-f").Wait()).Should(Exit(0))
 	})
 
-	It("creates the required files in the app container", func() {
-		tags := "list, of, tags"
-		creds := `{"username": "admin", "password":"pa55woRD"}`
-		Expect(cf.Cf("create-user-provided-service", serviceName, "-p", creds, "-t", tags).Wait()).To(Exit(0))
-		serviceGuid := services.GetServiceInstanceGuid(serviceName)
-
-		if lifecycle == BuildpackLifecycle {
-			Expect(cf.Cf("create-app", appName).Wait()).To(Exit(0))
-		}
-		if lifecycle == CNBLifecycle {
-			Expect(cf.Cf("create-app", appName, "--app-type", "cnb", "--buildpack", Config.GetGoBuildpackName()).Wait()).To(Exit(0))
-		}
-		if lifecycle == DockerLifecycle {
-			Expect(cf.Cf("create-app", appName, "--app-type", "docker").Wait()).To(Exit(0))
-		}
-		appGuid := app_helpers.GetAppGuid(appName)
-
-		appFeatureUrl := fmt.Sprintf("/v3/apps/%s/features/service-binding-k8s", appGuid)
-		Expect(cf.Cf("curl", appFeatureUrl, "-X", "PATCH", "-d", `{"enabled": true}`).Wait()).To(Exit(0))
-
-		Expect(cf.Cf("bind-service", appName, serviceName).Wait()).To(Exit(0))
-
-		if lifecycle == BuildpackLifecycle {
-			Expect(cf.Cf(app_helpers.CatnipWithArgs(
-				appName,
-				"-m", DEFAULT_MEMORY_LIMIT)...,
-			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-		}
-		if lifecycle == CNBLifecycle {
-			Expect(cf.Cf(
-				"push",
-				appName,
-				"--lifecycle", "cnb",
-				"--buildpack", Config.GetCNBGoBuildpackName(),
-				"-m", DEFAULT_MEMORY_LIMIT,
-				"-p", assets.NewAssets().CatnipSrc,
-			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-		}
-		if lifecycle == DockerLifecycle {
-			Expect(cf.Cf(
-				"push",
-				appName,
-				"--docker-image", Config.GetCatnipDockerAppImage(),
-				"-m", DEFAULT_MEMORY_LIMIT,
-			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-		}
-
-		services.ValidateFileBasedServicebinding(appName, serviceName, appGuid, serviceGuid)
-	})
 }

--- a/file_based_service_bindings/life_cycles.go
+++ b/file_based_service_bindings/life_cycles.go
@@ -1,0 +1,85 @@
+package file_based_service_bindings
+
+import (
+	"fmt"
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/services"
+	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+type LifeCycle interface {
+	Prepare(string, string, string) (string, string)
+}
+
+type BuildpackLifecycles struct{}
+type CNBLifecycles struct{}
+type DockerLifecycles struct{}
+
+func (b *BuildpackLifecycles) Prepare(serviceName, appName, appFeatureFlag string) (string, string) {
+
+	Expect(cf.Cf("create-app", appName).Wait()).To(Exit(0))
+	appGuid, serviceGuid := LifeCycleCommon(serviceName, appName, appFeatureFlag)
+
+	Expect(cf.Cf(app_helpers.CatnipWithArgs(
+		appName,
+		"-m", DEFAULT_MEMORY_LIMIT)...,
+	).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+	return appGuid, serviceGuid
+
+}
+
+func (c *CNBLifecycles) Prepare(serviceName, appName, appFeatureFlag string) (string, string) {
+
+	Expect(cf.Cf("create-app", appName, "--app-type", "cnb", "--buildpack", Config.GetGoBuildpackName()).Wait()).To(Exit(0))
+	appGuid, serviceGuid := LifeCycleCommon(serviceName, appName, appFeatureFlag)
+
+	Expect(cf.Cf(
+		"push",
+		appName,
+		"--lifecycle", "cnb",
+		"--buildpack", Config.GetCNBGoBuildpackName(),
+		"-m", DEFAULT_MEMORY_LIMIT,
+		"-p", assets.NewAssets().CatnipSrc,
+	).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+	return appGuid, serviceGuid
+}
+
+func (d *DockerLifecycles) Prepare(serviceName, appName, appFeatureFlag string) (string, string) {
+
+	Expect(cf.Cf("create-app", appName, "--app-type", "docker").Wait()).To(Exit(0))
+	appGuid, serviceGuid := LifeCycleCommon(serviceName, appName, appFeatureFlag)
+
+	Expect(cf.Cf(
+		"push",
+		appName,
+		"--docker-image", Config.GetCatnipDockerAppImage(),
+		"-m", DEFAULT_MEMORY_LIMIT,
+	).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+	return appGuid, serviceGuid
+}
+
+const (
+	TAGS  = "list, of, tags"
+	CREDS = `{"username": "admin", "password":"pa55woRD"}`
+)
+
+func LifeCycleCommon(serviceName, appName, appFeatureFlag string) (string, string) {
+
+	Expect(cf.Cf("create-user-provided-service", serviceName, "-p", CREDS, "-t", TAGS).Wait()).To(Exit(0))
+	serviceGuid := services.GetServiceInstanceGuid(serviceName)
+
+	appGuid := app_helpers.GetAppGuid(appName)
+
+	appFeatureUrl := fmt.Sprintf("/v3/apps/%s/features/%s", appGuid, appFeatureFlag)
+	Expect(cf.Cf("curl", appFeatureUrl, "-X", "PATCH", "-d", `{"enabled": true}`).Wait()).To(Exit(0))
+
+	Expect(cf.Cf("bind-service", appName, serviceName).Wait()).To(Exit(0))
+
+	return appGuid, serviceGuid
+}

--- a/helpers/services/vcap_services_json_struct.go
+++ b/helpers/services/vcap_services_json_struct.go
@@ -1,0 +1,34 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type UserProvided struct {
+	Label        string   `json:"label"`
+	Name         string   `json:"name"`
+	Tags         []string `json:"tags"`
+	InstanceGUID string   `json:"instance_guid"`
+	InstanceName string   `json:"instance_name"`
+	BindingGUID  string   `json:"binding_guid"`
+	BindingName  string   `json:"binding_name"`
+	Credentials  struct {
+		Password string `json:"password"`
+		Username string `json:"username"`
+	} `json:"credentials"`
+}
+
+type VCAPServicesFile struct {
+	UserProvided []UserProvided `json:"user-provided"`
+}
+
+func (v *VCAPServicesFile) ReadFromString(response string) error {
+	err := json.Unmarshal([]byte(response), v)
+
+	if err != nil {
+		fmt.Println("Error unmarshaling JSON:", err)
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
### What is this change about?
Implemented Test Cases for file based service bindings. We implemented  for `file-based-vcap-services`  option. 

### Please provide contextual information.
Please check the following link: 
https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0030-add-support-for-file-based-service-binding.md

### What version of cf-deployment have you run this cf-acceptance-test change against?
v48.5.0


### Please check all that apply for this PR:

- [x] introduces a new test --- Are you sure everyone should be running this test? 
Test is active only when `include_file_based_service_bindings` flag is set to true
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?
We want to test both mode that described in RFC-0030

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
4m46s


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

