### PR TITLE
Fix missing spaceGuid

### DIFF
--- a/routing_isolation_segments/routing_isolation_segments.go
+++ b/routing_isolation_segments/routing_isolation_segments.go
@@ -57,6 +57,10 @@ var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
 			bytes := session.Wait().Out.Contents()
 			orgGuid = v3_helpers.GetGuidFromResponse(bytes)
 
+			session = cf.Cf("curl", fmt.Sprintf("/v3/spaces?names=%s", spaceName))
+			bytes = session.Wait().Out.Contents()
+			spaceGuid = v3_helpers.GetGuidFromResponse(bytes)
+
 			isoSegGuid = v3_helpers.CreateOrGetIsolationSegment(isoSegName)
 		})
 	})
@@ -116,9 +120,6 @@ var _ = RoutingIsolationSegmentsDescribe("RoutingIsolationSegments", func() {
 		BeforeEach(func() {
 			workflowhelpers.AsUser(TestSetup.AdminUserContext(), TestSetup.ShortTimeout(), func() {
 				v3_helpers.EntitleOrgToIsolationSegment(orgGuid, isoSegGuid)
-				session := cf.Cf("curl", fmt.Sprintf("/v3/spaces?names=%s", spaceName))
-				bytes := session.Wait().Out.Contents()
-				spaceGuid = v3_helpers.GetGuidFromResponse(bytes)
 				v3_helpers.AssignIsolationSegmentToSpace(spaceGuid, isoSegGuid)
 
 				target := cf.Cf("target", "-o", orgName, "-s", spaceName).Wait()


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._

### What is this change about?

_Describe the change and why it's needed._

The test for routing isolation segments has two contexts which use the `spaceGuid`, but only the second context retrieves it. This changes fixes the missing `spaceGuid`. It looks like this worked before because the isolation segment is already assigned to the respective Org.

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

Logs show:

```
> cf curl /v3/spaces//relationships/isolation_segment -X PATCH -d {"data":{"guid":"12345678-abcd-1234-abcd-012345678912"}} 
  {"errors":[{"detail":"Unknown request","title":"CF-NotFound","code":10000}]}
```

### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?



### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
