### PR TITLE
Add cflinuxfs5 acceptance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ include_app_syslog_tcp
 * `windows_stack`: Windows stack to run tests against.
 
 * `include_service_discovery`: Flag to include test for the service discovery. These tests use `apps.internal` domain, which is the default in `cf-networking-release`. The internal domain is currently not configurable.
-* `stacks`: An array of stacks to test against. Default is `[cflinuxfs4]`.
+* `stacks`: An array of stacks to test against. Currently `cflinuxfs4` and `cflinuxfs5` stacks are supported. Default is `[cflinuxfs4]`.
 
 * `include_volume_services`: Flag to include the tests for volume services. The following requirements must be met to run this suite: tcp-routing must be deployed.
 * `volume_service_name`: The name of the volume service provided by the volume service broker.

--- a/apps/app_stack.go
+++ b/apps/app_stack.go
@@ -133,6 +133,8 @@ EOF
 				switch stackName {
 				case "cflinuxfs4":
 					expectedLSBRelease = "DISTRIB_CODENAME=jammy"
+				case "cflinuxfs5":
+					expectedLSBRelease = "DISTRIB_CODENAME=noble"
 				}
 
 				push := cf.Cf("push", appName,

--- a/assets/dotnet-core/Makefile
+++ b/assets/dotnet-core/Makefile
@@ -1,7 +1,10 @@
-all: cflinuxfs cflinuxfs4
+all: cflinuxfs4 cflinuxfs5
 
 cflinuxfs4:
 	dotnet publish -f net6.0 -c Release --sc -r ubuntu.22.04-x64 -o ./cflinuxfs4
+
+cflinuxfs5:
+	dotnet publish -f net8.0 -c Release --sc -r ubuntu.24.04-x64 -o ./cflinuxfs5
 
 .PHONY: \
 	all

--- a/assets/dotnet-core/README.md
+++ b/assets/dotnet-core/README.md
@@ -1,3 +1,5 @@
 Copied from
 https://github.com/cloudfoundry/dotnet-core-buildpack/tree/539f9ea5cfc0272ae5a3df36b820578effd01d64/fixtures/source_apps/simple
-and lightly modified to run on .NET Core 6.0.
+and lightly modified to run on .NET Core 6.0 (cflinuxfs4) and .NET 8.0 (cflinuxfs5).
+
+To build the assets, run `make` in this directory.

--- a/assets/dotnet-core/dotnet-core.csproj
+++ b/assets/dotnet-core/dotnet-core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <RootNamespace>dotnet_core</RootNamespace>
   </PropertyGroup>
 

--- a/example-cats-config.json
+++ b/example-cats-config.json
@@ -39,6 +39,7 @@ IN DEVELOPMENT
   "include_zipkin": true,
   "include_volume_services": false,
   "stacks": [
-    "cflinuxfs4"
+    "cflinuxfs4",
+    "cflinuxfs5"
   ]
 }

--- a/helpers/assets/assets.go
+++ b/helpers/assets/assets.go
@@ -60,6 +60,7 @@ func NewAssets() Assets {
 		DoraZip:              "assets/dora.zip",
 		DotnetCore: map[string]string{
 			"cflinuxfs4": "assets/dotnet-core/cflinuxfs4",
+			"cflinuxfs5": "assets/dotnet-core/cflinuxfs5",
 		},
 		GoCallsRubyZip:             "assets/go_calls_ruby.zip",
 		Golang:                     "assets/golang",

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -263,9 +263,6 @@ func getDefaults() config {
 
 	defaults.Stacks = &[]string{"cflinuxfs4"}
 
-	// NOTE: To test cflinuxfs5, override the stacks property in your cats config:
-	// "stacks": ["cflinuxfs5"]
-
 	return defaults
 }
 

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -263,6 +263,9 @@ func getDefaults() config {
 
 	defaults.Stacks = &[]string{"cflinuxfs4"}
 
+	// NOTE: To test cflinuxfs5, override the stacks property in your cats config:
+	// "stacks": ["cflinuxfs5"]
+
 	return defaults
 }
 

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -356,6 +356,7 @@ var _ = Describe("Config", func() {
 		Expect(config.GetCredHubLocation()).To(Equal("https://credhub.service.cf.internal:8844"))
 
 		Expect(config.GetStacks()).To(ConsistOf("cflinuxfs4"))
+		// NOTE: cflinuxfs5 is also supported - override stacks in config to test it
 
 		Expect(config.GetBinaryBuildpackName()).To(Equal("binary_buildpack"))
 		Expect(config.GetGoBuildpackName()).To(Equal("go_buildpack"))
@@ -749,6 +750,30 @@ var _ = Describe("Config", func() {
 			config, err := cfg.NewCatsConfig(tmpFilePath)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(config.GetStacks()).To(Equal([]string{"cflinuxfs4", "my-custom-stack"}))
+		})
+	})
+
+	Context("when providing cflinuxfs5 in the stacks property", func() {
+		BeforeEach(func() {
+			testCfg.Stacks = &[]string{"cflinuxfs5"}
+		})
+
+		It("is loaded into the config", func() {
+			config, err := cfg.NewCatsConfig(tmpFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.GetStacks()).To(Equal([]string{"cflinuxfs5"}))
+		})
+	})
+
+	Context("when providing cflinuxfs4 and cflinuxfs5 in the stacks property", func() {
+		BeforeEach(func() {
+			testCfg.Stacks = &[]string{"cflinuxfs4", "cflinuxfs5"}
+		})
+
+		It("is loaded into the config", func() {
+			config, err := cfg.NewCatsConfig(tmpFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.GetStacks()).To(Equal([]string{"cflinuxfs4", "cflinuxfs5"}))
 		})
 	})
 

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -356,7 +356,6 @@ var _ = Describe("Config", func() {
 		Expect(config.GetCredHubLocation()).To(Equal("https://credhub.service.cf.internal:8844"))
 
 		Expect(config.GetStacks()).To(ConsistOf("cflinuxfs4"))
-		// NOTE: cflinuxfs5 is also supported - override stacks in config to test it
 
 		Expect(config.GetBinaryBuildpackName()).To(Equal("binary_buildpack"))
 		Expect(config.GetGoBuildpackName()).To(Equal("go_buildpack"))


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch]

Yes, this PR targets the develop branch.

### What is this change about?

Adds support for the cflinuxfs5 stack (Ubuntu 24.04 Noble Numbat) to CATs, following the same pattern used when cflinuxfs4 (Ubuntu 22.04 Jammy) was introduced in PR #648.

### Please provide contextual information.

Part of https://github.com/cloudfoundry/cf-deployment/issues/1323. Required by the community pipeline cflinuxfs5-release to validate the new cflinuxfs5 stack
cflinuxfs5 is based on Ubuntu 24.04 Noble Numbat. 

### What version of cf-deployment have you run this cf-acceptance-test change against?

To be tested against cflinuxfs5-release community pipeline.

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [X] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [X] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A — no new tests introduced. Existing stack tests are extended to cover cflinuxfs5.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
@oliver-heinrich @jochenehret 
