### PR TITLE
Increase check timeout for "crashing" test

### DIFF
--- a/apps/crashing.go
+++ b/apps/crashing.go
@@ -95,7 +95,7 @@ var _ = AppsDescribe("Crashing", func() {
 			// Poll until at least one instance has crashed
 			Eventually(func() bool {
 				return hasOneInstanceInState(processStatsPath, "CRASHED")
-			}, 60*time.Second, 5*time.Second).Should(BeTrue(), "At least one instance should be in the CRASHED state")
+			}, 90*time.Second, 15*time.Second).Should(BeTrue(), "At least one instance should be in the CRASHED state")
 
 			By("Verifying at least one instance is still running")
 			foundRunning := hasOneInstanceInState(processStatsPath, "RUNNING")


### PR DESCRIPTION
### What is this change about?

The "crashing" test suite often fails because one of the app instances is still reported as "STARTING". The default health check interval is 30 seconds and the default health check timeout is 60 seconds, so the assertion can miss the moment when the app instance is reported as "CRASHED". Increasing the check timeout to 90 seconds should fix that. Also decrease check interval from 5 to 15 seconds.

### Please provide contextual information.

This test fails quite often, e.g.:
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/noble-stemcell-validation/jobs/run-cats/builds/311

### What version of cf-deployment have you run this cf-acceptance-test change against?

v54.0.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

At most 30 seconds.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
