### PR TITLE
RFC0055 Identity-Aware Routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ assets/credhub-enabled-app/.gradle
 bin/ginkgo
 .vs
 assets/nora/Nora/obj
+.worktrees

--- a/assets/proxy/main.go
+++ b/assets/proxy/main.go
@@ -138,7 +138,7 @@ func mtlsProxyHandler(resp http.ResponseWriter, req *http.Request) {
 			}).Dial,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
-				Certificates:      []tls.Certificate{cert},
+				Certificates:       []tls.Certificate{cert},
 			},
 		},
 	}

--- a/assets/proxy/main.go
+++ b/assets/proxy/main.go
@@ -24,6 +24,8 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/proxy/", proxyHandler)
 	mux.HandleFunc("/https_proxy/", httpsProxyHandler)
+	mux.HandleFunc("/mtls_proxy/", mtlsProxyHandler)
+	mux.HandleFunc("/headers", headersHandler)
 	mux.HandleFunc("/", infoHandler(systemPort))
 
 	server := &http.Server{
@@ -89,6 +91,93 @@ func handleRequest(destination string, resp http.ResponseWriter, req *http.Reque
 	}
 
 	_, _ = resp.Write(readBytes)
+}
+
+func headersHandler(resp http.ResponseWriter, req *http.Request) {
+	headers := make(map[string]string)
+	for name, values := range req.Header {
+		headers[name] = strings.Join(values, ", ")
+	}
+	resp.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(resp).Encode(headers)
+}
+
+func mtlsProxyHandler(resp http.ResponseWriter, req *http.Request) {
+	destination := strings.TrimPrefix(req.URL.Path, "/mtls_proxy/")
+	destination = fmt.Sprintf("https://%s", destination)
+
+	certFile := os.Getenv("CF_INSTANCE_CERT")
+	keyFile := os.Getenv("CF_INSTANCE_KEY")
+	if certFile == "" || keyFile == "" {
+		resp.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(resp).Encode(map[string]interface{}{
+			"status":      "error",
+			"status_code": 500,
+			"error":       "CF_INSTANCE_CERT or CF_INSTANCE_KEY not set",
+		})
+		return
+	}
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		resp.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(resp).Encode(map[string]interface{}{
+			"status":      "error",
+			"status_code": 500,
+			"error":       fmt.Sprintf("failed to load client cert: %s", err),
+		})
+		return
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+			Dial: (&net.Dialer{
+				Timeout:   10 * time.Second,
+				KeepAlive: 0,
+			}).Dial,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+				Certificates:      []tls.Certificate{cert},
+			},
+		},
+	}
+
+	getResp, err := client.Get(destination)
+	if err != nil {
+		resp.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(resp).Encode(map[string]interface{}{
+			"status":      "error",
+			"status_code": 0,
+			"error":       fmt.Sprintf("request failed: %s", err),
+		})
+		return
+	}
+	defer getResp.Body.Close()
+
+	body, err := io.ReadAll(getResp.Body)
+	if err != nil {
+		resp.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(resp).Encode(map[string]interface{}{
+			"status":      "error",
+			"status_code": 0,
+			"error":       fmt.Sprintf("read body failed: %s", err),
+		})
+		return
+	}
+
+	respHeaders := make(map[string]string)
+	for name, values := range getResp.Header {
+		respHeaders[name] = strings.Join(values, ", ")
+	}
+
+	resp.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(resp).Encode(map[string]interface{}{
+		"status":      "success",
+		"status_code": getResp.StatusCode,
+		"body":        string(body),
+		"headers":     respHeaders,
+	})
 }
 
 var httpClient = &http.Client{

--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -250,6 +250,17 @@ func CommaDelimitedSecurityGroupsDescribe(description string, callback func()) b
 	})
 }
 
