### PR TITLE
Increase "R" buildpack push memory to 2G

### DIFF
--- a/detect/buildpacks.go
+++ b/detect/buildpacks.go
@@ -237,7 +237,7 @@ var _ = DetectDescribe("Buildpacks", func() {
 			Context(fmt.Sprintf("when using %s stack", stack), func() {
 				It("makes the app reachable via its bound route", func() {
 					Expect(cf.Cf("push", appName,
-						"-m", DEFAULT_MEMORY_LIMIT,
+						"-m", "2G",
 						"-p", assets.NewAssets().R,
 						"-s", stack,
 					).Wait(Config.DetectTimeoutDuration())).To(Exit(0))


### PR DESCRIPTION
### What is this change about?

"R" buildpack test fails with OOM error on Azure (stemcell jammy/1.943). Increase to "2G", that seems sufficient.

### Please provide contextual information.

See https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/capi-team/pipelines/capi/jobs/scar-psql-tests/builds/223

### What version of cf-deployment have you run this cf-acceptance-test change against?

v53.1.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Change does not have effect on runtime.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**
