### PR TITLE
Add syslog filter test

### DIFF
--- a/app_syslog_tcp/syslog_drain.go
+++ b/app_syslog_tcp/syslog_drain.go
@@ -83,7 +83,9 @@ var _ = AppSyslogTcpDescribe("Syslog Drain over TCP", func() {
 		})
 
 		AfterEach(func() {
-			logs.Kill()
+			if logs != nil {
+				logs.Kill()
+			}
 			close(interrupt)
 
 			app_helpers.AppReport(logWriterAppName1)

--- a/app_syslog_tcp/syslog_drain.go
+++ b/app_syslog_tcp/syslog_drain.go
@@ -32,7 +32,7 @@ var _ = AppSyslogTcpDescribe("Syslog Drain over TCP", func() {
 	var interrupt chan struct{}
 	var serviceName string
 
-	Describe("Syslog drains", func() {
+	Describe("Syslog drains", Ordered, func() {
 		BeforeEach(func() {
 			interrupt = make(chan struct{}, 1)
 			domainName = Config.GetTCPDomain()

--- a/app_syslog_tcp/syslog_drain.go
+++ b/app_syslog_tcp/syslog_drain.go
@@ -96,6 +96,10 @@ var _ = AppSyslogTcpDescribe("Syslog Drain over TCP", func() {
 			Eventually(cf.Cf("delete", logWriterAppName2, "-f", "-r")).Should(Exit(0), "Failed to delete app")
 			Eventually(cf.Cf("delete", listenerAppName, "-f", "-r")).Should(Exit(0), "Failed to delete app")
 			Eventually(cf.Cf("delete-service", serviceName, "-f")).Should(Exit(0), "Failed to delete service")
+			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+				Expect(cf.Cf("target", "-o", TestSetup.GetOrganizationName()).Wait()).To(Exit(0))
+				Eventually(cf.Cf("delete-shared-domain", domainName, "-f")).Should(Exit(0), "Failed to delete TCP shared domain")
+			})
 
 			Eventually(cf.Cf("delete-orphaned-routes", "-f"), Config.CfPushTimeoutDuration()).Should(Exit(0), "Failed to delete orphaned routes")
 		})

--- a/app_syslog_tcp/syslog_drain_filter.go
+++ b/app_syslog_tcp/syslog_drain_filter.go
@@ -1,0 +1,141 @@
+package apps
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/tcp_routing"
+
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	logshelper "github.com/cloudfoundry/cf-acceptance-tests/helpers/logs"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
+	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
+	"github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+// Verifies the per-drain log source type filter from the syslog-agent. HTTP traffic
+// against a ruby_simple app produces both APP logs (the appMarker echoed to STDOUT)
+// and RTR logs (gorouter access logs).
+const rtrSourceTypeMarker = `source_type="RTR"`
+
+var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() {
+	var (
+		logWriterAppName string
+		externalPort     string
+		domainName       string
+		listenerAppName  string
+		logs             *Session
+		interrupt        chan struct{}
+		serviceName      string
+	)
+
+	Describe("Syslog drain source type filter", func() {
+		BeforeEach(func() {
+			interrupt = make(chan struct{}, 1)
+			domainName = Config.GetTCPDomain()
+			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+				routerGroupOutput := string(cf.Cf("router-groups").Wait().Out.Contents())
+				Expect(routerGroupOutput).To(
+					MatchRegexp(fmt.Sprintf("%s\\s+tcp", tcp_routing.DefaultRouterGroupName)),
+					fmt.Sprintf("Router group %s of type tcp doesn't exist", tcp_routing.DefaultRouterGroupName),
+				)
+
+				Expect(cf.Cf("create-shared-domain",
+					domainName,
+					"--router-group", tcp_routing.DefaultRouterGroupName,
+				).Wait()).To(Exit())
+			})
+			serviceName = random_name.CATSRandomName("SVIN")
+			listenerAppName = random_name.CATSRandomName("APP-SYSLOG-LISTENER")
+			logWriterAppName = random_name.CATSRandomName("APP-LOG-WRITER")
+
+			Eventually(cf.Cf(
+				"push",
+				listenerAppName,
+				"--health-check-type", "port",
+				"-b", Config.GetGoBuildpackName(),
+				"-m", DEFAULT_MEMORY_LIMIT,
+				"-p", assets.NewAssets().SyslogDrainListener,
+				"-f", assets.NewAssets().SyslogDrainListener+"/manifest.yml",
+			), Config.CfPushTimeoutDuration()).Should(Exit(0), "Failed to push listener app")
+
+			externalPort = MapTCPRoute(listenerAppName, domainName)
+
+			Eventually(cf.Cf(
+				"push",
+				logWriterAppName,
+				"-b", Config.GetRubyBuildpackName(),
+				"-m", DEFAULT_MEMORY_LIMIT,
+				"-p", assets.NewAssets().RubySimple,
+			), Config.CfPushTimeoutDuration()).Should(Exit(0), "Failed to push log writer app")
+		})
+
+		AfterEach(func() {
+			if logs != nil {
+				logs.Kill()
+			}
+			close(interrupt)
+
+			app_helpers.AppReport(logWriterAppName)
+			app_helpers.AppReport(listenerAppName)
+
+			Eventually(cf.Cf("delete", logWriterAppName, "-f", "-r")).Should(Exit(0), "Failed to delete log writer app")
+			Eventually(cf.Cf("delete", listenerAppName, "-f", "-r")).Should(Exit(0), "Failed to delete listener app")
+			Eventually(cf.Cf("delete-service", serviceName, "-f")).Should(Exit(0), "Failed to delete service")
+
+			Eventually(cf.Cf("delete-orphaned-routes", "-f"), Config.CfPushTimeoutDuration()).Should(Exit(0), "Failed to delete orphaned routes")
+		})
+
+		It("include-log-source-types=APP forwards APP logs and drops RTR logs", func() {
+			drainURL := fmt.Sprintf("syslog://%s:%s/?include-log-source-types=APP", domainName, externalPort)
+			Eventually(cf.Cf("cups", serviceName, "-l", drainURL)).Should(Exit(0), "Failed to create syslog drain service")
+			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
+
+			appMarker := random_name.CATSRandomName("APP-MARKER")
+
+			logs = logshelper.Follow(listenerAppName)
+
+			go driveAppUntilInterrupted(interrupt, logWriterAppName, appMarker)
+
+			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the include-APP drain")
+			Consistently(logs, 30).ShouldNot(Say(rtrSourceTypeMarker), "RTR log line leaked through the include-APP drain")
+		})
+
+		It("exclude-log-source-types=RTR forwards APP logs and drops RTR logs", func() {
+			drainURL := fmt.Sprintf("syslog://%s:%s/?exclude-log-source-types=RTR", domainName, externalPort)
+			Eventually(cf.Cf("cups", serviceName, "-l", drainURL)).Should(Exit(0), "Failed to create syslog drain service")
+			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
+
+			appMarker := random_name.CATSRandomName("APP-MARKER")
+
+			logs = logshelper.Follow(listenerAppName)
+
+			go driveAppUntilInterrupted(interrupt, logWriterAppName, appMarker)
+
+			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the exclude-RTR drain")
+			Consistently(logs, 30).ShouldNot(Say(rtrSourceTypeMarker), "RTR log line leaked through the exclude-RTR drain")
+		})
+	})
+})
+
+// driveAppUntilInterrupted curls the app so it emits both an APP log line
+// (GET /log/<appMarker>) and RTR router access logs, until interrupted.
+func driveAppUntilInterrupted(interrupt chan struct{}, appName, appMarker string) {
+	defer GinkgoRecover()
+	for {
+		select {
+		case <-interrupt:
+			return
+		default:
+			helpers.CurlAppWithTimeout(Config, appName, "/log/"+appMarker, Config.DefaultTimeoutDuration())
+			time.Sleep(3 * time.Second)
+		}
+	}
+}

--- a/app_syslog_tcp/syslog_drain_filter.go
+++ b/app_syslog_tcp/syslog_drain_filter.go
@@ -137,6 +137,36 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the drain-data=all include-APP drain")
 			Consistently(logs, 30).ShouldNot(Say(rtrSourceTypeMarker), "RTR log line leaked through the drain-data=all include-APP drain")
 		})
+
+		It("include-log-source-types=STG,APP with two types forwards APP logs and drops RTR logs", func() {
+			drainURL := fmt.Sprintf("syslog://%s:%s/?include-log-source-types=STG,APP", domainName, externalPort)
+			Eventually(cf.Cf("cups", serviceName, "-l", drainURL)).Should(Exit(0), "Failed to create syslog drain service")
+			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
+
+			appMarker := random_name.CATSRandomName("APP-MARKER")
+
+			logs = logshelper.Follow(listenerAppName)
+
+			go driveAppUntilInterrupted(interrupt, logWriterAppName, appMarker)
+
+			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the include-STG,APP drain")
+			Consistently(logs, 30).ShouldNot(Say(rtrSourceTypeMarker), "RTR log line leaked through the include-STG,APP drain")
+		})
+
+		It("with no source type filter forwards both APP and RTR logs", func() {
+			drainURL := fmt.Sprintf("syslog://%s:%s/", domainName, externalPort)
+			Eventually(cf.Cf("cups", serviceName, "-l", drainURL)).Should(Exit(0), "Failed to create syslog drain service")
+			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
+
+			appMarker := random_name.CATSRandomName("APP-MARKER")
+
+			logs = logshelper.Follow(listenerAppName)
+
+			go driveAppUntilInterrupted(interrupt, logWriterAppName, appMarker)
+
+			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the unfiltered drain")
+			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(rtrSourceTypeMarker), "RTR log line was not forwarded by the unfiltered drain")
+		})
 	})
 })
 

