### PR TITLE
Add test to validate stderr/stdout streaming on linux apps as well as the existing windows tests

### DIFF
--- a/apps/running_log.go
+++ b/apps/running_log.go
@@ -1,0 +1,63 @@
+package apps
+
+import (
+	"fmt"
+	"net/url"
+
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
+	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
+)
+
+var _ = AppsDescribe("app logs", func() {
+	var appName string
+
+	BeforeEach(func() {
+		appName = random_name.CATSRandomName("APP")
+
+		Expect(cf.Cf("push",
+			appName,
+			"-p", assets.NewAssets().Dora,
+		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+		Eventually(helpers.CurlingAppRoot(Config, appName)).Should(ContainSubstring("Hi, I'm Dora!"))
+	})
+
+	AfterEach(func() {
+		app_helpers.AppReport(appName)
+
+		Expect(cf.Cf("delete", appName, "-f", "-r").Wait()).Should(Exit(0))
+	})
+
+	It("captures stdout logs with the correct tag", func() {
+		var message string
+
+		By("logging application stdout")
+		message = "message-from-stdout"
+		helpers.CurlApp(Config, appName, fmt.Sprintf("/print/%s", url.QueryEscape(message)))
+
+		Eventually(func() *Buffer {
+			return logs.Recent(appName).Wait().Out
+		}).Should(Say(fmt.Sprintf("\\[APP(.*)/0\\]\\s*OUT %s", message)))
+	})
+
+	It("captures stderr logs with the correct tag", func() {
+		var message string
+
+		By("logging application stderr")
+		message = "message-from-stderr"
+		helpers.CurlApp(Config, appName, fmt.Sprintf("/print_err/%s", url.QueryEscape(message)))
+
+		Eventually(func() *Buffer {
+			return logs.Recent(appName).Wait().Out
+		}).Should(Say(fmt.Sprintf("\\[APP(.*)/0\\]\\s*ERR %s", message)))
+	})
+})

--- a/assets/dora/dora.rb
+++ b/assets/dora/dora.rb
@@ -141,4 +141,12 @@ class Dora < Sinatra::Base
   end
 
   run! if app_file == $0
+
+  get '/print/:string' do
+    STDOUT.puts params[:string]
+  end
+
+  get '/print_err/:string' do
+    STDERR.puts params[:string]
+  end
 end


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes!

### What is this change about?

Adds a test to validate STDERR and STDOUT streaming logs for apps on linux. This test exists for windows apps, but recently almost broke across all apps, and only the rarely-tested windows suite caught it.

### Please provide contextual information.

This seems important enough to want to catch on non-windows cases as well

### What version of cf-deployment have you run this cf-acceptance-test change against?

Latest

### Please check all that apply for this PR:

- [x] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

Parity between app testing on windows + linux

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

2 cf app pushes, unless parallelized

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
