### PR TITLE
fix: add name

### DIFF
--- a/assets/logging-route-service/manifest.yml
+++ b/assets/logging-route-service/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
-  - buildpacks:
+  - name: logging-route-service
+    buildpacks:
       - go_buildpack
     env:
       GOVERSION: go1.24


### PR DESCRIPTION
### What is this change about?

The README.md in https://github.com/cloudfoundry/cf-acceptance-tests/tree/release-candidate/assets/logging-route-service describes to just use `cf push`. But this fails as the name isn't defined in the manifest.yml.

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config
- [X] Other

### Did you update the README as appropriate for this change?

- [ ] YES
- [X] N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**
