### PR TITLE
Skip deprecated doppler test

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -236,6 +236,7 @@ jobs:
     params:
       CONFIG_FILE_PATH: environments/test/cats/integration_config.json
       REPORTER_CONFIG_FILE_PATH: environments/test/cats/reporter_config.json
+      SKIP_REGEXP: "shows logs and metrics"
 
 - name: bless-cats
   public: true


### PR DESCRIPTION
### What is this change about?

Skip deprecated doppler test (as in cf-deployment validation pipeline).

### Please provide contextual information.

Test started failing because we have disable skip_ssl_validation: https://github.com/cloudfoundry/relint-envs/pull/81

### What version of cf-deployment have you run this cf-acceptance-test change against?

v53.5.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Skipped test saves 2-3 minutes.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**
