### PR TITLE
Add an endpoint to catnip to write the file

### DIFF
--- a/assets/catnip/file/read_file.go
+++ b/assets/catnip/file/read_file.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-func FileHandler(res http.ResponseWriter, req *http.Request) {
+func ReadFileHandler(res http.ResponseWriter, req *http.Request) {
 	filename := chi.URLParam(req, "filename")
 	decodedFilename, err := url.PathUnescape(filename)
 	if err != nil {
@@ -19,13 +19,13 @@ func FileHandler(res http.ResponseWriter, req *http.Request) {
 
 	_, err = os.Stat(decodedFilename)
 	if err != nil {
-		http.Error(res, http.StatusText(404) + ": " + decodedFilename, 404)
+		http.Error(res, http.StatusText(404)+": "+decodedFilename, 404)
 		return
 	}
 
 	content, err := os.ReadFile(decodedFilename)
 	if err != nil {
-		http.Error(res, http.StatusText(500) + ": " + err.Error(), 500)
+		http.Error(res, http.StatusText(500)+": "+err.Error(), 500)
 		return
 	}
 	res.Write(append(content, '\n'))

--- a/assets/catnip/file/write_file.go
+++ b/assets/catnip/file/write_file.go
@@ -1,0 +1,36 @@
+package file
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func WriteFileHandler(res http.ResponseWriter, req *http.Request) {
+	filename := chi.URLParam(req, "filename")
+	decodedFilename, err := url.PathUnescape(filename)
+	if err != nil {
+		http.Error(res, fmt.Sprintf("Cannot unescape file name: %s", filename), http.StatusBadRequest)
+		return
+	}
+
+	decodedFilename = "/" + decodedFilename
+
+	content, err := io.ReadAll(req.Body)
+	if err != nil {
+		http.Error(res, fmt.Sprintf("failed to read the file: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	err = os.WriteFile(decodedFilename, content, 0644)
+	if err != nil {
+		http.Error(res, http.StatusText(500)+": "+err.Error(), 500)
+		return
+	}
+
+	res.WriteHeader(http.StatusCreated)
+}

--- a/assets/catnip/router/router.go
+++ b/assets/catnip/router/router.go
@@ -39,7 +39,8 @@ func New(out io.Writer, clock clock.Clock) *chi.Mux {
 	r.Get("/curl/{host}", linux.CurlHandler)
 	r.Get("/curl/{host}/", linux.CurlHandler)
 	r.Get("/curl/{host}/{port}", linux.CurlHandler)
-	r.Get("/file/{filename}", file.FileHandler)
+	r.Get("/file/{filename}", file.ReadFileHandler)
+	r.Post("/file/{filename}", file.WriteFileHandler)
 
 	return r
 }


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

- Add an endpoint to catnip app to write a file along with read file
- Rename FileHandler to ReadFileHandler

### What version of cf-deployment have you run this cf-acceptance-test change against?

[v56.3.0](https://github.com/cloudfoundry/cf-deployment/releases/tag/v56.3.0)

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [X] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@davewalter 
