### PR TITLE
Acceptance tests for service credential binding rotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ include_app_syslog_tcp
 * `comma_delim_asgs_enabled`: Defaults to `false`. Set to true if comma delimited ASG destinations are enabled in the test environment.
 * `include_services`: Flag to include test for the services API.
 * `include_service_instance_sharing`: Flag to include tests for service instance sharing between spaces. `include_services` must be set for these tests to run. The `service_instance_sharing` feature flag must also be enabled for these tests to pass.
+* `include_service_credential_binding_rotation`: Execute tests for multiple service bindings. See [RFC-0040](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0040-service-binding-rotation.md) for details. This test requires CF CLI v8.18.0 or later. The backend must support at least 2 service bindings per app and service instance.
 * `include_ssh`: Flag to include tests for Diego container ssh feature.
 * `include_sso`: Flag to include the services tests that integrate with Single Sign On.
 * `include_tasks`: Flag to include the v3 task tests. `include_v3` must also be set for tests to run. The CC API task_creation feature flag must be enabled for these tests to pass.

--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -117,7 +117,7 @@ const (
 )
 
 func FileBasedServiceBindingsDescribe(description string, lifecycle string, callback func()) bool {
-	return Describe(fmt.Sprintf("[file-based service bindings]", lifecycle), func() {
+	return Describe(fmt.Sprintf("[file-based service bindings %s]", lifecycle), func() {
 		BeforeEach(func() {
 			if lifecycle == BuildpackLifecycle && !Config.GetIncludeFileBasedServiceBindings() {
 				Skip(skip_messages.SkipFileBasedServiceBindingsBuildpackApp)
@@ -277,6 +277,17 @@ func ServiceInstanceSharingDescribe(description string, callback func()) bool {
 		BeforeEach(func() {
 			if !Config.GetIncludeServiceInstanceSharing() {
 				Skip(skip_messages.SkipServiceInstanceSharingMessage)
+			}
+		})
+		Describe(description, callback)
+	})
+}
+
+func ServiceCredentialBindingRotationDescribe(description string, callback func()) bool {
+	return Describe("[service credential binding rotation]", func() {
+		BeforeEach(func() {
+			if !Config.GetIncludeServiceCredentialBindingRotation() {
+				Skip(skip_messages.SkipServiceCredentialBindingRotationMessage)
 			}
 		})
 		Describe(description, callback)

--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/cloudfoundry/cf-acceptance-tests/routing"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/routing_isolation_segments"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/security_groups"
+	_ "github.com/cloudfoundry/cf-acceptance-tests/service_credential_binding_rotation"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/service_discovery"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/services"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/ssh"

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -25,6 +25,7 @@ type CatsConfig interface {
 	GetIncludeServices() bool
 	GetIncludeUserProvidedServices() bool
 	GetIncludeServiceDiscovery() bool
+	GetIncludeServiceCredentialBindingRotation() bool
 	GetIncludeSsh() bool
 	GetIncludeTasks() bool
 	GetIncludeV3() bool

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -74,35 +74,36 @@ type config struct {
 	VolumeServiceBindConfig   *string `json:"volume_service_bind_config"`
 	VolumeServiceBrokerName   *string `json:"volume_service_broker_name"`
 
-	IncludeAppSyslogTCP             *bool `json:"include_app_syslog_tcp"`
-	IncludeApps                     *bool `json:"include_apps"`
-	IncludeContainerNetworking      *bool `json:"include_container_networking"`
-	IncludeDeployments              *bool `json:"include_deployments"`
-	IncludeDetect                   *bool `json:"include_detect"`
-	IncludeDocker                   *bool `json:"include_docker"`
-	IncludeCNB                      *bool `json:"include_cnb"`
-	IncludeFileBasedServiceBindings *bool `json:"include_file_based_service_bindings"`
-	IncludeInternetDependent        *bool `json:"include_internet_dependent"`
-	IncludeIsolationSegments        *bool `json:"include_isolation_segments"`
-	IncludePrivateDockerRegistry    *bool `json:"include_private_docker_registry"`
-	IncludeRouteServices            *bool `json:"include_route_services"`
-	IncludeRouting                  *bool `json:"include_routing"`
-	IncludeRoutingIsolationSegments *bool `json:"include_routing_isolation_segments"`
-	IncludeSSO                      *bool `json:"include_sso"`
-	IncludeSecurityGroups           *bool `json:"include_security_groups"`
-	IncludeServiceDiscovery         *bool `json:"include_service_discovery"`
-	IncludeServiceInstanceSharing   *bool `json:"include_service_instance_sharing"`
-	IncludeServices                 *bool `json:"include_services"`
-	IncludeUserProvidedServices     *bool `json:"include_user_provided_services"`
-	IncludeSsh                      *bool `json:"include_ssh"`
-	IncludeTCPIsolationSegments     *bool `json:"include_tcp_isolation_segments"`
-	IncludeHTTP2Routing             *bool `json:"include_http2_routing"`
-	IncludeTCPRouting               *bool `json:"include_tcp_routing"`
-	IncludeTasks                    *bool `json:"include_tasks"`
-	IncludeV3                       *bool `json:"include_v3"`
-	IncludeVolumeServices           *bool `json:"include_volume_services"`
-	IncludeZipkin                   *bool `json:"include_zipkin"`
-	IncludeIPv6                     *bool `json:"include_ipv6"`
+	IncludeAppSyslogTCP                     *bool `json:"include_app_syslog_tcp"`
+	IncludeApps                             *bool `json:"include_apps"`
+	IncludeContainerNetworking              *bool `json:"include_container_networking"`
+	IncludeDeployments                      *bool `json:"include_deployments"`
+	IncludeDetect                           *bool `json:"include_detect"`
+	IncludeDocker                           *bool `json:"include_docker"`
+	IncludeCNB                              *bool `json:"include_cnb"`
+	IncludeFileBasedServiceBindings         *bool `json:"include_file_based_service_bindings"`
+	IncludeInternetDependent                *bool `json:"include_internet_dependent"`
+	IncludeIsolationSegments                *bool `json:"include_isolation_segments"`
+	IncludePrivateDockerRegistry            *bool `json:"include_private_docker_registry"`
+	IncludeRouteServices                    *bool `json:"include_route_services"`
+	IncludeRouting                          *bool `json:"include_routing"`
+	IncludeRoutingIsolationSegments         *bool `json:"include_routing_isolation_segments"`
+	IncludeSSO                              *bool `json:"include_sso"`
+	IncludeSecurityGroups                   *bool `json:"include_security_groups"`
+	IncludeServiceDiscovery                 *bool `json:"include_service_discovery"`
+	IncludeServiceInstanceSharing           *bool `json:"include_service_instance_sharing"`
+	IncludeServiceCredentialBindingRotation *bool `json:"include_service_credential_binding_rotation"`
+	IncludeServices                         *bool `json:"include_services"`
+	IncludeUserProvidedServices             *bool `json:"include_user_provided_services"`
+	IncludeSsh                              *bool `json:"include_ssh"`
+	IncludeTCPIsolationSegments             *bool `json:"include_tcp_isolation_segments"`
+	IncludeHTTP2Routing                     *bool `json:"include_http2_routing"`
+	IncludeTCPRouting                       *bool `json:"include_tcp_routing"`
+	IncludeTasks                            *bool `json:"include_tasks"`
+	IncludeV3                               *bool `json:"include_v3"`
+	IncludeVolumeServices                   *bool `json:"include_volume_services"`
+	IncludeZipkin                           *bool `json:"include_zipkin"`
+	IncludeIPv6                             *bool `json:"include_ipv6"`
 
 	CredhubMode         *string `json:"credhub_mode"`
 	CredhubLocation     *string `json:"credhub_location"`
@@ -206,6 +207,7 @@ func getDefaults() config {
 	defaults.IncludeTasks = ptrToBool(false)
 	defaults.IncludeZipkin = ptrToBool(false)
 	defaults.IncludeServiceInstanceSharing = ptrToBool(false)
+	defaults.IncludeServiceCredentialBindingRotation = ptrToBool(false)
 	defaults.IncludeHTTP2Routing = ptrToBool(false)
 	defaults.IncludeTCPRouting = ptrToBool(false)
 	defaults.IncludeVolumeServices = ptrToBool(false)
@@ -481,6 +483,9 @@ func validateConfig(config *config) error {
 	}
 	if config.IncludeServiceDiscovery == nil {
 		errs = errors.Join(errs, fmt.Errorf("* 'include_service_discovery' must not be null"))
+	}
+	if config.IncludeServiceCredentialBindingRotation == nil {
+		errs = errors.Join(errs, fmt.Errorf("* 'include_service_credential_binding_rotation' must not be null"))
 	}
 	if config.IncludeServices == nil {
 		errs = errors.Join(errs, fmt.Errorf("* 'include_services' must not be null"))
@@ -1109,6 +1114,10 @@ func (c *config) GetCredHubLocation() string {
 
 func (c *config) GetIncludeServiceInstanceSharing() bool {
 	return *c.IncludeServiceInstanceSharing
+}
+
+func (c *config) GetIncludeServiceCredentialBindingRotation() bool {
+	return *c.IncludeServiceCredentialBindingRotation
 }
 
 func (c *config) GetIncludeWindows() bool {

--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -56,6 +56,7 @@ const SkipRoutingIsolationSegmentsMessage = `Skipping this test because Config.I
 const SkipZipkinMessage = `Skipping this test because config.IncludeZipkin is set to 'false'`
 const SkipServiceDiscoveryMessage = `Skipping this test because config.IncludeServiceDiscovery is set to 'false'.`
 const SkipServiceInstanceSharingMessage = `Skipping this test because config.IncludeServiceInstanceSharing is set to 'false'.`
+const SkipServiceCredentialBindingRotationMessage = `Skipping this test because config.IncludeServiceCredentialBindingRotation is set to 'false'.`
 const SkipCapiExperimentalMessage = `Skipping this test because config.IncludeCapiExperimental is set to 'false'.`
 const SkipWindowsTasksMessage = `Skipping Windows tasks tests (requires diego-release v1.20.0 and above)`
 const SkipNoAlternateStacksMessage = `Skipping this test because config.Stacks is empty.`

--- a/service_credential_binding_rotation/service_credential_binding_rotation.go
+++ b/service_credential_binding_rotation/service_credential_binding_rotation.go
@@ -1,0 +1,217 @@
+package service_credential_binding_rotation
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"time"
+
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	svchelper "github.com/cloudfoundry/cf-acceptance-tests/helpers/services"
+	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
+	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+type bindingResource struct {
+	GUID      string    `json:"guid"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type bindingListResponse struct {
+	Resources []bindingResource `json:"resources"`
+}
+
+type vcapServiceEntry struct {
+	BindingName string `json:"binding_name"`
+	BindingGUID string `json:"binding_guid"`
+}
+
+var _ = ServiceCredentialBindingRotationDescribe("Service Credential Binding Rotation", func() {
+	var broker svchelper.ServiceBroker
+	var appName string
+	var serviceName string
+	var bindingName string
+
+	extractBindingGUIDFromVCAPServices := func(vcapServicesStr, serviceBindingName string) string {
+		vcapServices := map[string][]vcapServiceEntry{}
+		Expect(json.Unmarshal([]byte(vcapServicesStr), &vcapServices)).NotTo(HaveOccurred(), "failed to parse VCAP_SERVICES")
+
+		serviceEntries := vcapServices[broker.Service.Name]
+		for _, serviceEntry := range serviceEntries {
+			if serviceEntry.BindingName == serviceBindingName {
+				return serviceEntry.BindingGUID
+			}
+		}
+
+		Fail(fmt.Sprintf("expected VCAP_SERVICES to contain binding_guid for service binding %q under label %q", serviceBindingName, broker.Service.Name))
+		return ""
+	}
+
+	listBindingsForAppAndService := func(appName, serviceName string) []bindingResource {
+		appGUID := app_helpers.GetAppGuid(appName)
+		serviceGUID := svchelper.GetServiceInstanceGuid(serviceName)
+
+		bindingEndpoint := fmt.Sprintf("/v3/service_credential_bindings?app_guids=%s&service_instance_guids=%s", appGUID, serviceGUID)
+		session := cf.Cf("curl", bindingEndpoint).Wait()
+		Expect(session).To(Exit(0), "failed to list service credential bindings")
+
+		var response bindingListResponse
+		Expect(json.Unmarshal(session.Out.Contents(), &response)).NotTo(HaveOccurred())
+		return response.Resources
+	}
+
+	oldestBindingGUID := func(bindings []bindingResource) string {
+		oldest := bindings[0]
+		for _, binding := range bindings[1:] {
+			if binding.CreatedAt.Before(oldest.CreatedAt) {
+				oldest = binding
+			}
+		}
+		return oldest.GUID
+	}
+
+	BeforeEach(func() {
+		appName = random_name.CATSRandomName("APP")
+		serviceName = random_name.CATSRandomName("SVIN")
+
+		broker = svchelper.NewServiceBroker(
+			random_name.CATSRandomName("BRKR"),
+			assets.NewAssets().ServiceBroker,
+			TestSetup,
+		)
+		broker.Push(Config)
+		broker.Configure()
+		broker.Create()
+		broker.PublicizePlans()
+
+		Expect(cf.Cf(app_helpers.CatnipWithArgs(
+			appName,
+			"-m", DEFAULT_MEMORY_LIMIT)...,
+		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed pushing app")
+
+		Expect(cf.Cf("create-service", broker.Service.Name, broker.SyncPlans[0].Name, serviceName).Wait()).To(Exit(0))
+
+		bindingName = random_name.CATSRandomName("BIND")
+		Expect(cf.Cf("bind-service", appName, serviceName, "--binding-name", bindingName, "--strategy", "multiple").Wait()).To(
+			Exit(0),
+			fmt.Sprintf("failed binding app %s to service %s with binding name %s", appName, serviceName, bindingName),
+		)
+
+		Expect(cf.Cf("restage", appName, "--strategy", "rolling").Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed rolling restage")
+	})
+
+	AfterEach(func() {
+		app_helpers.AppReport(appName)
+		app_helpers.AppReport(broker.Name)
+
+		Expect(cf.Cf("delete-service", serviceName, "-f").Wait()).To(Exit(0))
+		Expect(cf.Cf("delete", appName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+		broker.Destroy()
+	})
+
+	Context("one binding exists for the test application and test service instance", func() {
+
+		It("rotates credentials when creating the second binding", func() {
+			vcapServices := helpers.CurlApp(Config, appName, "/env/VCAP_SERVICES")
+			// test service broker supports only static credentials for service bindings,
+			// so compare binding_guids to verify that the second bind-service call caused credential rotation (instead of being a no-op)
+			initialBindingGUID := extractBindingGUIDFromVCAPServices(vcapServices, bindingName)
+
+			secondBindSession := cf.Cf("bind-service", appName, serviceName, "--binding-name", bindingName, "--strategy", "multiple").Wait()
+			Expect(secondBindSession).To(
+				Exit(0),
+				fmt.Sprintf("failed binding app %s to service %s with binding name %s", appName, serviceName, bindingName),
+			)
+			Expect(string(secondBindSession.Out.Contents())).ToNot(
+				ContainSubstring(fmt.Sprintf("App %s is already bound to service instance %s.", appName, serviceName)),
+				"Make sure to enable the multi-service-binding feature in your test backend.",
+			)
+
+			Expect(cf.Cf("restage", appName, "--strategy", "rolling").Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed rolling restage")
+
+			vcapServices = helpers.CurlApp(Config, appName, "/env/VCAP_SERVICES")
+			rotatedBindingGUID := extractBindingGUIDFromVCAPServices(vcapServices, bindingName)
+
+			Expect(rotatedBindingGUID).ToNot(Equal(initialBindingGUID), fmt.Sprintf("expected new service binding guid after completing credential rotation"))
+		})
+	})
+
+	Context("two service bindings exist for the test application and test service instance", func() {
+
+		BeforeEach(func() {
+			secondBindSession := cf.Cf("bind-service", appName, serviceName, "--binding-name", bindingName, "--strategy", "multiple").Wait()
+			Expect(secondBindSession).To(
+				Exit(0),
+				fmt.Sprintf("failed binding app %s to service %s with binding name %s", appName, serviceName, bindingName),
+			)
+			Expect(string(secondBindSession.Out.Contents())).ToNot(
+				ContainSubstring(fmt.Sprintf("App %s is already bound to service instance %s.", appName, serviceName)),
+				"Make sure to enable the multi-service-binding feature in your test backend.",
+			)
+
+			Expect(cf.Cf("restage", appName, "--strategy", "rolling").Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed rolling restage")
+
+			bindings := listBindingsForAppAndService(appName, serviceName)
+			Expect(len(bindings)).To(Equal(2), fmt.Sprintf("expected two bindings for app %s and service %s", appName, serviceName))
+		})
+
+		Describe("show service instance information", func() {
+			It("shows all bindings", func() {
+				serviceSession := cf.Cf("service", serviceName).Wait()
+				Expect(serviceSession).To(Exit(0))
+
+				serviceOutput := string(serviceSession.Out.Contents())
+
+				bindings := listBindingsForAppAndService(appName, serviceName)
+				for _, binding := range bindings {
+					/* "cf service SERVICE_INSTANCE" output has a table of bindings with columns like:
+									name      binding name   status             message   guid                                   created_at
+					                testapp                  create succeeded             9ec888c4-547c-4c7b-bc51-6f15a7821e5d   2026-03-16T12:37:31Z
+					                testapp                  create succeeded             ccee98fb-8146-4a4f-8b72-a8f96d44f525   2026-03-16T12:16:27Z
+					*/
+					linePattern := fmt.Sprintf(
+						`(?m)^\s+%s\s+%s\s+create succeeded\s+%s\s+\S+$`,
+						regexp.QuoteMeta(appName),
+						regexp.QuoteMeta(binding.Name),
+						regexp.QuoteMeta(binding.GUID),
+					)
+					Expect(serviceOutput).To(
+						MatchRegexp(linePattern),
+						fmt.Sprintf("expected cf service output to contain row matching app=%s binding=%s guid=%s", appName, binding.Name, binding.GUID),
+					)
+				}
+			})
+		})
+
+		Describe("unbind-service", func() {
+			It("deletes both service bindings", func() {
+				Expect(cf.Cf("unbind-service", appName, serviceName).Wait()).To(Exit(0))
+
+				bindings := listBindingsForAppAndService(appName, serviceName)
+				Expect(len(bindings)).To(Equal(0), fmt.Sprintf("expected no bindings for app %s and service %s after unbind-service", appName, serviceName))
+			})
+		})
+
+		Describe("cleanup-outdated-service-bindings", func() {
+			It("deletes the oldest binding", func() {
+				bindings := listBindingsForAppAndService(appName, serviceName)
+				oldestBindingGUID := oldestBindingGUID(bindings)
+
+				Expect(cf.Cf("cleanup-outdated-service-bindings", appName, "--force").Wait()).To(Exit(0))
+
+				bindings = listBindingsForAppAndService(appName, serviceName)
+				Expect(len(bindings)).To(Equal(1), fmt.Sprintf("expected one binding for app %s and service %s after cleanup", appName, serviceName))
+				Expect(bindings[0].GUID).ToNot(Equal(oldestBindingGUID), fmt.Sprintf("expected oldest binding for app %s / service %s to be deleted", appName, serviceName))
+			})
+		})
+	})
+})


### PR DESCRIPTION
### What is this change about?

New acceptance tests for the service credential binding rotations feature. 

The first test creates one service binding for the test app / test service and records its guid. Then it creates a second binding (with the `multiple` strategy), restages the test app and ensures that the binding guid has changed. This validates the full "credential rotation" scenario.

The other tests create two service bindings for the test app / test service and then check the following actions:
1. `cf service <service name>` shows all bindings
2. `cf unbind-service <app name> <service name>` deletes all bindings
3. `cf cleanup-outdated-service-bindings` deletes the oldest binding

### Please provide contextual information.

https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0040-service-binding-rotation.md

### What version of cf-deployment have you run this cf-acceptance-test change against?

v54.14.0 (with `cc.max_service_credential_bindings_per_app_service_instance` set to `2`)

### Please check all that apply for this PR:

- [x] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [x] requires an update to a CATs integration-config (new config option `include_service_credential_binding_rotation`, default is false)

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

This is a new major CF feature, see [RFC-0040](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0040-service-binding-rotation.md).

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Each test takes about 4 minutes to complete, so an additional of 12 minutes (if test suite is enabled).

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
