### PR TITLE
Cleanup shared TCP domain after in AfterEach()

### DIFF
--- a/tcp_routing/tcp_routing.go
+++ b/tcp_routing/tcp_routing.go
@@ -36,6 +36,12 @@ var _ = TCPRoutingDescribe("TCP Routing", func() {
 		})
 	})
 
+	AfterEach(func() {
+		workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+			Expect(cf.Cf("delete-shared-domain", domainName).Wait()).To(Exit())
+		})
+	})
+
 	Context("external ports", func() {
 		var (
 			appName            string


### PR DESCRIPTION
### What is this change about?

`cf create-shared-domain` is not idempotent and will fail if the domain already exists (e.g. from a previous CATs run that failed for some other reason), so delete the domain in `AfterEach()`.

### Please provide contextual information.

This CATs run was green and created the domain:
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/fips-cats/builds/903

The two subsequent CATs runs were red because the domain already existed:
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/fips-cats/builds/904
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/fips-cats/builds/905

### What version of cf-deployment have you run this cf-acceptance-test change against?

v49.0.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

A few seconds to execute `cf delete-shared-domain`.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
