### PR TITLE
Adjust bosh-lite domain

### DIFF
--- a/assets/service_broker/README.md
+++ b/assets/service_broker/README.md
@@ -181,7 +181,7 @@ as specified, and then makes the corresponding cf cli command. The CLI output is
 name as the input file with a "-out" suffix. (For example, acceptance.csv becomes acceptance-out.csv)
 
 If the caller provides a broker URL, the script will use that address for its test cases, otherwise it will default to 
-async-broker.bosh-lite.com.
+async-broker.bosh-lite.env.wg-ard.ci.cloudfoundry.org.
 
 The script also preforms setup and cleanup for each test it executes. e.g. performing an update requires a setup which
 creates an instance and cleanup which deletes it.

--- a/assets/service_broker/data.json
+++ b/assets/service_broker/data.json
@@ -180,7 +180,7 @@
         "sleep_seconds": 0,
         "status": 201,
         "body": {
-          "route_service_url": "https://logging-route-service.bosh-lite.com",
+          "route_service_url": "https://logging-route-service.bosh-lite.env.wg-ard.ci.cloudfoundry.org",
           "credentials": {
             "uri": "fake-service://fake-user:fake-password@fake-host:3306/fake-dbname",
             "username": "fake-user",

--- a/assets/service_broker/run_all_cases.rb
+++ b/assets/service_broker/run_all_cases.rb
@@ -6,7 +6,7 @@ require 'benchmark'
 require 'securerandom'
 require 'optparse'
 
-DEFAULT_BROKER_URL = 'http://async-broker.bosh-lite.com'
+DEFAULT_BROKER_URL = 'http://async-broker.bosh-lite.env.wg-ard.ci.cloudfoundry.org'
 
 def get_config
   raw_config = File.read('data.json')

--- a/bin/catsconfiggenerator/main.go
+++ b/bin/catsconfiggenerator/main.go
@@ -10,11 +10,11 @@ import (
 )
 
 var requiredConfig = `{
-  "api": "api.bosh-lite.com",
+  "api": "api.bosh-lite.env.wg-ard.ci.cloudfoundry.org",
   "admin_user": "admin",
   "admin_password": "password",
   "skip_ssl_validation": false,
-  "apps_domain": "cf-app.bosh-lite.com",
+  "apps_domain": "cf-app.bosh-lite.env.wg-ard.ci.cloudfoundry.org",
   "use_http": false
 }`
 

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -203,6 +203,7 @@ type testReporterConfig struct {
 	CustomTags        map[string]interface{} `json:"custom_tags"`
 }
 
+const BoshLiteDomain = "bosh-lite.env.wg-ard.ci.cloudfoundry.org"
 var tmpFilePath string
 var testCfg testConfig
 
@@ -240,11 +241,11 @@ func ptrToFloat(f float64) *float64 {
 var _ = Describe("Config", func() {
 	BeforeEach(func() {
 		testCfg = testConfig{}
-		testCfg.ApiEndpoint = ptrToString("api.bosh-lite.com")
+		testCfg.ApiEndpoint = ptrToString(BoshLiteDomain)
 		testCfg.AdminUser = ptrToString("admin")
 		testCfg.AdminPassword = ptrToString("admin")
 		testCfg.SkipSSLValidation = ptrToBool(true)
-		testCfg.AppsDomain = ptrToString("cf-app.bosh-lite.com")
+		testCfg.AppsDomain = ptrToString(BoshLiteDomain)
 		testCfg.UseHttp = ptrToBool(false)
 	})
 
@@ -826,12 +827,12 @@ var _ = Describe("Config", func() {
 		It(`returns the URL`, func() {
 			cfg, err := cfg.NewCatsConfig(tmpFilePath)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(cfg.GetApiEndpoint()).To(Equal("api.bosh-lite.com"))
+			Expect(cfg.GetApiEndpoint()).To(Equal("api." + BoshLiteDomain))
 		})
 
 		Context("when url is an IP address", func() {
 			BeforeEach(func() {
-				testCfg.ApiEndpoint = ptrToString("10.244.0.34") // api.bosh-lite.com
+				testCfg.ApiEndpoint = ptrToString("10.244.0.34") // api.bosh-lite.env.wg-ard.ci.cloudfoundry.org
 			})
 
 			It("returns the IP address", func() {
@@ -879,13 +880,13 @@ var _ = Describe("Config", func() {
 
 		Context("when the url contains https://", func() {
 			BeforeEach(func() {
-				testCfg.ApiEndpoint = ptrToString("https://api.bosh-lite.com")
+				testCfg.ApiEndpoint = ptrToString("https://api." + BoshLiteDomain)
 			})
 
 			It("returns an error", func() {
 				_, err := cfg.NewCatsConfig(tmpFilePath)
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError("* Invalid configuration: 'api' must not contain a scheme/protocol but was set to 'https' in 'https://api.bosh-lite.com'"))
+				Expect(err).To(MatchError("* Invalid configuration: 'api' must not contain a scheme/protocol but was set to 'https' in 'https://api." + BoshLiteDomain + "'"))
 			})
 		})
 
@@ -906,7 +907,7 @@ var _ = Describe("Config", func() {
 		It("returns the domain", func() {
 			c, err := cfg.NewCatsConfig(tmpFilePath)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(c.GetAppsDomain()).To(Equal("cf-app.bosh-lite.com"))
+			Expect(c.GetAppsDomain()).To(Equal("cf-app." + BoshLiteDomain))
 		})
 
 		Context("when the domain is not valid", func() {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -241,11 +241,11 @@ func ptrToFloat(f float64) *float64 {
 var _ = Describe("Config", func() {
 	BeforeEach(func() {
 		testCfg = testConfig{}
-		testCfg.ApiEndpoint = ptrToString(BoshLiteDomain)
+		testCfg.ApiEndpoint = ptrToString("api." + BoshLiteDomain)
 		testCfg.AdminUser = ptrToString("admin")
 		testCfg.AdminPassword = ptrToString("admin")
 		testCfg.SkipSSLValidation = ptrToBool(true)
-		testCfg.AppsDomain = ptrToString(BoshLiteDomain)
+		testCfg.AppsDomain = ptrToString("cf-app." + BoshLiteDomain)
 		testCfg.UseHttp = ptrToBool(false)
 	})
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes.

### What is this change about?

Adjust bosh-lite domain to "bosh-lite.env.wg-ard.ci.cloudfoundry.org"

### Please provide contextual information.

CATs unit tests ([run-unit-tests](https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cats/jobs/run-unit-tests)) are currently failing due to [bosh-lite.com](http://bosh-lite.com/) was shut down.

An A record *.[bosh-lite.env.wg-ard.ci.cloudfoundry.org](http://bosh-lite.env.wg-ard.ci.cloudfoundry.org/) is added to our DNS zone.


### What version of cf-deployment have you run this cf-acceptance-test change against?
N/A

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A


### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
