### PR TITLE
Automatic updates for "spring-sleuth" asset

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,7 +46,9 @@ updates:
   - "/assets/service_broker"
 
 - package-ecosystem: "maven"
-  directory: "/assets/java-spring"
+  directories:
+  - "/assets/java-spring"
+  - "/assets/spring-sleuth"
   target-branch: "develop"
   schedule:
     interval: "weekly"

--- a/.github/workflows/build-spring-sleuth-jar.yml
+++ b/.github/workflows/build-spring-sleuth-jar.yml
@@ -1,0 +1,59 @@
+name: Build spring-sleuth jar
+
+on:
+  push:
+    branches: ["develop"]
+    paths:
+      - "assets/spring-sleuth/src/**"
+      - "assets/spring-sleuth/pom.xml"
+      - ".github/workflows/build-spring-sleuth-jar.yml"
+  pull_request:
+    branches: ["develop"]
+    paths:
+      - "assets/spring-sleuth/src/**"
+      - "assets/spring-sleuth/pom.xml"
+      - ".github/workflows/build-spring-sleuth-jar.yml"
+
+jobs:
+  build:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GIT_BOT_TOKEN || github.token }}
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Build jar with Maven
+        working-directory: assets/spring-sleuth
+        run: mvn package
+
+      - name: Commit rebuilt jar to PR branch
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && env.GIT_BOT_TOKEN != '' && env.GIT_BOT_NAME != '' && env.GIT_BOT_EMAIL != ''
+        env:
+          GIT_BOT_TOKEN: ${{ secrets.GIT_BOT_TOKEN }}
+          GIT_BOT_NAME: ${{ secrets.GIT_BOT_NAME }}
+          GIT_BOT_EMAIL: ${{ secrets.GIT_BOT_EMAIL }}
+        run: |
+          git config user.name "${GIT_BOT_NAME}"
+          git config user.email "${GIT_BOT_EMAIL}"
+          git remote set-url origin "https://x-access-token:${GIT_BOT_TOKEN}@github.com/${{ github.repository }}.git"
+
+          git add assets/spring-sleuth/target/spring-sleuth-0.0.1.jar
+          if git diff --cached --quiet; then
+            echo "No jar changes to commit"
+            exit 0
+          fi
+
+          git commit -m "Build spring-sleuth-0.0.1.jar with 'mvn package'"
+          git push origin "HEAD:${{ github.head_ref }}"
+


### PR DESCRIPTION
### What is this change about?

Automatic updates for the "spring-sleuth" asset:
* configure Dependabot to update artifacts in pom.xml
* add GitHub action to build jar with "mvn package" when sources change

**Note:** The automatic commit of the re-built jar requires configuration of the "ARD WG Git Bot" credentials as GitHub secrets. This should be no problem, but it's a new pattern. If you think it's over-engineered, please comment.

### Please provide contextual information.

https://github.com/cloudfoundry/cf-acceptance-tests/pull/1912

### What version of cf-deployment have you run this cf-acceptance-test change against?

N/A

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