--- a/app_syslog_tcp/syslog_drain_filter.go
+++ b/app_syslog_tcp/syslog_drain_filter.go
@@ -122,6 +122,21 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the exclude-RTR drain")
 			Consistently(logs, 30).ShouldNot(Say(rtrSourceTypeMarker), "RTR log line leaked through the exclude-RTR drain")
 		})
+
+		It("drain-data=all with include-log-source-types=APP forwards APP logs and drops RTR logs", func() {
+			drainURL := fmt.Sprintf("syslog://%s:%s/?drain-data=all&include-log-source-types=APP", domainName, externalPort)
+			Eventually(cf.Cf("cups", serviceName, "-l", drainURL)).Should(Exit(0), "Failed to create syslog drain service")
+			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
+
+			appMarker := random_name.CATSRandomName("APP-MARKER")
+
+			logs = logshelper.Follow(listenerAppName)
+
+			go driveAppUntilInterrupted(interrupt, logWriterAppName, appMarker)
+
+			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the drain-data=all include-APP drain")
+			Consistently(logs, 30).ShouldNot(Say(rtrSourceTypeMarker), "RTR log line leaked through the drain-data=all include-APP drain")
+		})
 	})
 })
 

--- a/app_syslog_tcp/syslog_drain_filter.go
+++ b/app_syslog_tcp/syslog_drain_filter.go
@@ -93,8 +93,8 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 			Eventually(cf.Cf("delete-orphaned-routes", "-f"), Config.CfPushTimeoutDuration()).Should(Exit(0), "Failed to delete orphaned routes")
 		})
 
