### PR TITLE
IPv6 validation for Nginx

### DIFF
--- a/assets/nginx/nginx.conf
+++ b/assets/nginx/nginx.conf
@@ -9,5 +9,24 @@ http {
        location = / {
             return 200 "Hello NGINX!";
        }
-   }
+
+        location /ipv4-test {
+            proxy_pass https://api4.ipify.org/?format=json;
+            proxy_set_header Host api4.ipify.org;
+            proxy_ssl_server_name on;
+           }
+
+       location /ipv6-test {
+             proxy_pass https://api6.ipify.org/?format=json;
+             proxy_set_header Host api6.ipify.org;
+             proxy_ssl_server_name on;
+            }
+
+       location /dual-stack-test {
+             proxy_pass https://api64.ipify.org/?format=json;
+             proxy_set_header Host api64.ipify.org;
+             proxy_ssl_server_name on;
+            }
+
+       }
 }


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes.

### What is this change about?

The change is part of the IPv6 egress validation cycle. We progressively extend all of the exciting buildpacks relevant to our ecosystem.  In this PR we provide additional endpoints in the Nginx application for testing IPv6 support. In case ipv6 validation is enabled, we verify that egress IPv6 calls are possible with Nginx applications.  

### Please provide contextual information.

https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0038-ipv6-dual-stack-for-cf.md

### What version of cf-deployment have you run this cf-acceptance-test change against?

v48.9.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate IPv6 egress calls with Nginx application. We add changes regarding to this buildpack only. The test group for ipv6 was already created.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Around 90 seconds per test.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@oliver-heinrich @iaftab-alam 
