### PR TITLE
Bump all go.mod files to Golang 1.24

### DIFF
--- a/assets/binary/go.mod
+++ b/assets/binary/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/binary
 
-go 1.23
+go 1.24
 
-toolchain go1.23.7
+toolchain go1.24.2

--- a/assets/catnip/go.mod
+++ b/assets/catnip/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/catnip
 
-go 1.24.0
+go 1.24
 
 toolchain go1.24.2
 

--- a/assets/credhub-service-broker/go.mod
+++ b/assets/credhub-service-broker/go.mod
@@ -1,8 +1,8 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/credhub-service-broker
 
-go 1.23.0
+go 1.24
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require (
 	code.cloudfoundry.org/credhub-cli v0.0.0-20230320130818-a7d5420b283b

--- a/assets/go_calls_ruby/go.mod
+++ b/assets/go_calls_ruby/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/go_calls_ruby
 
-go 1.23
+go 1.24
 
-toolchain go1.23.7
+toolchain go1.24.2

--- a/assets/golang/go.mod
+++ b/assets/golang/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/golang
 
-go 1.23
+go 1.24
 
-toolchain go1.23.7
+toolchain go1.24.2

--- a/assets/grpc/go.mod
+++ b/assets/grpc/go.mod
@@ -1,8 +1,8 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/grpc
 
-go 1.23.0
+go 1.24
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require (
 	google.golang.org/grpc v1.75.1

--- a/assets/http2/go.mod
+++ b/assets/http2/go.mod
@@ -1,8 +1,8 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/http2
 
-go 1.24.0
+go 1.24
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require golang.org/x/net v0.44.0
 

--- a/assets/logging-route-service/go.mod
+++ b/assets/logging-route-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry-samples/logging-route-service
 
-go 1.23
+go 1.24
 
-toolchain go1.23.7
+toolchain go1.24.2

--- a/assets/multi-port-app/go.mod
+++ b/assets/multi-port-app/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/multi-port-app
 
-go 1.23
+go 1.24
 
-toolchain go1.23.7
+toolchain go1.24.2

--- a/assets/pora/go.mod
+++ b/assets/pora/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/pora
 
-go 1.23
+go 1.24
 
-toolchain go1.23.7
+toolchain go1.24.2

--- a/assets/proxy/go.mod
+++ b/assets/proxy/go.mod
@@ -1,5 +1,5 @@
 module example-apps/proxy
 
-go 1.23
+go 1.24
 
-toolchain go1.23.7
+toolchain go1.24.2

--- a/assets/syslog-drain-listener/go.mod
+++ b/assets/syslog-drain-listener/go.mod
@@ -1,5 +1,7 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/syslog-drain-listener
 
-go 1.24.0
+go 1.24
+
+toolchain go1.24.2
 
 require code.cloudfoundry.org/tlsconfig v0.35.0

--- a/assets/tcp-listener/go.mod
+++ b/assets/tcp-listener/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/tcp-listener
 
-go 1.23
+go 1.24
 
-toolchain go1.23.7
+toolchain go1.24.2

--- a/assets/worker/go.mod
+++ b/assets/worker/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudfoundry/cf-acceptance-tests/assets/worker
 
-go 1.23
+go 1.24
 
-toolchain go1.23.7
+toolchain go1.24.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cf-acceptance-tests
 
-go 1.24.0
+go 1.24
 
 toolchain go1.24.1
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

This PR bumps all go.mod files to Golang 1.24.

### Please provide contextual information.

Golang 1.23 is out of support now that 1.25 has been released and will soon be removed from the go-buildpack.

### What version of cf-deployment have you run this cf-acceptance-test change against?

Latest.

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
