### PR TITLE
Remove unused dependency from the node asset

### DIFF
--- a/assets/node/package.json
+++ b/assets/node/package.json
@@ -1,7 +1,4 @@
 {
     "name" : "node_without_procfile",
-    "version": "0.1.0",
-    "dependencies": {
-        "ip": "^1.1.8"
-      }
+    "version": "0.1.0"
 }


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

[Recent changes to the node asset](https://github.com/cloudfoundry/cf-acceptance-tests/commit/508e154a1cf9f6703e2b945bbeb09478ba877f48#diff-cf0ded9bac8dfc9d31d2b7e42fafb3eddee428c5d1f73b54b6c78e80b6d3bffb) left a reference to the "ip" NPM package in the
package.json file, even though it is [not used in the actual application](https://github.com/cloudfoundry/cf-acceptance-tests/commit/f342ab503adca426f7079bcc99ba9f69bd425fe5#diff-e2b2a6d837840f14e3fb8db405f0e1e46dd2683211b75cfa9a27a7818b5cd9c1). This PR
removes the unused dependency.

### Please provide contextual information.

The dependency in the node asset's package.json causes unnecessary
downloads from npmjs.org when the app is pushed to a foundation.

### What version of cf-deployment have you run this cf-acceptance-test change against?

Latest

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
