### PR TITLE
Change CNB registry to docker.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Many tests specify a buildpack when pushing an app, so that on diego the app sta
 
 For the Cloud Native Buildpacks lifecycle, you can override them by setting different names:
 
-* `cnb_nodejs_buildpack_name: docker://gcr.io/paketo-buildpacks/nodejs:latest`
+* `cnb_nodejs_buildpack_name: docker://docker.io/paketobuildpacks/nodejs:latest`
 
 #### Route Services Test Group Setup
 The `route_services` test group pushes applications which must be able to reach the load balancer of your Cloud Foundry deployment. This requires configuring application security groups to support this. Your deployment manifest should include the following data if you are running the `route_services` group:

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -169,8 +169,8 @@ func getDefaults() config {
 	defaults.StaticFileBuildpackName = ptrToString("staticfile_buildpack")
 	defaults.PythonBuildpackName = ptrToString("python_buildpack")
 
-	defaults.CNBGoBuildpackName = ptrToString("docker://gcr.io/paketo-buildpacks/go:latest")
-	defaults.CNBNodejsBuildpackName = ptrToString("docker://gcr.io/paketo-buildpacks/nodejs:latest")
+	defaults.CNBGoBuildpackName = ptrToString("docker://docker.io/paketobuildpacks/go:latest")
+	defaults.CNBNodejsBuildpackName = ptrToString("docker://docker.io/paketobuildpacks/nodejs:latest")
 
 	defaults.IncludeAppSyslogTCP = ptrToBool(true)
 	defaults.IncludeApps = ptrToBool(true)


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._
Yes.

### What is this change about?

_Describe the change and why it's needed._
We change the registry for Cloud Native Buildpacks from gcr.io to docker.io.

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._
Paketo stopped providing images on gcr.io. See [blog](https://blog.paketo.io/posts/paketo-gcr-registry-sunset/).

### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?



### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
