### PR TITLE
IPv6 validation for PHP apps

### DIFF
--- a/assets/php/htdocs/.htaccess
+++ b/assets/php/htdocs/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^(ipv4-test|ipv6-test|dual-stack-test)$ $1.php [L]

--- a/assets/php/htdocs/dual-stack-test.php
+++ b/assets/php/htdocs/dual-stack-test.php
@@ -1,0 +1,25 @@
+<?php
+
+require 'ip_functions.php';
+
+$url = 'https://api64.ipify.org?format=json';
+list($response, $curlError) = fetchIpAddress($url);
+
+if ($response === false) {
+    $validationType = "Dual-stack";
+    $message = createResponseMessage($validationType, false, "unknown", $curlError);
+    echo $message;
+    exit;
+}
+
+$data = json_decode($response, true);
+$ip = $data['ip'] ?? null;
+
+$ipType = determineIpType($ip);
+$isSuccess = $ipType === "IPv4" || $ipType === "IPv6";
+
+$validationType = "Dual stack";
+$message = createResponseMessage($validationType, $isSuccess, $ipType, $isSuccess ? "none" : "failure");
+echo $message;
+
+?>

--- a/assets/php/htdocs/ip_functions.php
+++ b/assets/php/htdocs/ip_functions.php
@@ -1,0 +1,32 @@
+<?php
+
+function determineIpType($ip) {
+    if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+        return "IPv4";
+    } elseif (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+        return "IPv6";
+    }
+    return "Invalid IP";
+}
+
+function createResponseMessage($validationType, $isSuccess, $ipType, $errorMessage = "none") {
+    $status = $isSuccess ? "success" : "failure";
+    return "$validationType validation resulted in $status. Detected IP type is $ipType. Error message: $errorMessage.";
+}
+
+function fetchIpAddress($url) {
+    $curlHandle = curl_init($url);
+    curl_setopt_array($curlHandle, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_FAILONERROR => true,
+        CURLOPT_TIMEOUT => 5,
+    ]);
+
+    $response = curl_exec($curlHandle);
+    $error = curl_error($curlHandle);
+    curl_close($curlHandle);
+
+    return [$response, $error];
+}
+
+?>

--- a/assets/php/htdocs/ipv4-test.php
+++ b/assets/php/htdocs/ipv4-test.php
@@ -1,0 +1,25 @@
+<?php
+
+require 'ip_functions.php';
+
+$url = 'https://api.ipify.org?format=json';
+list($response, $curlError) = fetchIpAddress($url);
+
+if ($response === false) {
+    $validationType = "IPv4";
+    $message = createResponseMessage($validationType, false, "unknown", $curlError);
+    echo $message;
+    exit;
+}
+
+$data = json_decode($response, true);
+$ip = $data['ip'] ?? null;
+
+$ipType = determineIpType($ip);
+$isSuccess = $ipType === "IPv4";
+
+$validationType = "IPv4";
+$message = createResponseMessage($validationType, $isSuccess, $ipType, $isSuccess ? "none" : "failure");
+echo $message;
+
+?>

--- a/assets/php/htdocs/ipv6-test.php
+++ b/assets/php/htdocs/ipv6-test.php
@@ -1,0 +1,25 @@
+<?php
+
+require 'ip_functions.php';
+
+$url = 'https://api6.ipify.org?format=json';
+list($response, $curlError) = fetchIpAddress($url);
+
+if ($response === false) {
+    $validationType = "IPv6";
+    $message = createResponseMessage($validationType, false, "unknown", $curlError);
+    echo $message;
+    exit;
+}
+
+$data = json_decode($response, true);
+$ip = $data['ip'] ?? null;
+
+$ipType = determineIpType($ip);
+$isSuccess = $ipType === "IPv6";
+
+$validationType = "IPv6";
+$message = createResponseMessage($validationType, $isSuccess, $ipType, $isSuccess ? "none" : "failure");
+echo $message;
+
+?>

--- a/ipv6/ipv6.go
+++ b/ipv6/ipv6.go
@@ -100,6 +100,12 @@ var _ = IPv6Describe("IPv6 Connectivity Tests", func() {
 					describeIPv6Tests(assets.NewAssets().Golang, stack)
 				})
 			})
+
+            Context(fmt.Sprintf("Using PHP stack: %s", stack), func() {
+                It("validates IPv6 egress for PHP App", func() {
+                    describeIPv6Tests(assets.NewAssets().Php, stack)
+                })
+            })
 		}
 	})
 })


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes.

### What is this change about?

The change is part of the ipv6 egress validation cycle. We progressively extend all of the exciting buildpacks relevant to our ecosystem. In this PR we provide additional endpoints in the PHP application for testing IPv6 support. In case IPv6 validation is enabled, we verify that egress IPv6 calls are possible with PHP applications.

### Please provide contextual information.

https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0038-ipv6-dual-stack-for-cf.md

### What version of cf-deployment have you run this cf-acceptance-test change against?

v48.9.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate IPv6 egress calls with PHP application. We add changes regarding to this buildpack only. The test group for IPv6 was already created.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Around 90 seconds per test.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@oliver-heinrich @iaftab-alam 
