### PR TITLE
Set `daemon: off` in nginx config

### DIFF
--- a/assets/nginx-ipv6/nginx.conf
+++ b/assets/nginx-ipv6/nginx.conf
@@ -1,3 +1,5 @@
+daemon off;
+
 events {
     worker_connections 1024;
 }

--- a/assets/nginx/nginx.conf
+++ b/assets/nginx/nginx.conf
@@ -1,3 +1,5 @@
+daemon off;
+
 events {
    worker_connections  1024;
 }


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._

### What is this change about?

Set `daemon: off` in nginx config

### Please provide contextual information.

Keeps nginx in foreground so that Garden can signal it

### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