-		It("include-log-source-types=APP forwards APP logs and drops RTR logs", func() {
-			drainURL := fmt.Sprintf("syslog://%s:%s/?include-log-source-types=APP", domainName, externalPort)
+		It("include-log-types=APP forwards APP logs and drops RTR logs", func() {
+			drainURL := fmt.Sprintf("syslog://%s:%s/?include-log-types=APP", domainName, externalPort)
 			Eventually(cf.Cf("cups", serviceName, "-l", drainURL)).Should(Exit(0), "Failed to create syslog drain service")
 			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
 
@@ -108,8 +108,8 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 			Consistently(logs, 30).ShouldNot(Say(rtrSourceTypeMarker), "RTR log line leaked through the include-APP drain")
 		})
 
-		It("exclude-log-source-types=RTR forwards APP logs and drops RTR logs", func() {
-			drainURL := fmt.Sprintf("syslog://%s:%s/?exclude-log-source-types=RTR", domainName, externalPort)
+		It("exclude-log-types=RTR forwards APP logs and drops RTR logs", func() {
+			drainURL := fmt.Sprintf("syslog://%s:%s/?exclude-log-types=RTR", domainName, externalPort)
 			Eventually(cf.Cf("cups", serviceName, "-l", drainURL)).Should(Exit(0), "Failed to create syslog drain service")
 			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
 
@@ -123,8 +123,8 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 			Consistently(logs, 30).ShouldNot(Say(rtrSourceTypeMarker), "RTR log line leaked through the exclude-RTR drain")
 		})
 
-		It("drain-data=all with include-log-source-types=APP forwards APP logs and drops RTR logs", func() {
-			drainURL := fmt.Sprintf("syslog://%s:%s/?drain-data=all&include-log-source-types=APP", domainName, externalPort)
+		It("drain-data=all with include-log-types=APP forwards APP logs and drops RTR logs", func() {
+			drainURL := fmt.Sprintf("syslog://%s:%s/?drain-data=all&include-log-types=APP", domainName, externalPort)
 			Eventually(cf.Cf("cups", serviceName, "-l", drainURL)).Should(Exit(0), "Failed to create syslog drain service")
 			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
 
@@ -138,8 +138,8 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 			Consistently(logs, 30).ShouldNot(Say(rtrSourceTypeMarker), "RTR log line leaked through the drain-data=all include-APP drain")
 		})
 
-		It("include-log-source-types=STG,APP with two types forwards APP logs and drops RTR logs", func() {
-			drainURL := fmt.Sprintf("syslog://%s:%s/?include-log-source-types=STG,APP", domainName, externalPort)
+		It("include-log-types=STG,APP with two types forwards APP logs and drops RTR logs", func() {
+			drainURL := fmt.Sprintf("syslog://%s:%s/?include-log-types=STG,APP", domainName, externalPort)
 			Eventually(cf.Cf("cups", serviceName, "-l", drainURL)).Should(Exit(0), "Failed to create syslog drain service")
 			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
 

--- a/app_syslog_tcp/syslog_drain_filter.go
+++ b/app_syslog_tcp/syslog_drain_filter.go
@@ -98,6 +98,10 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 
 			Eventually(cf.Cf("delete", logWriterAppName, "-f", "-r")).Should(Exit(0), "Failed to delete log writer app")
 			Eventually(cf.Cf("delete", listenerAppName, "-f", "-r")).Should(Exit(0), "Failed to delete listener app")
+			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+				Expect(cf.Cf("target", "-o", TestSetup.GetOrganizationName()).Wait()).To(Exit(0))
+				Eventually(cf.Cf("delete-shared-domain", domainName, "-f")).Should(Exit(0), "Failed to delete TCP shared domain")
+			})
 			Eventually(cf.Cf("delete-orphaned-routes", "-f"), Config.CfPushTimeoutDuration()).Should(Exit(0), "Failed to delete orphaned routes")
 		})
 

--- a/app_syslog_tcp/syslog_drain_filter.go
+++ b/app_syslog_tcp/syslog_drain_filter.go
@@ -105,8 +105,7 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 			Eventually(cf.Cf("delete-orphaned-routes", "-f"), Config.CfPushTimeoutDuration()).Should(Exit(0), "Failed to delete orphaned routes")
 		})
 
-		It("include-log-types=APP forwards APP logs and drops RTR logs", func() {
-			drainURL := fmt.Sprintf("syslog://%s:%s/?include-log-types=APP", domainName, externalPort)
+		assertDrainBehavior := func(drainURL, scenario string, expectRTR bool) {
 			Eventually(cf.Cf("cups", serviceName, "-l", drainURL)).Should(Exit(0), "Failed to create syslog drain service")
 			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
 
@@ -116,60 +115,32 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 
 			go driveAppUntilInterrupted(interrupt, logWriterAppName, appMarker)
 
-			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the include-APP drain")
-			Consistently(logs, 30).ShouldNot(Say(rtrSourceTypeMarker), "RTR log line leaked through the include-APP drain")
+			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the "+scenario+" drain")
+			if expectRTR {
+				Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(rtrSourceTypeMarker), "RTR log line was not forwarded by the "+scenario+" drain")
+			} else {
+				Consistently(logs, 30).ShouldNot(Say(rtrSourceTypeMarker), "RTR log line leaked through the "+scenario+" drain")
+			}
+		}
+
+		It("include-log-types=APP forwards APP logs and drops RTR logs", func() {
+			assertDrainBehavior(fmt.Sprintf("syslog://%s:%s/?include-log-types=APP", domainName, externalPort), "include-APP", false)
 		})
 
 		It("exclude-log-types=RTR forwards APP logs and drops RTR logs", func() {
-			drainURL := fmt.Sprintf("syslog://%s:%s/?exclude-log-types=RTR", domainName, externalPort)
-			Eventually(cf.Cf("cups", serviceName, "-l", drainURL)).Should(Exit(0), "Failed to create syslog drain service")
-			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
-
-			appMarker := random_name.CATSRandomName("APP-MARKER")
-			logs = logshelper.Follow(listenerAppName)
-			go driveAppUntilInterrupted(interrupt, logWriterAppName, appMarker)
-
-			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the exclude-RTR drain")
-			Consistently(logs, 30).ShouldNot(Say(rtrSourceTypeMarker), "RTR log line leaked through the exclude-RTR drain")
+			assertDrainBehavior(fmt.Sprintf("syslog://%s:%s/?exclude-log-types=RTR", domainName, externalPort), "exclude-RTR", false)
 		})
 
 		It("drain-data=all with include-log-types=APP forwards APP logs and drops RTR logs", func() {
-			drainURL := fmt.Sprintf("syslog://%s:%s/?drain-data=all&include-log-types=APP", domainName, externalPort)
-			Eventually(cf.Cf("cups", serviceName, "-l", drainURL)).Should(Exit(0), "Failed to create syslog drain service")
-			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
-
-			appMarker := random_name.CATSRandomName("APP-MARKER")
-			logs = logshelper.Follow(listenerAppName)
-			go driveAppUntilInterrupted(interrupt, logWriterAppName, appMarker)
-
-			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the drain-data=all include-APP drain")
-			Consistently(logs, 30).ShouldNot(Say(rtrSourceTypeMarker), "RTR log line leaked through the drain-data=all include-APP drain")
+			assertDrainBehavior(fmt.Sprintf("syslog://%s:%s/?drain-data=all&include-log-types=APP", domainName, externalPort), "drain-data=all include-APP", false)
 		})
 
 		It("include-log-types=STG,APP with two types forwards APP logs and drops RTR logs", func() {
-			drainURL := fmt.Sprintf("syslog://%s:%s/?include-log-types=STG,APP", domainName, externalPort)
-			Eventually(cf.Cf("cups", serviceName, "-l", drainURL)).Should(Exit(0), "Failed to create syslog drain service")
-			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
-
-			appMarker := random_name.CATSRandomName("APP-MARKER")
-			logs = logshelper.Follow(listenerAppName)
-			go driveAppUntilInterrupted(interrupt, logWriterAppName, appMarker)
-
-			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the include-STG,APP drain")
-			Consistently(logs, 30).ShouldNot(Say(rtrSourceTypeMarker), "RTR log line leaked through the include-STG,APP drain")
+			assertDrainBehavior(fmt.Sprintf("syslog://%s:%s/?include-log-types=STG,APP", domainName, externalPort), "include-STG,APP", false)
 		})
 
 		It("with no source type filter forwards both APP and RTR logs", func() {
-			drainURL := fmt.Sprintf("syslog://%s:%s/", domainName, externalPort)
-			Eventually(cf.Cf("cups", serviceName, "-l", drainURL)).Should(Exit(0), "Failed to create syslog drain service")
-			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
-
-			appMarker := random_name.CATSRandomName("APP-MARKER")
-			logs = logshelper.Follow(listenerAppName)
-			go driveAppUntilInterrupted(interrupt, logWriterAppName, appMarker)
-
-			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the unfiltered drain")
-			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(rtrSourceTypeMarker), "RTR log line was not forwarded by the unfiltered drain")
+			assertDrainBehavior(fmt.Sprintf("syslog://%s:%s/", domainName, externalPort), "unfiltered", true)
 		})
 	})
 })

