### PR TITLE
Fix left overs from PR#1564

### DIFF
--- a/route_services/route_services.go
+++ b/route_services/route_services.go
@@ -86,7 +86,7 @@ var _ = RouteServicesDescribe("Route Services", func() {
 					logs := logshelper.Recent(routeServiceName)
 					Expect(logs.Wait()).To(Exit(0))
 					return logs
-				}).Should(Say("Response Body: go, world"))
+				}).Should(Say("Response Body: Hello go, world"))
 			})
 		})
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

### What is this change about?

There were some left overs from  [PR](https://github.com/cloudfoundry/cf-acceptance-tests/pull/1564). This PR aim to fix this.

### Please provide contextual information.

The existing go lang app was changed with this [PR](https://github.com/cloudfoundry/cf-acceptance-tests/pull/1564) that introduces new group and made changes to already existing check, which needs to be propagated where is is consumed.

### What version of cf-deployment have you run this cf-acceptance-test change against?

N/A

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
N/A


### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
