### PR TITLE
Update all Golang assets to use the latest available version

### DIFF
--- a/assets/golang/manifest.yml
+++ b/assets/golang/manifest.yml
@@ -2,4 +2,4 @@
 applications:
   - env:
       GOPACKAGENAME: go-online
-      GOVERSION: go1.24
+      GOVERSION: latest

--- a/assets/logging-route-service/manifest.yml
+++ b/assets/logging-route-service/manifest.yml
@@ -4,5 +4,5 @@ applications:
     buildpacks:
       - go_buildpack
     env:
-      GOVERSION: go1.24
+      GOVERSION: latest
       GOPACKAGENAME: github.com/cloudfoundry-samples/logging-route-service

--- a/assets/multi-port-app/manifest.yml
+++ b/assets/multi-port-app/manifest.yml
@@ -1,4 +1,4 @@
 ---
 applications:
   - env:
-      GOVERSION: go1.24
+      GOVERSION: latest

--- a/assets/pora/manifest.yml
+++ b/assets/pora/manifest.yml
@@ -5,4 +5,4 @@ applications:
       - go_buildpack
     env:
       GOPACKAGENAME: pora
-      GOVERSION: go1.24
+      GOVERSION: latest

--- a/assets/proxy/internal-route-manifest.yml
+++ b/assets/proxy/internal-route-manifest.yml
@@ -6,6 +6,6 @@ applications:
     buildpack: go_buildpack
     env:
       GOPACKAGENAME: example-apps/proxy
-      GOVERSION: go1.24
+      GOVERSION: latest
     routes:
       - route: app-smoke.apps.internal

--- a/assets/proxy/manifest.yml
+++ b/assets/proxy/manifest.yml
@@ -7,4 +7,4 @@ applications:
       - go_buildpack
     env:
       GOPACKAGENAME: example-apps/proxy
-      GOVERSION: go1.24
+      GOVERSION: latest

--- a/assets/syslog-drain-listener/manifest.yml
+++ b/assets/syslog-drain-listener/manifest.yml
@@ -3,4 +3,4 @@ applications:
   - name: syslog-drain-listener
     env:
       GOPACKAGENAME: main
-      GOVERSION: go1.24
+      GOVERSION: latest

--- a/assets/tcp-listener/manifest.yml
+++ b/assets/tcp-listener/manifest.yml
@@ -2,4 +2,4 @@
 applications:
   - env:
       GOPACKAGENAME: tcp-listener
-      GOVERSION: go1.24
+      GOVERSION: latest


### PR DESCRIPTION
Avoid forgetting to update this in future when bumping the Golang version in the go.mod files for each asset. This is supported as of go-buildpack-release 1.10.41.

### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes.

### What is this change about?

This PR updates the manifest.yml files for all Golang assets to specify GOVERSION=latest to avoid forgeetting to update this in future when bumping the Golang version in the go.mod files for each asset. (this is a duplicate of #1780)

### Please provide contextual information.

* See https://github.com/cloudfoundry/cf-acceptance-tests/pull/1700 and https://github.com/cloudfoundry/cf-acceptance-tests/pull/1716 for a recent example of this happening.
* This functionality was added to the [go-buildpack-release](https://github.com/cloudfoundry/go-buildpack-release/releases) in v1.10.41, which has been integrated into CF-Deployment.

### What version of cf-deployment have you run this cf-acceptance-test change against?

N/A

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