--- a/app_syslog_tcp/syslog_drain_filter.go
+++ b/app_syslog_tcp/syslog_drain_filter.go
@@ -36,9 +36,8 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 		serviceName      string
 	)
 
-	Describe("Syslog drain source type filter", func() {
-		BeforeEach(func() {
-			interrupt = make(chan struct{}, 1)
+	Describe("Syslog drain source type filter", Ordered, func() {
+		BeforeAll(func() {
 			domainName = Config.GetTCPDomain()
 			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
 				routerGroupOutput := string(cf.Cf("router-groups").Wait().Out.Contents())
@@ -52,7 +51,6 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 					"--router-group", tcp_routing.DefaultRouterGroupName,
 				).Wait()).To(Exit())
 			})
-			serviceName = random_name.CATSRandomName("SVIN")
 			listenerAppName = random_name.CATSRandomName("APP-SYSLOG-LISTENER")
 			logWriterAppName = random_name.CATSRandomName("APP-LOG-WRITER")
 
@@ -77,19 +75,29 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 			), Config.CfPushTimeoutDuration()).Should(Exit(0), "Failed to push log writer app")
 		})
 
+		BeforeEach(func() {
+			interrupt = make(chan struct{}, 1)
+			serviceName = random_name.CATSRandomName("SVIN")
+		})
+
 		AfterEach(func() {
 			if logs != nil {
 				logs.Kill()
+				logs = nil
 			}
-			close(interrupt)
+			if interrupt != nil {
+				close(interrupt)
+			}
 
+			Eventually(cf.Cf("delete-service", serviceName, "-f")).Should(Exit(0), "Failed to delete service")
+		})
+
+		AfterAll(func() {
 			app_helpers.AppReport(logWriterAppName)
 			app_helpers.AppReport(listenerAppName)
 
 			Eventually(cf.Cf("delete", logWriterAppName, "-f", "-r")).Should(Exit(0), "Failed to delete log writer app")
 			Eventually(cf.Cf("delete", listenerAppName, "-f", "-r")).Should(Exit(0), "Failed to delete listener app")
-			Eventually(cf.Cf("delete-service", serviceName, "-f")).Should(Exit(0), "Failed to delete service")
-
 			Eventually(cf.Cf("delete-orphaned-routes", "-f"), Config.CfPushTimeoutDuration()).Should(Exit(0), "Failed to delete orphaned routes")
 		})
 
