### PR TITLE
Fix catnip image OS mismatch between build and final stages

### DIFF
--- a/assets/catnip/Dockerfile
+++ b/assets/catnip/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang AS builder
+FROM --platform=$BUILDPLATFORM golang:alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /go/src/app
@@ -6,7 +6,7 @@ COPY ./ ./
 
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /go/bin/catnip /go/src/app/main.go
 
-FROM --platform=$TARGETPLATFORM alpine
+FROM alpine
 COPY --from=builder /go/bin/catnip /go/bin/catnip
 
 RUN apk add --no-cache ca-certificates bash curl lsb-release


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Fixes the catnip image

### Please provide contextual information.

Fixes the mismatch in the OS between the build (debian) and final (alpine) stages

### What version of cf-deployment have you run this cf-acceptance-test change against?

`v55.1.0`

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

none

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
