### PR TITLE
Bump all Golang asset manifests to Golang 1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ in such a way as to impact other tests.
 
 ## Test Setup
 ### Prerequisites for running CATS
-- Install golang >= `1.23.0`. Set up your golang development environment, per
+- Install golang >= `1.24.0`. Set up your golang development environment, per
   [golang.org](http://golang.org/doc/install).
 - Install the [`cf CLI`](https://github.com/cloudfoundry/cli) >= `8.5.0`. Make
   sure that it is accessible in your `$PATH`.
@@ -53,7 +53,7 @@ in such a way as to impact other tests.
 All `go` dependencies required by CATs
 are vendored in the `vendor` directory.
 
-Make sure to have Golang 1.23+
+Make sure to have Golang 1.24+
 
 In order to update a current dependency to a specific version,
 do the following:

--- a/assets/golang/manifest.yml
+++ b/assets/golang/manifest.yml
@@ -2,4 +2,4 @@
 applications:
   - env:
       GOPACKAGENAME: go-online
-      GOVERSION: go1.23
+      GOVERSION: go1.24

--- a/assets/logging-route-service/manifest.yml
+++ b/assets/logging-route-service/manifest.yml
@@ -3,5 +3,5 @@ applications:
   - buildpacks:
       - go_buildpack
     env:
-      GOVERSION: go1.23
+      GOVERSION: go1.24
       GOPACKAGENAME: github.com/cloudfoundry-samples/logging-route-service

--- a/assets/multi-port-app/manifest.yml
+++ b/assets/multi-port-app/manifest.yml
@@ -1,4 +1,4 @@
 ---
 applications:
   - env:
-      GOVERSION: go1.23
+      GOVERSION: go1.24

--- a/assets/pora/manifest.yml
+++ b/assets/pora/manifest.yml
@@ -5,4 +5,4 @@ applications:
       - go_buildpack
     env:
       GOPACKAGENAME: pora
-      GOVERSION: go1.23
+      GOVERSION: go1.24

--- a/assets/proxy/internal-route-manifest.yml
+++ b/assets/proxy/internal-route-manifest.yml
@@ -6,6 +6,6 @@ applications:
     buildpack: go_buildpack
     env:
       GOPACKAGENAME: example-apps/proxy
-      GOVERSION: go1.23
+      GOVERSION: go1.24
     routes:
       - route: app-smoke.apps.internal

--- a/assets/proxy/manifest.yml
+++ b/assets/proxy/manifest.yml
@@ -7,4 +7,4 @@ applications:
       - go_buildpack
     env:
       GOPACKAGENAME: example-apps/proxy
-      GOVERSION: go1.23
+      GOVERSION: go1.24

--- a/assets/syslog-drain-listener/manifest.yml
+++ b/assets/syslog-drain-listener/manifest.yml
@@ -3,4 +3,4 @@ applications:
   - name: syslog-drain-listener
     env:
       GOPACKAGENAME: main
-      GOVERSION: go1.23
+      GOVERSION: go1.24

--- a/assets/tcp-listener/manifest.yml
+++ b/assets/tcp-listener/manifest.yml
@@ -2,4 +2,4 @@
 applications:
   - env:
       GOPACKAGENAME: tcp-listener
-      GOVERSION: go1.23
+      GOVERSION: go1.24


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes.

### What is this change about?

Bump the version in the manifest.yml files for all Golang assets. It also updates the README with the new required Golang version.

### Please provide contextual information.

This is a follow-on change to https://github.com/cloudfoundry/cf-acceptance-tests/pull/1700.

### What version of cf-deployment have you run this cf-acceptance-test change against?

Latest.

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
