### PR TITLE
Reduce Nodes for CATS

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -237,6 +237,7 @@ jobs:
       CONFIG_FILE_PATH: environments/test/cats/integration_config.json
       REPORTER_CONFIG_FILE_PATH: environments/test/cats/reporter_config.json
       SKIP_REGEXP: "shows logs and metrics"
+      NODES: 5
 
 - name: bless-cats
   public: true


### PR DESCRIPTION

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._

### What is this change about?

Currently, CATS are failing in the ARD pipeline. There is only one windows cell for CATS env and the CATS runs with 12 nodes for Ginko puts high CPU load on windows cell. This will reduce nodes 12(default) to 5.


### Please provide contextual information.

https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cats/jobs/run-cats-vms/builds/684

### What version of cf-deployment have you run this cf-acceptance-test change against?

N/A

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [X] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
