### PR TITLE
Make internal cc dns name configurable

### DIFF
--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -69,6 +69,7 @@ type CatsConfig interface {
 	GetExistingClientSecret() string
 	GetGoBuildpackName() string
 	GetHwcBuildpackName() string
+	GetInternalCCAddress() string
 	GetIsolationSegmentName() string
 	GetIsolationSegmentDomain() string
 	GetIsolationSegmentTCPDomain() string

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -124,9 +124,10 @@ type config struct {
 
 	UnallocatedIPForSecurityGroup *string `json:"unallocated_ip_for_security_group"`
 
-	DynamicASGsEnabled           *bool `json:"dynamic_asgs_enabled"`
-	CommaDelimitedASGsEnabled    *bool `json:"comma_delim_asgs_enabled"`
-	ReadinessHealthChecksEnabled *bool `json:"readiness_health_checks_enabled"`
+	DynamicASGsEnabled           *bool   `json:"dynamic_asgs_enabled"`
+	CommaDelimitedASGsEnabled    *bool   `json:"comma_delim_asgs_enabled"`
+	ReadinessHealthChecksEnabled *bool   `json:"readiness_health_checks_enabled"`
+	InternalCCAddress            *string `json:"internal_cc_address"`
 
 	NamePrefix *string `json:"name_prefix"`
 
@@ -890,6 +891,14 @@ func (c *config) GetArtifactsDirectory() string {
 
 func (c *config) GetIsolationSegmentName() string {
 	return *c.IsolationSegmentName
+}
+
+func (c *config) GetInternalCCAddress() string {
+	if c.InternalCCAddress == nil || *c.InternalCCAddress == "" {
+		return "cloud-controller-ng.service.cf.internal"
+	}
+
+	return *c.InternalCCAddress
 }
 
 func (c *config) GetIsolationSegmentDomain() string {

--- a/security_groups/comma_delmited_asgs.go
+++ b/security_groups/comma_delmited_asgs.go
@@ -44,7 +44,8 @@ var _ = CommaDelimitedSecurityGroupsDescribe("Comma Delimited ASGs", func() {
 	})
 
 	It("manages whether apps can reach certain IP addresses per ASG configuration with commas", func() {
-		proxyRequestURL := fmt.Sprintf("%s%s.%s/https_proxy/cloud-controller-ng.service.cf.internal:9024/", Config.Protocol(), appName, Config.GetAppsDomain())
+		internalAddress := Config.GetInternalCCAddress()
+		proxyRequestURL := fmt.Sprintf("%s%s.%s/https_proxy/%s:9024/", Config.Protocol(), appName, Config.GetAppsDomain(), internalAddress)
 
 		client := &http.Client{
 			Transport: &http.Transport{

--- a/security_groups/dynamic_asgs.go
+++ b/security_groups/dynamic_asgs.go
@@ -46,7 +46,8 @@ var _ = SecurityGroupsDescribe("ASGs", func() {
 	})
 
 	It("manages whether apps can reach certain IP addresses per ASG configuration", func() {
-		proxyRequestURL := fmt.Sprintf("%s%s.%s/https_proxy/cloud-controller-ng.service.cf.internal:9024/", Config.Protocol(), appName, Config.GetAppsDomain())
+		internalAddress := Config.GetInternalCCAddress()
+		proxyRequestURL := fmt.Sprintf("%s%s.%s/https_proxy/%s:9024/", Config.Protocol(), appName, Config.GetAppsDomain(), internalAddress)
 
 		client := &http.Client{
 			Transport: &http.Transport{


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Make the reference to the internal address of the cloudcontroller (`cloud-controller-ng.service.cf.internal`) configurable. This makes it possible to reuse the ASG test if you have another internal domain (e.g. `kind`)

### Please provide contextual information.

Enable for `include_security_groups` [kind](https://github.com/cloudfoundry/kind-deployment). The default is the old hardcoded value, so no user has to change anything.

### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [X] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

0

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._

@nicolasbender @modulo11 
