### PR TITLE
Add acceptance test for Cloud Controller API log emission

### DIFF
--- a/apps/running_log.go
+++ b/apps/running_log.go
@@ -60,4 +60,10 @@ var _ = AppsDescribe("app logs", func() {
 			return logs.Recent(appName).Wait().Out
 		}).Should(Say(fmt.Sprintf("\\[APP(.*)/0\\]\\s*ERR %s", message)))
 	})
+
+	It("captures [API/*] logs emitted by the Cloud Controller", func() {
+		Eventually(func() *Buffer {
+			return logs.Recent(appName).Wait().Out
+		}).Should(Say(`\[API/\d+\]\s*OUT Created app with guid `))
+	})
 })


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

yes
### What is this change about?

Adds an acceptance test to verify that Cloud Controller emits [API/*] lifecycle log messages (e.g. "Created app with guid ...") via loggregator when processing an app push. The test checks that these messages appear in the app's recent log stream end-to-end.

### Please provide contextual information.
https://github.com/cloudfoundry/cloud_controller_ng/pull/5043
https://github.com/cloudfoundry/capi-release/pull/644
https://github.com/cloudfoundry/cf-deployment/pull/1327

### What version of cf-deployment have you run this cf-acceptance-test change against?
there will be new version since it includes changes also in cf-deployment


### Please check all that apply for this PR:

- [x] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

The [API/*] logs are part of the core CF app lifecycle and are relied upon by operators. This test validates that Cloud Controller correctly emits these logs end-to-end through the loggregator pipeline.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?
1-2 sec.


### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
