### PR TITLE
Reduce size of catnip image

### DIFF
--- a/assets/catnip/Dockerfile
+++ b/assets/catnip/Dockerfile
@@ -1,8 +1,15 @@
-FROM golang
+FROM --platform=$BUILDPLATFORM golang AS builder
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /go/src/app
 COPY ./ ./
 
-RUN go build -o /go/bin/catnip /go/src/app/main.go
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /go/bin/catnip /go/src/app/main.go
+
+FROM --platform=$TARGETPLATFORM alpine
+COPY --from=builder /go/bin/catnip /go/bin/catnip
+
+RUN apk add --no-cache ca-certificates bash curl lsb-release
 
 ENV PORT=8080
 CMD ["/go/bin/catnip"]


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Reducing the size of the catnip image drastically

### Please provide contextual information.

No need to include the complete `go` build chain on the image. Now it uses a builder to build the app and puts it on an `alpine` image.

* Size is now < 100MB instead of > 1 GB
* Multi architecture is enabled
* Dependencies (e.g. `bash`, `curl`) are now explicit and not part of `golang`.
 
### What version of cf-deployment have you run this cf-acceptance-test change against?

v21.0.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [X] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

A bit less, depending on your internet speed and if the image already has been downloaded before.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**
- [X] Not urgent

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._

@pbusko 
