### PR TITLE
Revert "Merge pull request #1780 from cloudfoundry/use-goversion-latest"

### DIFF
--- a/assets/golang/manifest.yml
+++ b/assets/golang/manifest.yml
@@ -2,4 +2,4 @@
 applications:
   - env:
       GOPACKAGENAME: go-online
-      GOVERSION: latest
+      GOVERSION: go1.24

--- a/assets/logging-route-service/manifest.yml
+++ b/assets/logging-route-service/manifest.yml
@@ -3,5 +3,5 @@ applications:
   - buildpacks:
       - go_buildpack
     env:
-      GOVERSION: latest
+      GOVERSION: go1.24
       GOPACKAGENAME: github.com/cloudfoundry-samples/logging-route-service

--- a/assets/multi-port-app/manifest.yml
+++ b/assets/multi-port-app/manifest.yml
@@ -1,4 +1,4 @@
 ---
 applications:
   - env:
-      GOVERSION: latest
+      GOVERSION: go1.24

--- a/assets/pora/manifest.yml
+++ b/assets/pora/manifest.yml
@@ -5,4 +5,4 @@ applications:
       - go_buildpack
     env:
       GOPACKAGENAME: pora
-      GOVERSION: latest
+      GOVERSION: go1.24

--- a/assets/proxy/internal-route-manifest.yml
+++ b/assets/proxy/internal-route-manifest.yml
@@ -6,6 +6,6 @@ applications:
     buildpack: go_buildpack
     env:
       GOPACKAGENAME: example-apps/proxy
-      GOVERSION: latest
+      GOVERSION: go1.24
     routes:
       - route: app-smoke.apps.internal

--- a/assets/proxy/manifest.yml
+++ b/assets/proxy/manifest.yml
@@ -7,4 +7,4 @@ applications:
       - go_buildpack
     env:
       GOPACKAGENAME: example-apps/proxy
-      GOVERSION: latest
+      GOVERSION: go1.24

--- a/assets/syslog-drain-listener/manifest.yml
+++ b/assets/syslog-drain-listener/manifest.yml
@@ -3,4 +3,4 @@ applications:
   - name: syslog-drain-listener
     env:
       GOPACKAGENAME: main
-      GOVERSION: latest
+      GOVERSION: go1.24

--- a/assets/tcp-listener/manifest.yml
+++ b/assets/tcp-listener/manifest.yml
@@ -2,4 +2,4 @@
 applications:
   - env:
       GOPACKAGENAME: tcp-listener
-      GOVERSION: latest
+      GOVERSION: go1.24


### PR DESCRIPTION
This reverts commit e635384c7f084943f5b4d10d3b40c3e19774af9d, reversing changes made to ee6c75b1b9d07e2c193dddac5dd0624b8263847c.

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?



### What is this change about?

WIth ths pr #1780 it Updated all Golang assets to use the latest available version. But this latest feature which is merge via this https://github.com/cloudfoundry/go-buildpack/pull/524 made to the go buildpack source repo but no to the release. We have to wait until we have latest go-buildpack release.

Also It's unclear for us when a new go-buildpack-release will be available!

Now the [run-cats-vm](https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cats/jobs/run-cats-vms/builds/653) job is red in order to unblock it we have to revert that commit.

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

### What version of cf-deployment have you run this cf-acceptance-test change against?

https://github.com/cloudfoundry/cf-acceptance-tests/pull/1780

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [X] N/A


### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

