### PR TITLE
Ipv6 validation for Golang

### DIFF
--- a/assets/golang/site.go
+++ b/assets/golang/site.go
@@ -2,29 +2,119 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"log"
+	"net"
 	"net/http"
 	"os"
+	"time"
 )
 
+type EndpointType struct {
+	validationName string
+	path           string
+}
+
+var endpointTypeMap = map[string]EndpointType{
+	"api.ipify.org": {
+		validationName: "IPv4",
+		path:           "/ipv4-test",
+	},
+	"api6.ipify.org": {
+		validationName: "IPv6",
+		path:           "/ipv6-test",
+	},
+	"api64.ipify.org": {
+		validationName: "Dual stack",
+		path:           "/dual-stack-test",
+	},
+}
+
 func main() {
-	http.HandleFunc("/", hello)
+	http.HandleFunc("/", handleRequest)
 	http.HandleFunc("/requesturi/", echo)
-	fmt.Println("listening...")
+
+	log.Printf("Starting server on %s\n", os.Getenv("PORT"))
 
 	server := &http.Server{
 		Addr:    fmt.Sprintf(":%s", os.Getenv("PORT")),
-		Handler: nil,
 	}
-	err := server.ListenAndServe()
-	if err != nil {
-		panic(err)
+
+	if err := server.ListenAndServe(); err != nil {
+		log.Fatalf("Could not start server: %s\n", err)
 	}
 }
 
+func handleRequest(res http.ResponseWriter, req *http.Request) {
+	for endpoint, data := range endpointTypeMap {
+		if req.URL.Path == data.path {
+			testEndpoint(res, endpoint, data.validationName)
+			return
+		}
+	}
+
+	hello(res, req)
+}
+
 func hello(res http.ResponseWriter, req *http.Request) {
-	fmt.Fprintln(res, "go, world")
+	fmt.Fprintln(res, "Hello go, world")
 }
 
 func echo(res http.ResponseWriter, req *http.Request) {
 	fmt.Fprintln(res, fmt.Sprintf("Request URI is [%s]\nQuery String is [%s]", req.RequestURI, req.URL.RawQuery))
+}
+
+func testEndpoint(res http.ResponseWriter, endpoint, validationName string) {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	resp, err := client.Get(fmt.Sprintf("http://%s", endpoint))
+	if err != nil {
+		log.Printf("Failed to reach %s: %v\n", endpoint, err)
+		writeTestResponse(res, validationName, false, "Unknown", err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("Error reading response: %v\n", err)
+		writeTestResponse(res, validationName, false, "Unknown", err.Error())
+		return
+	}
+
+	ipType := determineIPType(string(body))
+	success := resp.StatusCode == http.StatusOK
+
+	writeTestResponse(res, validationName, success, ipType, "")
+}
+
+func writeTestResponse(res http.ResponseWriter, validationName string, success bool, ipType, errorMsg string) {
+	responseCode := http.StatusInternalServerError
+	if success {
+		responseCode = http.StatusOK
+	}
+	res.WriteHeader(responseCode)
+
+	if errorMsg == "" {
+		errorMsg = "none"
+	}
+
+	message := fmt.Sprintf("%s validation resulted in %s. Detected IP type is %s. Error message: %s.\n",
+		validationName, map[bool]string{true: "success", false: "failure"}[success], ipType, errorMsg)
+	res.Write([]byte(message))
+}
+
+func determineIPType(ipString string) string {
+	ip := net.ParseIP(ipString)
+	if ip == nil {
+		return "Invalid IP"
+	}
+
+	if ip.To4() != nil {
+		return "IPv4"
+	}
+
+	return "IPv6"
 }

--- a/ipv6/ipv6.go
+++ b/ipv6/ipv6.go
@@ -81,7 +81,7 @@ var _ = IPv6Describe("IPv6 Connectivity Tests", func() {
 				})
 			})
 
-			Context(fmt.Sprintf("Using Node.js stack: %s", stack), func() {
+			Context(fmt.Sprintf("Using Golang stack: %s", stack), func() {
 				It("validates IPv6 egress for Golang App", func() {
 					describeIPv6Tests(assets.NewAssets().Golang, stack)
 				})

--- a/ipv6/ipv6.go
+++ b/ipv6/ipv6.go
@@ -80,6 +80,12 @@ var _ = IPv6Describe("IPv6 Connectivity Tests", func() {
 					describeIPv6Tests(assets.NewAssets().Node, stack)
 				})
 			})
+
+			Context(fmt.Sprintf("Using Node.js stack: %s", stack), func() {
+				It("validates IPv6 egress for Node.js App", func() {
+					describeIPv6Tests(assets.NewAssets().Golang, stack)
+				})
+			})
 		}
 	})
 })

--- a/ipv6/ipv6.go
+++ b/ipv6/ipv6.go
@@ -82,7 +82,7 @@ var _ = IPv6Describe("IPv6 Connectivity Tests", func() {
 			})
 
 			Context(fmt.Sprintf("Using Node.js stack: %s", stack), func() {
-				It("validates IPv6 egress for Node.js App", func() {
+				It("validates IPv6 egress for Golang App", func() {
 					describeIPv6Tests(assets.NewAssets().Golang, stack)
 				})
 			})


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes.

### What is this change about?

The change is part of the ipv6 egress validation cycle. We progressively extend all of the exciting buildpacks relevant to our ecosystem.  In this PR we provide additional endpoints in the Golang application for testing IPv6 support. In case ipv6 validation is enabled, we verify that egress ipv6 call are possible with Go applications. 

### Please provide contextual information.

https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0038-ipv6-dual-stack-for-cf.md

### What version of cf-deployment have you run this cf-acceptance-test change against?

v48.9.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate IPv6 egress calls with Golang application. We add changes regarding to this buildpack only. The test group for ipv6 was already created.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Around 90 seconds per test.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@oliver-heinrich @iaftab-alam 
