### PR TITLE
New asset for nginx ipv6 validation

### DIFF
--- a/assets/nginx-ipv6/nginx.conf
+++ b/assets/nginx-ipv6/nginx.conf
@@ -1,0 +1,32 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen {{port}};
+
+        location = / {
+            return 200 "Hello NGINX!";
+        }
+
+        location /ipv4-test {
+            proxy_pass https://api4.ipify.org/?format=json;
+            proxy_set_header Host api4.ipify.org;
+            proxy_ssl_server_name on;
+        }
+
+        location /ipv6-test {
+            proxy_pass https://api6.ipify.org/?format=json;
+            proxy_set_header Host api6.ipify.org;
+            proxy_ssl_server_name on;
+        }
+
+        location /dual-stack-test {
+            proxy_pass https://api64.ipify.org/?format=json;
+            proxy_set_header Host api64.ipify.org;
+            proxy_ssl_server_name on;
+        }
+    }
+}
+

--- a/assets/nginx/nginx.conf
+++ b/assets/nginx/nginx.conf
@@ -1,31 +1,13 @@
 events {
-    worker_connections 1024;
+   worker_connections  1024;
 }
 
 http {
-    server {
-        listen {{port}};
+   server {
+       listen {{port}};
 
-        location = / {
+       location = / {
             return 200 "Hello NGINX!";
-        }
-
-        location /ipv4-test {
-            proxy_pass https://api4.ipify.org/?format=json;
-            proxy_set_header Host api4.ipify.org;
-            proxy_ssl_server_name on;
-        }
-
-        location /ipv6-test {
-            proxy_pass https://api6.ipify.org/?format=json;
-            proxy_set_header Host api6.ipify.org;
-            proxy_ssl_server_name on;
-        }
-
-        location /dual-stack-test {
-            proxy_pass https://api64.ipify.org/?format=json;
-            proxy_set_header Host api64.ipify.org;
-            proxy_ssl_server_name on;
-        }
-    }
+       }
+   }
 }

--- a/helpers/assets/assets.go
+++ b/helpers/assets/assets.go
@@ -23,6 +23,7 @@ type Assets struct {
 	Python                     string
 	PythonCrashApp             string
 	Nginx                      string
+	NginxIPv6                  string
 	Node                       string
 	CNBNode                    string
 	NodeWithProcfile           string
@@ -70,6 +71,7 @@ func NewAssets() Assets {
 		LoggregatorLoadGenerator:   "assets/loggregator-load-generator",
 		LoggregatorLoadGeneratorGo: "assets/loggregator-load-generator-go",
 		Nginx:                      "assets/nginx",
+		NginxIPv6:                  "assets/nginx-ipv6",
 		Node:                       "assets/node",
 		CNBNode:                    "assets/cnb-node",
 		NodeWithProcfile:           "assets/node-with-procfile",

--- a/ipv6/ipv6.go
+++ b/ipv6/ipv6.go
@@ -3,7 +3,6 @@ package ipv6
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
@@ -14,8 +13,8 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 	"net"
+	"os"
 )
-
 
 var _ = IPv6Describe("IPv6 Connectivity Tests", func() {
 	var appName string
@@ -78,45 +77,45 @@ var _ = IPv6Describe("IPv6 Connectivity Tests", func() {
 	}
 
 	describeIpv6NginxTest := func(assetPath, stack string) {
-        pushSession := cf.Cf("push", appName, "-s", stack, "-p", assetPath, "-m", DEFAULT_MEMORY_LIMIT)
-        Expect(pushSession.Wait(Config.DetectTimeoutDuration())).To(Exit(0))
+		pushSession := cf.Cf("push", appName, "-s", stack, "-p", assetPath, "-m", DEFAULT_MEMORY_LIMIT)
+		Expect(pushSession.Wait(Config.DetectTimeoutDuration())).To(Exit(0))
 
-        isIPv4 := func(ip string) bool {
-            parsedIP := net.ParseIP(ip)
-            return parsedIP != nil && parsedIP.To4() != nil
-        }
+		isIPv4 := func(ip string) bool {
+			parsedIP := net.ParseIP(ip)
+			return parsedIP != nil && parsedIP.To4() != nil
+		}
 
-        isIPv6 := func(ip string) bool {
-            parsedIP := net.ParseIP(ip)
-            return parsedIP != nil && parsedIP.To4() == nil
-        }
+		isIPv6 := func(ip string) bool {
+			parsedIP := net.ParseIP(ip)
+			return parsedIP != nil && parsedIP.To4() == nil
+		}
 
-        for key, data := range EndpointTypeMap {
-            response := helpers.CurlApp(Config, appName, data.path)
+		for key, data := range EndpointTypeMap {
+			response := helpers.CurlApp(Config, appName, data.path)
 
-            if key == "default" {
-                Expect(response).To(ContainSubstring("Hello NGINX!"))
-            } else {
-                var result map[string]interface{}
-                Expect(json.Unmarshal([]byte(response), &result)).To(Succeed())
-                ip, ok := result["ip"].(string)
-                Expect(ok).To(BeTrue())
+			if key == "default" {
+				Expect(response).To(ContainSubstring("Hello NGINX!"))
+			} else {
+				var result map[string]interface{}
+				Expect(json.Unmarshal([]byte(response), &result)).To(Succeed())
+				ip, ok := result["ip"].(string)
+				Expect(ok).To(BeTrue())
 
-                validationResult := false
+				validationResult := false
 
-                switch data.validationName {
-                case "IPv4":
-                    validationResult = isIPv4(ip)
-                case "IPv6":
-                    validationResult = isIPv6(ip)
-                case "Dual stack":
-                    validationResult = isIPv4(ip) || isIPv6(ip)
-                }
+				switch data.validationName {
+				case "IPv4":
+					validationResult = isIPv4(ip)
+				case "IPv6":
+					validationResult = isIPv6(ip)
+				case "Dual stack":
+					validationResult = isIPv4(ip) || isIPv6(ip)
+				}
 
-                Expect(validationResult).To(BeTrue(), fmt.Sprintf("%s validation failed with the following error: %s", data.validationName, ip))
-            }
-        }
-    }
+				Expect(validationResult).To(BeTrue(), fmt.Sprintf("%s validation failed with the following error: %s", data.validationName, ip))
+			}
+		}
+	}
 
 	Describe("Egress Capability in Apps", func() {
 		for _, stack := range Config.GetStacks() {
@@ -147,7 +146,7 @@ var _ = IPv6Describe("IPv6 Connectivity Tests", func() {
 
 			Context(fmt.Sprintf("Using Nginx stack: %s", stack), func() {
 				It("validates IPv6 egress for Nginx App", func() {
-					describeIpv6NginxTest(assets.NewAssets().Nginx, stack)
+					describeIpv6NginxTest(assets.NewAssets().NginxIPv6, stack)
 				})
 			})
 		}


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes.

### What is this change about?

In order not to break the other nginx test - new conf file for the nginx ipv6 validation was needed. 


### What version of cf-deployment have you run this cf-acceptance-test change against?

v48.9.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate IPv6 egress calls with Nginx application. We add changes regarding to this buildpack only. The test group for ipv6 was already created.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Around 90 seconds per test.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@oliver-heinrich @iaftab-alam 