@@ -114,9 +122,7 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
 
 			appMarker := random_name.CATSRandomName("APP-MARKER")
-
 			logs = logshelper.Follow(listenerAppName)
-
 			go driveAppUntilInterrupted(interrupt, logWriterAppName, appMarker)
 
 			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the exclude-RTR drain")
@@ -129,9 +135,7 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
 
 			appMarker := random_name.CATSRandomName("APP-MARKER")
-
 			logs = logshelper.Follow(listenerAppName)
-
 			go driveAppUntilInterrupted(interrupt, logWriterAppName, appMarker)
 
 			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the drain-data=all include-APP drain")
@@ -144,9 +148,7 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
 
 			appMarker := random_name.CATSRandomName("APP-MARKER")
-
 			logs = logshelper.Follow(listenerAppName)
-
 			go driveAppUntilInterrupted(interrupt, logWriterAppName, appMarker)
 
 			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the include-STG,APP drain")
@@ -159,9 +161,7 @@ var _ = AppSyslogTcpDescribe("Syslog Drain source type filter over TCP", func() 
 			Eventually(cf.Cf("bind-service", logWriterAppName, serviceName)).Should(Exit(0), "Failed to bind service")
 
 			appMarker := random_name.CATSRandomName("APP-MARKER")
-
 			logs = logshelper.Follow(listenerAppName)
-
 			go driveAppUntilInterrupted(interrupt, logWriterAppName, appMarker)
 
 			Eventually(logs, Config.DefaultTimeoutDuration()+2*time.Minute).Should(Say(appMarker), "APP log line was not forwarded by the unfiltered drain")


### PR DESCRIPTION
### What is this change about?

A new feature has been added to the syslog-agent of the loggregator-agent-release. This adds some initial tests to make sure users can use the feature as expected.

### Please provide contextual information.

PR: https://github.com/cloudfoundry/loggregator-agent-release/pull/714

Issue: https://github.com/cloudfoundry/loggregator-agent-release/issues/711

Documentation PRs:

* https://github.com/cloudfoundry/docs-dev-guide/pull/576
* https://github.com/cloudfoundry/docs-dev-guide/pull/609
* https://github.com/cloudfoundry/docs-dev-guide/pull/608

### What version of cf-deployment have you run this cf-acceptance-test change against?

I deployed CF-on-K8s using cloudfoundry/kind-deployment at commit [db520282](https://github.com/cloudfoundry/kind-deployment/commit/db5202825b28baa2d36bc6b4899b152cc58d13a4) (v0.22.0).

### Please check all that apply for this PR:

- [x] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

This is a new feature for syslog drains.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

On my machine tests run through (including skipping tests) in roughly 8 minutes:

```bash
CONFIG="$HOME/Workspace/public/cloudfoundry/kind-deployment/.github/cats-config.json" go run github.com/onsi/ginkgo/v2/ginkgo --no-color --timeout=45m \
  --focus="Syslog Drain source type filter over TCP" .
  ...
Ran 5 of 291 Specs in 1132.745 seconds
SUCCESS! -- 5 Passed | 0 Failed | 2 Pending | 284 Skipped
```

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@beyhan

**Disclaimer**: Claude Opus 4.8 (and Claude Code) generated this code, I reviewed carefully and edited.