+func IdentityAwareRoutingDescribe(description string, callback func()) bool {
+	return Describe("[identity aware routing]", func() {
+		BeforeEach(func() {
+			if !Config.GetIncludeIdentityAwareRouting() {
+				Skip(skip_messages.SkipIdentityAwareRoutingMessage)
+			}
+		})
+		Describe(description, callback)
+	})
+}
+
 func ServiceDiscoveryDescribe(description string, callback func()) bool {
 	return Describe("[service discovery]", func() {
 		BeforeEach(func() {

--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/cloudfoundry/cf-acceptance-tests/docker"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/file_based_service_bindings"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/http2_routing"
+	_ "github.com/cloudfoundry/cf-acceptance-tests/identity_aware_routing"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/internet_dependent"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/ipv6"
 	_ "github.com/cloudfoundry/cf-acceptance-tests/isolation_segments"

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -24,6 +24,8 @@ type CatsConfig interface {
 	GetIncludeSecurityGroups() bool
 	GetIncludeServices() bool
 	GetIncludeUserProvidedServices() bool
+	GetIncludeIdentityAwareRouting() bool
+	GetIdentityAwareDomain() string
 	GetIncludeServiceDiscovery() bool
 	GetIncludeServiceCredentialBindingRotation() bool
 	GetIncludeSsh() bool

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -74,36 +74,38 @@ type config struct {
 	VolumeServiceBindConfig   *string `json:"volume_service_bind_config"`
 	VolumeServiceBrokerName   *string `json:"volume_service_broker_name"`
 
-	IncludeAppSyslogTCP                     *bool `json:"include_app_syslog_tcp"`
-	IncludeApps                             *bool `json:"include_apps"`
-	IncludeContainerNetworking              *bool `json:"include_container_networking"`
-	IncludeDeployments                      *bool `json:"include_deployments"`
-	IncludeDetect                           *bool `json:"include_detect"`
-	IncludeDocker                           *bool `json:"include_docker"`
-	IncludeCNB                              *bool `json:"include_cnb"`
-	IncludeFileBasedServiceBindings         *bool `json:"include_file_based_service_bindings"`
-	IncludeInternetDependent                *bool `json:"include_internet_dependent"`
-	IncludeIsolationSegments                *bool `json:"include_isolation_segments"`
-	IncludePrivateDockerRegistry            *bool `json:"include_private_docker_registry"`
-	IncludeRouteServices                    *bool `json:"include_route_services"`
-	IncludeRouting                          *bool `json:"include_routing"`
-	IncludeRoutingIsolationSegments         *bool `json:"include_routing_isolation_segments"`
-	IncludeSSO                              *bool `json:"include_sso"`
-	IncludeSecurityGroups                   *bool `json:"include_security_groups"`
-	IncludeServiceDiscovery                 *bool `json:"include_service_discovery"`
-	IncludeServiceInstanceSharing           *bool `json:"include_service_instance_sharing"`
-	IncludeServiceCredentialBindingRotation *bool `json:"include_service_credential_binding_rotation"`
-	IncludeServices                         *bool `json:"include_services"`
-	IncludeUserProvidedServices             *bool `json:"include_user_provided_services"`
-	IncludeSsh                              *bool `json:"include_ssh"`
-	IncludeTCPIsolationSegments             *bool `json:"include_tcp_isolation_segments"`
-	IncludeHTTP2Routing                     *bool `json:"include_http2_routing"`
-	IncludeTCPRouting                       *bool `json:"include_tcp_routing"`
-	IncludeTasks                            *bool `json:"include_tasks"`
-	IncludeV3                               *bool `json:"include_v3"`
-	IncludeVolumeServices                   *bool `json:"include_volume_services"`
-	IncludeZipkin                           *bool `json:"include_zipkin"`
-	IncludeIPv6                             *bool `json:"include_ipv6"`
+	IncludeAppSyslogTCP                     *bool   `json:"include_app_syslog_tcp"`
+	IncludeApps                             *bool   `json:"include_apps"`
+	IncludeContainerNetworking              *bool   `json:"include_container_networking"`
+	IncludeDeployments                      *bool   `json:"include_deployments"`
+	IncludeDetect                           *bool   `json:"include_detect"`
+	IncludeDocker                           *bool   `json:"include_docker"`
+	IncludeCNB                              *bool   `json:"include_cnb"`
+	IncludeFileBasedServiceBindings         *bool   `json:"include_file_based_service_bindings"`
+	IncludeIdentityAwareRouting             *bool   `json:"include_identity_aware_routing"`
+	IdentityAwareDomain                     *string `json:"identity_aware_domain"`
+	IncludeInternetDependent                *bool   `json:"include_internet_dependent"`
+	IncludeIsolationSegments                *bool   `json:"include_isolation_segments"`
+	IncludePrivateDockerRegistry            *bool   `json:"include_private_docker_registry"`
+	IncludeRouteServices                    *bool   `json:"include_route_services"`
+	IncludeRouting                          *bool   `json:"include_routing"`
+	IncludeRoutingIsolationSegments         *bool   `json:"include_routing_isolation_segments"`
+	IncludeSSO                              *bool   `json:"include_sso"`
+	IncludeSecurityGroups                   *bool   `json:"include_security_groups"`
+	IncludeServiceDiscovery                 *bool   `json:"include_service_discovery"`
+	IncludeServiceInstanceSharing           *bool   `json:"include_service_instance_sharing"`
+	IncludeServiceCredentialBindingRotation *bool   `json:"include_service_credential_binding_rotation"`
+	IncludeServices                         *bool   `json:"include_services"`
+	IncludeUserProvidedServices             *bool   `json:"include_user_provided_services"`
+	IncludeSsh                              *bool   `json:"include_ssh"`
+	IncludeTCPIsolationSegments             *bool   `json:"include_tcp_isolation_segments"`
+	IncludeHTTP2Routing                     *bool   `json:"include_http2_routing"`
+	IncludeTCPRouting                       *bool   `json:"include_tcp_routing"`
+	IncludeTasks                            *bool   `json:"include_tasks"`
+	IncludeV3                               *bool   `json:"include_v3"`
+	IncludeVolumeServices                   *bool   `json:"include_volume_services"`
+	IncludeZipkin                           *bool   `json:"include_zipkin"`
+	IncludeIPv6                             *bool   `json:"include_ipv6"`
 
 	CredhubMode         *string `json:"credhub_mode"`
 	CredhubLocation     *string `json:"credhub_location"`
@@ -200,6 +202,8 @@ func getDefaults() config {
 	defaults.IncludeRouteServices = ptrToBool(false)
 	defaults.IncludeSSO = ptrToBool(false)
 	defaults.IncludeSecurityGroups = ptrToBool(false)
+	defaults.IncludeIdentityAwareRouting = ptrToBool(false)
+	defaults.IdentityAwareDomain = ptrToString("apps.identity")
 	defaults.IncludeServiceDiscovery = ptrToBool(false)
 	defaults.IncludeServices = ptrToBool(false)
 	defaults.IncludeUserProvidedServices = ptrToBool(false)
@@ -480,6 +484,9 @@ func validateConfig(config *config) error {
 	}
 	if config.IncludeSecurityGroups == nil {
 		errs = errors.Join(errs, fmt.Errorf("* 'include_security_groups' must not be null"))
+	}
+	if config.IncludeIdentityAwareRouting == nil {
+		errs = errors.Join(errs, fmt.Errorf("* 'include_identity_aware_routing' must not be null"))
 	}
 	if config.IncludeServiceDiscovery == nil {
 		errs = errors.Join(errs, fmt.Errorf("* 'include_service_discovery' must not be null"))
@@ -1122,6 +1129,14 @@ func (c *config) GetIncludeServiceCredentialBindingRotation() bool {
 
 func (c *config) GetIncludeWindows() bool {
 	return *c.IncludeWindows
+}
+
+func (c *config) GetIncludeIdentityAwareRouting() bool {
+	return *c.IncludeIdentityAwareRouting
+}
+
+func (c *config) GetIdentityAwareDomain() string {
+	return *c.IdentityAwareDomain
 }
 
 func (c *config) GetIncludeServiceDiscovery() bool {

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -360,6 +360,11 @@ func validateConfig(config *config) error {
 		errs = errors.Join(errs, err)
 	}
 
+	err = validateIdentityAwareRouting(config)
+	if err != nil {
+		errs = errors.Join(errs, err)
+	}
+
 	err = validateTimeoutScale(config)
 	if err != nil {
 		errs = errors.Join(errs, err)
@@ -777,6 +782,22 @@ func validateVolumeServices(config *config) error {
 	}
 	if config.GetVolumeServicePlanName() == "" {
 		return fmt.Errorf("* Invalid configuration: 'volume_service_plan_name' must be provided if 'include_volume_services' is true")
+	}
+
+	return nil
+}
+
+func validateIdentityAwareRouting(config *config) error {
+	if config.IncludeIdentityAwareRouting == nil {
+		return fmt.Errorf("* 'include_identity_aware_routing' must not be null")
+	}
+
+	if !config.GetIncludeIdentityAwareRouting() {
+		return nil
+	}
+
+	if config.IdentityAwareDomain == nil {
+		return fmt.Errorf("* Invalid configuration: 'identity_aware_domain' must not be null if 'include_identity_aware_routing' is true")
 	}
 
 	return nil

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -490,9 +490,6 @@ func validateConfig(config *config) error {
 	if config.IncludeSecurityGroups == nil {
 		errs = errors.Join(errs, fmt.Errorf("* 'include_security_groups' must not be null"))
 	}
-	if config.IncludeIdentityAwareRouting == nil {
-		errs = errors.Join(errs, fmt.Errorf("* 'include_identity_aware_routing' must not be null"))
-	}
 	if config.IncludeServiceDiscovery == nil {
 		errs = errors.Join(errs, fmt.Errorf("* 'include_service_discovery' must not be null"))
 	}

--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -55,6 +55,8 @@ const SkipIsolationSegmentsMessage = `Skipping this test because config.IncludeI
 const SkipRoutingIsolationSegmentsMessage = `Skipping this test because Config.IncludeRoutingIsolationSegments is set to 'false'.`
 const SkipZipkinMessage = `Skipping this test because config.IncludeZipkin is set to 'false'`
 const SkipServiceDiscoveryMessage = `Skipping this test because config.IncludeServiceDiscovery is set to 'false'.`
+const SkipIdentityAwareRoutingMessage = `Skipping this test because config.IncludeIdentityAwareRouting is set to 'false'.
+NOTE: Ensure that identity-aware routing is enabled and the identity-aware domain is configured before running this test.`
 const SkipServiceInstanceSharingMessage = `Skipping this test because config.IncludeServiceInstanceSharing is set to 'false'.`
 const SkipServiceCredentialBindingRotationMessage = `Skipping this test because config.IncludeServiceCredentialBindingRotation is set to 'false'.`
 const SkipCapiExperimentalMessage = `Skipping this test because config.IncludeCapiExperimental is set to 'false'.`

--- a/identity_aware_routing/identity_aware_routing.go
+++ b/identity_aware_routing/identity_aware_routing.go
@@ -62,25 +62,14 @@ var _ = IdentityAwareRoutingDescribe("Identity-Aware Routing", func() {
 			"-p", assets.NewAssets().Proxy,
 			"-f", assets.NewAssets().Proxy+"/manifest.yml",
 		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
-
-		// push unauthorized app (same proxy app, different identity)
-		Expect(cf.Cf(
-			"push", appNameUnauthorized,
-			"-b", Config.GetGoBuildpackName(),
-			"-m", DEFAULT_MEMORY_LIMIT,
-			"-p", assets.NewAssets().Proxy,
-			"-f", assets.NewAssets().Proxy+"/manifest.yml",
-		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 	})
 
 	AfterEach(func() {
 		app_helpers.AppReport(appNameFrontend)
 		app_helpers.AppReport(appNameBackend)
-		app_helpers.AppReport(appNameUnauthorized)
 
 		Expect(cf.Cf("delete", appNameFrontend, "-f", "-r").Wait()).To(Exit(0))
 		Expect(cf.Cf("delete", appNameBackend, "-f", "-r").Wait()).To(Exit(0))
-		Expect(cf.Cf("delete", appNameUnauthorized, "-f", "-r").Wait()).To(Exit(0))
 	})
 
 	mtlsProxyURL := func(appName, backendHost, domain, path string) string {
@@ -124,9 +113,36 @@ var _ = IdentityAwareRoutingDescribe("Identity-Aware Routing", func() {
 				resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")
 				return resp.StatusCode
 			}, 2*time.Minute).Should(Equal(200))
+
+			By("removing the route policy for the frontend app")
+			Expect(cf.Cf(
+				"remove-route-policy", identityAwareDomain,
+				"--source-app", appNameFrontend,
+				"--hostname", backendHostName,
+				"-f",
+			).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+
+			By("verifying the frontend can no longer reach the backend")
+			Eventually(func() int {
+				resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")
+				return resp.StatusCode
+			}, 2*time.Minute).Should(Equal(403))
 		})
 
 		It("denies access from an unauthorized app even with a valid certificate", func() {
+			By("pushing an unauthorized app (same proxy app, different identity)")
+			Expect(cf.Cf(
+				"push", appNameUnauthorized,
+				"-b", Config.GetGoBuildpackName(),
+				"-m", DEFAULT_MEMORY_LIMIT,
+				"-p", assets.NewAssets().Proxy,
+				"-f", assets.NewAssets().Proxy+"/manifest.yml",
+			).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+			defer func() {
+				app_helpers.AppReport(appNameUnauthorized)
+				Expect(cf.Cf("delete", appNameUnauthorized, "-f", "-r").Wait()).To(Exit(0))
+			}()
+
 			By("creating a route policy only for the frontend app")
 			Expect(cf.Cf(
 				"add-route-policy", identityAwareDomain,

--- a/identity_aware_routing/identity_aware_routing.go
+++ b/identity_aware_routing/identity_aware_routing.go
@@ -97,25 +97,25 @@ var _ = IdentityAwareRoutingDescribe("Identity-Aware Routing", func() {
 		return resp
 	}
 
-	Describe("mTLS authorization with access rules", func() {
+	Describe("mTLS authorization with route policies", func() {
 	It("denies access by default and allows after adding an access rule", func() {
-		By("verifying the frontend is denied without access rules (default deny)")
+		By("verifying the frontend is denied without route policies (default deny)")
 		Eventually(func() int {
 			resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")
 			return resp.StatusCode
 		}, 2*time.Minute).Should(Equal(403))
 
-		By("creating an access rule for the frontend app")
+		By("creating a route policy for the frontend app")
 		Expect(cf.Cf(
-			"add-access-rule", identityAwareDomain,
+			"add-route-policy", identityAwareDomain,
 			"--source-app", appNameFrontend,
 			"--hostname", backendHostName,
 		).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 
-		By("verifying the access rule is listed")
-		accessRulesOutput := cf.Cf("access-rules", "--domain", identityAwareDomain).Wait(Config.DefaultTimeoutDuration())
-		Expect(accessRulesOutput).To(Exit(0))
-		Expect(string(accessRulesOutput.Out.Contents())).To(ContainSubstring(appNameFrontend))
+		By("verifying the route policy is listed")
+		routePoliciesOutput := cf.Cf("route-policies", "--domain", identityAwareDomain).Wait(Config.DefaultTimeoutDuration())
+		Expect(routePoliciesOutput).To(Exit(0))
+		Expect(string(routePoliciesOutput.Out.Contents())).To(ContainSubstring(appNameFrontend))
 
 		By("verifying the frontend can now reach the backend")
 		Eventually(func() int {
@@ -125,9 +125,9 @@ var _ = IdentityAwareRoutingDescribe("Identity-Aware Routing", func() {
 	})
 
 	It("denies access from an unauthorized app even with a valid certificate", func() {
-		By("creating an access rule only for the frontend app")
+		By("creating a route policy only for the frontend app")
 		Expect(cf.Cf(
-			"add-access-rule", identityAwareDomain,
+			"add-route-policy", identityAwareDomain,
 			"--source-app", appNameFrontend,
 			"--hostname", backendHostName,
 		).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
@@ -148,9 +148,9 @@ var _ = IdentityAwareRoutingDescribe("Identity-Aware Routing", func() {
 		It("forwards X-Forwarded-Client-Cert header with caller identity in Envoy format", func() {
 			frontendGuid := GuidForAppName(appNameFrontend)
 
-			By("creating an access rule for the frontend app")
+			By("creating a route policy for the frontend app")
 			Expect(cf.Cf(
-				"add-access-rule", identityAwareDomain,
+				"add-route-policy", identityAwareDomain,
 				"--source-app", appNameFrontend,
 				"--hostname", backendHostName,
 			).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))

--- a/identity_aware_routing/identity_aware_routing.go
+++ b/identity_aware_routing/identity_aware_routing.go
@@ -98,7 +98,7 @@ var _ = IdentityAwareRoutingDescribe("Identity-Aware Routing", func() {
 	}
 
 	Describe("mTLS authorization with route policies", func() {
-	It("denies access by default and allows after adding an access rule", func() {
+	It("denies access by default and allows after adding a route policy", func() {
 		By("verifying the frontend is denied without route policies (default deny)")
 		Eventually(func() int {
 			resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")

--- a/identity_aware_routing/identity_aware_routing.go
+++ b/identity_aware_routing/identity_aware_routing.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
 	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
+	"github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
 )
 
 type mtlsProxyResponse struct {
@@ -98,52 +99,52 @@ var _ = IdentityAwareRoutingDescribe("Identity-Aware Routing", func() {
 	}
 
 	Describe("mTLS authorization with route policies", func() {
-	It("denies access by default and allows after adding a route policy", func() {
-		By("verifying the frontend is denied without route policies (default deny)")
-		Eventually(func() int {
-			resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")
-			return resp.StatusCode
-		}, 2*time.Minute).Should(Equal(403))
+		It("denies access by default and allows after adding a route policy", func() {
+			By("verifying the frontend is denied without route policies (default deny)")
+			Eventually(func() int {
+				resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")
+				return resp.StatusCode
+			}, 2*time.Minute).Should(Equal(403))
 
-		By("creating a route policy for the frontend app")
-		Expect(cf.Cf(
-			"add-route-policy", identityAwareDomain,
-			"--source-app", appNameFrontend,
-			"--hostname", backendHostName,
-		).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+			By("creating a route policy for the frontend app")
+			Expect(cf.Cf(
+				"add-route-policy", identityAwareDomain,
+				"--source-app", appNameFrontend,
+				"--hostname", backendHostName,
+			).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 
-		By("verifying the route policy is listed")
-		routePoliciesOutput := cf.Cf("route-policies", "--domain", identityAwareDomain).Wait(Config.DefaultTimeoutDuration())
-		Expect(routePoliciesOutput).To(Exit(0))
-		Expect(string(routePoliciesOutput.Out.Contents())).To(ContainSubstring(appNameFrontend))
+			By("verifying the route policy is listed")
+			routePoliciesOutput := cf.Cf("route-policies", "--domain", identityAwareDomain).Wait(Config.DefaultTimeoutDuration())
+			Expect(routePoliciesOutput).To(Exit(0))
+			Expect(string(routePoliciesOutput.Out.Contents())).To(ContainSubstring(appNameFrontend))
 
-		By("verifying the frontend can now reach the backend")
-		Eventually(func() int {
-			resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")
-			return resp.StatusCode
-		}, 2*time.Minute).Should(Equal(200))
-	})
+			By("verifying the frontend can now reach the backend")
+			Eventually(func() int {
+				resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")
+				return resp.StatusCode
+			}, 2*time.Minute).Should(Equal(200))
+		})
 
-	It("denies access from an unauthorized app even with a valid certificate", func() {
-		By("creating a route policy only for the frontend app")
-		Expect(cf.Cf(
-			"add-route-policy", identityAwareDomain,
-			"--source-app", appNameFrontend,
-			"--hostname", backendHostName,
-		).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+		It("denies access from an unauthorized app even with a valid certificate", func() {
+			By("creating a route policy only for the frontend app")
+			Expect(cf.Cf(
+				"add-route-policy", identityAwareDomain,
+				"--source-app", appNameFrontend,
+				"--hostname", backendHostName,
+			).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 
-		By("verifying the authorized frontend can reach the backend")
-		Eventually(func() int {
-			resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")
-			return resp.StatusCode
-		}, 2*time.Minute).Should(Equal(200))
+			By("verifying the authorized frontend can reach the backend")
+			Eventually(func() int {
+				resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")
+				return resp.StatusCode
+			}, 2*time.Minute).Should(Equal(200))
 
-		By("verifying the unauthorized app is denied")
-		Consistently(func() int {
-			resp := curlMtlsProxy(appNameUnauthorized, backendHostName, identityAwareDomain, "headers")
-			return resp.StatusCode
-		}, 30*time.Second).Should(Equal(403))
-	})
+			By("verifying the unauthorized app is denied")
+			Consistently(func() int {
+				resp := curlMtlsProxy(appNameUnauthorized, backendHostName, identityAwareDomain, "headers")
+				return resp.StatusCode
+			}, 30*time.Second).Should(Equal(403))
+		})
 
 		It("forwards X-Forwarded-Client-Cert header with caller identity in Envoy format", func() {
 			frontendGuid := GuidForAppName(appNameFrontend)
@@ -155,22 +156,22 @@ var _ = IdentityAwareRoutingDescribe("Identity-Aware Routing", func() {
 				"--hostname", backendHostName,
 			).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
 
-		By("calling the backend and examining the XFCC header")
-		var xfcc string
-		Eventually(func() string {
-			resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")
-			if resp.StatusCode != 200 {
-				return ""
-			}
-			// The backend returns its request headers as JSON via /headers
-			var headers map[string]string
-			err := json.Unmarshal([]byte(resp.Body), &headers)
-			if err != nil {
-				return ""
-			}
-			xfcc = headers["X-Forwarded-Client-Cert"]
-			return xfcc
-		}, 2*time.Minute).ShouldNot(BeEmpty())
+			By("calling the backend and examining the XFCC header")
+			var xfcc string
+			Eventually(func() string {
+				resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")
+				if resp.StatusCode != 200 {
+					return ""
+				}
+				// The backend returns its request headers as JSON via /headers
+				var headers map[string]string
+				err := json.Unmarshal([]byte(resp.Body), &headers)
+				if err != nil {
+					return ""
+				}
+				xfcc = headers["X-Forwarded-Client-Cert"]
+				return xfcc
+			}, 2*time.Minute).ShouldNot(BeEmpty())
 
 			By("verifying the XFCC header is in Envoy format")
 			Expect(xfcc).To(ContainSubstring("Hash="))
@@ -179,5 +180,46 @@ var _ = IdentityAwareRoutingDescribe("Identity-Aware Routing", func() {
 			By("verifying the XFCC header contains the frontend app GUID")
 			Expect(strings.ToLower(xfcc)).To(ContainSubstring("ou=app:" + strings.ToLower(frontendGuid)))
 		})
+	})
+})
+
+var _ = IdentityAwareRoutingDescribe("Route Policy Domain Management", func() {
+	var domainName string
+
+	BeforeEach(func() {
+		domainName = random_name.CATSRandomName("DOMAIN") + "." + Config.GetAppsDomain()
+	})
+
+	AfterEach(func() {
+		workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+			cf.Cf("target", "-o", TestSetup.GetOrganizationName()).Wait(Config.DefaultTimeoutDuration())
+			cf.Cf("delete-shared-domain", domainName, "-f").Wait()
+		})
+	})
+
+	It("creates a shared domain with route policy enforcement and verifies it in cf domains", func() {
+		By("creating the domain with --enforce-route-policies and --scope space")
+		workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+			createSession := cf.Cf(
+				"create-shared-domain", domainName,
+				"--enforce-route-policies",
+				"--scope", "space",
+			)
+			Expect(createSession.Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+			Expect(string(createSession.Out.Contents())).To(ContainSubstring("identity-aware"))
+		})
+
+		By("verifying the domain appears in cf domains")
+		domainsOutput := cf.Cf("domains").Wait(Config.DefaultTimeoutDuration())
+		Expect(domainsOutput).To(Exit(0))
+
+		var domainLine string
+		for _, line := range strings.Split(string(domainsOutput.Out.Contents()), "\n") {
+			if strings.Contains(line, domainName) {
+				domainLine = line
+				break
+			}
+		}
+		Expect(domainLine).NotTo(BeEmpty(), "domain %s not found in cf domains output:\n%s", domainName, string(domainsOutput.Out.Contents()))
 	})
 })

--- a/identity_aware_routing/identity_aware_routing.go
+++ b/identity_aware_routing/identity_aware_routing.go
@@ -1,0 +1,183 @@
+package identity_aware_routing
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+
+	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
+	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
+)
+
+type mtlsProxyResponse struct {
+	Status     string            `json:"status"`
+	StatusCode int               `json:"status_code"`
+	Body       string            `json:"body"`
+	Headers    map[string]string `json:"headers"`
+	Error      string            `json:"error"`
+}
+
+var _ = IdentityAwareRoutingDescribe("Identity-Aware Routing", func() {
+	var appNameFrontend string
+	var appNameBackend string
+	var appNameUnauthorized string
+	var backendHostName string
+	var identityAwareDomain string
+
+	BeforeEach(func() {
+		identityAwareDomain = Config.GetIdentityAwareDomain()
+
+		backendHostName = random_name.CATSRandomName("HOST")
+		appNameFrontend = random_name.CATSRandomName("APP-FRONT")
+		appNameBackend = random_name.CATSRandomName("APP-BACK")
+		appNameUnauthorized = random_name.CATSRandomName("APP-UNAUTH")
+
+		// push backend app (proxy app so it has /headers endpoint)
+		Expect(cf.Cf(
+			"push", appNameBackend,
+			"-b", Config.GetGoBuildpackName(),
+			"-m", DEFAULT_MEMORY_LIMIT,
+			"-p", assets.NewAssets().Proxy,
+			"-f", assets.NewAssets().Proxy+"/manifest.yml",
+		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+		// map identity-aware route to backend app
+		Expect(cf.Cf("map-route", appNameBackend, identityAwareDomain, "--hostname", backendHostName).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+		// push frontend app (proxy app with /mtls_proxy endpoint)
+		Expect(cf.Cf(
+			"push", appNameFrontend,
+			"-b", Config.GetGoBuildpackName(),
+			"-m", DEFAULT_MEMORY_LIMIT,
+			"-p", assets.NewAssets().Proxy,
+			"-f", assets.NewAssets().Proxy+"/manifest.yml",
+		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+
+		// push unauthorized app (same proxy app, different identity)
+		Expect(cf.Cf(
+			"push", appNameUnauthorized,
+			"-b", Config.GetGoBuildpackName(),
+			"-m", DEFAULT_MEMORY_LIMIT,
+			"-p", assets.NewAssets().Proxy,
+			"-f", assets.NewAssets().Proxy+"/manifest.yml",
+		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
+	})
+
+	AfterEach(func() {
+		app_helpers.AppReport(appNameFrontend)
+		app_helpers.AppReport(appNameBackend)
+		app_helpers.AppReport(appNameUnauthorized)
+
+		Expect(cf.Cf("delete", appNameFrontend, "-f", "-r").Wait()).To(Exit(0))
+		Expect(cf.Cf("delete", appNameBackend, "-f", "-r").Wait()).To(Exit(0))
+		Expect(cf.Cf("delete", appNameUnauthorized, "-f", "-r").Wait()).To(Exit(0))
+	})
+
+	mtlsProxyURL := func(appName, backendHost, domain, path string) string {
+		return fmt.Sprintf("%s%s.%s/mtls_proxy/%s.%s/%s",
+			Config.Protocol(), appName, Config.GetAppsDomain(),
+			backendHost, domain, path)
+	}
+
+	curlMtlsProxy := func(appName, backendHost, domain, path string) mtlsProxyResponse {
+		curlArgs := mtlsProxyURL(appName, backendHost, domain, path)
+		curl := helpers.Curl(Config, curlArgs).Wait()
+		var resp mtlsProxyResponse
+		err := json.Unmarshal(curl.Out.Contents(), &resp)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to parse mtls_proxy response: %s", string(curl.Out.Contents()))
+		return resp
+	}
+
+	Describe("mTLS authorization with access rules", func() {
+	It("denies access by default and allows after adding an access rule", func() {
+		By("verifying the frontend is denied without access rules (default deny)")
+		Eventually(func() int {
+			resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")
+			return resp.StatusCode
+		}, 2*time.Minute).Should(Equal(403))
+
+		By("creating an access rule for the frontend app")
+		Expect(cf.Cf(
+			"add-access-rule", identityAwareDomain,
+			"--source-app", appNameFrontend,
+			"--hostname", backendHostName,
+		).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+
+		By("verifying the access rule is listed")
+		accessRulesOutput := cf.Cf("access-rules", "--domain", identityAwareDomain).Wait(Config.DefaultTimeoutDuration())
+		Expect(accessRulesOutput).To(Exit(0))
+		Expect(string(accessRulesOutput.Out.Contents())).To(ContainSubstring(appNameFrontend))
+
+		By("verifying the frontend can now reach the backend")
+		Eventually(func() int {
+			resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")
+			return resp.StatusCode
+		}, 2*time.Minute).Should(Equal(200))
+	})
+
+	It("denies access from an unauthorized app even with a valid certificate", func() {
+		By("creating an access rule only for the frontend app")
+		Expect(cf.Cf(
+			"add-access-rule", identityAwareDomain,
+			"--source-app", appNameFrontend,
+			"--hostname", backendHostName,
+		).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+
+		By("verifying the authorized frontend can reach the backend")
+		Eventually(func() int {
+			resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")
+			return resp.StatusCode
+		}, 2*time.Minute).Should(Equal(200))
+
+		By("verifying the unauthorized app is denied")
+		Consistently(func() int {
+			resp := curlMtlsProxy(appNameUnauthorized, backendHostName, identityAwareDomain, "headers")
+			return resp.StatusCode
+		}, 30*time.Second).Should(Equal(403))
+	})
+
+		It("forwards X-Forwarded-Client-Cert header with caller identity in Envoy format", func() {
+			frontendGuid := GuidForAppName(appNameFrontend)
+
+			By("creating an access rule for the frontend app")
+			Expect(cf.Cf(
+				"add-access-rule", identityAwareDomain,
+				"--source-app", appNameFrontend,
+				"--hostname", backendHostName,
+			).Wait(Config.DefaultTimeoutDuration())).To(Exit(0))
+
+		By("calling the backend and examining the XFCC header")
+		var xfcc string
+		Eventually(func() string {
+			resp := curlMtlsProxy(appNameFrontend, backendHostName, identityAwareDomain, "headers")
+			if resp.StatusCode != 200 {
+				return ""
+			}
+			// The backend returns its request headers as JSON via /headers
+			var headers map[string]string
+			err := json.Unmarshal([]byte(resp.Body), &headers)
+			if err != nil {
+				return ""
+			}
+			xfcc = headers["X-Forwarded-Client-Cert"]
+			return xfcc
+		}, 2*time.Minute).ShouldNot(BeEmpty())
+
+			By("verifying the XFCC header is in Envoy format")
+			Expect(xfcc).To(ContainSubstring("Hash="))
+			Expect(xfcc).To(ContainSubstring("Subject="))
+
+			By("verifying the XFCC header contains the frontend app GUID")
+			Expect(strings.ToLower(xfcc)).To(ContainSubstring("ou=app:" + strings.ToLower(frontendGuid)))
+		})
+	})
+})

--- a/identity_aware_routing/identity_aware_routing.go
+++ b/identity_aware_routing/identity_aware_routing.go
@@ -93,8 +93,9 @@ var _ = IdentityAwareRoutingDescribe("Identity-Aware Routing", func() {
 		curlArgs := mtlsProxyURL(appName, backendHost, domain, path)
 		curl := helpers.Curl(Config, curlArgs).Wait()
 		var resp mtlsProxyResponse
-		err := json.Unmarshal(curl.Out.Contents(), &resp)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to parse mtls_proxy response: %s", string(curl.Out.Contents()))
+		if err := json.Unmarshal(curl.Out.Contents(), &resp); err != nil {
+			return mtlsProxyResponse{StatusCode: -1}
+		}
 		return resp
 	}
 


### PR DESCRIPTION
## Summary
Add comprehensive acceptance test coverage for the Identity-Aware Routing feature that enables mTLS-based authentication and authorization for app-to-app communication on dedicated domains (e.g., `*.apps.identity`).

This PR implements the CATs portion of [RFC0055](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0055-identity-aware-routing-for-gorouter.md) for domain-scoped mTLS routing in GoRouter.

## Changes

### Test Coverage
Four test cases across two suites:

**Identity-Aware Routing** (`identity_aware_routing/identity_aware_routing.go`):
1. **Default-deny + route policy creation**: Verifies requests are denied by default and allowed after running `cf add-route-policy`; confirms the policy appears in `cf route-policies --domain`
2. **Unauthorized app denial**: Verifies that apps without a route policy are denied even when they hold a valid Diego mTLS certificate; uses `Consistently` to confirm the denial persists
3. **XFCC header forwarding**: Verifies that the `X-Forwarded-Client-Cert` header is forwarded to the backend in Envoy format, containing the frontend app GUID (`OU=app:<guid>`)

**Route Policy Domain Management** (`identity_aware_routing/identity_aware_routing.go`):
4. **Domain creation**: Verifies that `cf create-shared-domain <name> --enforce-route-policies --scope space` succeeds and the resulting domain appears in `cf domains`

### Infrastructure Changes
- **Extended proxy app** (`assets/proxy/main.go`):
  - Added `/headers` endpoint: Returns all incoming request headers as JSON — used by tests to inspect what the backend receives
  - Added `/mtls_proxy/<host.domain>/<path>` endpoint: Dials `<host.domain>:443` and performs an HTTPS request using the Diego instance identity certificate (`CF_INSTANCE_CERT` / `CF_INSTANCE_KEY`) for mTLS client auth; returns status code, body, and headers as JSON

- **New test suite** (`identity_aware_routing/identity_aware_routing.go`):
  - 4 test cases following existing CATs patterns
  - Uses `cf add-route-policy`, `cf route-policies`, and `cf create-shared-domain --enforce-route-policies --scope space`
  - Retryable curl helper: parse failures during `Eventually`/`Consistently` polling return a `StatusCode: -1` sentinel instead of hard-failing, preventing flakiness during route convergence

- **Configuration support** (`helpers/config/`):
  - Added `IncludeIdentityAwareRouting` bool and `IdentityAwareDomain` string (default: `apps.identity`) config fields
  - Added `IdentityAwareRoutingDescribe()` wrapper for test gating
  - Added skip message constant

## Requirements
- Custom CF CLI with route policy and domain management commands:
  - `cf add-route-policy <domain> --source-app <app> --hostname <host>`
  - `cf route-policies --domain <domain>`
  - `cf create-shared-domain <name> --enforce-route-policies --scope space`
- Cloud Foundry deployment with:
  - GoRouter configured with an mTLS domain (via `router.domains` job property)
  - A shared domain with route policy enforcement enabled (e.g., `apps.identity`)
  - BOSH DNS alias for the mTLS domain resolving to router instances

## Testing
Tested against a local CF deployment with all 4 tests passing:
```
Ran 4 of 283 Specs in 582.609 seconds
SUCCESS! -- 4 Passed | 0 Failed | 2 Pending | 277 Skipped
```

## Related Work
- RFC: `community/toc/rfc/rfc-draft-domain-scoped-mtls-gorouter.md`
- GoRouter implementation: routing-release (in parallel development)
- CF CLI commands: cli repository (custom commands for route policy management)
- Acceptance testing guide: https://gist.github.com/rkoster/5b252b0edca606f10be2dbdcb81a796f
