### PR TITLE
Disentangle SSO and Service tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ include_app_syslog_tcp
 * `include_services`: Flag to include test for the services API.
 * `include_service_instance_sharing`: Flag to include tests for service instance sharing between spaces. `include_services` must be set for these tests to run. The `service_instance_sharing` feature flag must also be enabled for these tests to pass.
 * `include_ssh`: Flag to include tests for Diego container ssh feature.
-* `include_sso`: Flag to include the services tests that integrate with Single Sign On. `include_services` must also be set for tests to run.
+* `include_sso`: Flag to include the services tests that integrate with Single Sign On.
 * `include_tasks`: Flag to include the v3 task tests. `include_v3` must also be set for tests to run. The CC API task_creation feature flag must be enabled for these tests to pass.
 * `include_tcp_routing`: Flag to include the TCP Routing tests. These tests are equivalent to the [TCP Routing tests](https://github.com/cloudfoundry/routing-acceptance-tests/blob/master/tcp_routing/tcp_routing_test.go) from the Routing Acceptance Tests.
 * `tcp_domain`: Domain that will be used for apps with TCP routes

--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -283,6 +283,17 @@ func ServiceInstanceSharingDescribe(description string, callback func()) bool {
 	})
 }
 
+func ServicesSsoDescribe(description string, callback func()) bool {
+	return Describe("[services sso]", func() {
+		BeforeEach(func() {
+			if !Config.GetIncludeSSO() {
+				Skip(skip_messages.SkipSSOMessage)
+			}
+		})
+		Describe(description, callback)
+	})
+}
+
 func UserProvidedServicesDescribe(description string, callback func()) bool {
 	return Describe("[user provided services]", func() {
 		BeforeEach(func() {

--- a/services/sso_lifecycle.go
+++ b/services/sso_lifecycle.go
@@ -11,10 +11,9 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
 	. "github.com/cloudfoundry/cf-acceptance-tests/helpers/services"
-	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 )
 
-var _ = ServicesDescribe("SSO Lifecycle", func() {
+var _ = ServicesSsoDescribe("SSO Lifecycle", func() {
 	var broker ServiceBroker
 	var oauthConfig OAuthConfig
 	var apiEndpoint string
@@ -22,9 +21,6 @@ var _ = ServicesDescribe("SSO Lifecycle", func() {
 	redirectUri := `http://example.com`
 
 	BeforeEach(func() {
-		if !Config.GetIncludeSSO() {
-			Skip(skip_messages.SkipSSOMessage)
-		}
 		apiEndpoint = Config.Protocol() + Config.GetApiEndpoint()
 		broker = NewServiceBroker(
 			random_name.CATSRandomName("BRKR"),


### PR DESCRIPTION
### What is this change about?

This change disentangles the enablement of service tests and sso test since there is no technical dependency for that. Instead it makes it more difficult to enable/disable the sso tests. 

This change has no implications to running CATs configurations.

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

0


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
