### PR TITLE
Skip GitBuildpack internet-dependent test on non-OSS stacks

### DIFF
--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -60,6 +60,7 @@ const SkipServiceCredentialBindingRotationMessage = `Skipping this test because 
 const SkipCapiExperimentalMessage = `Skipping this test because config.IncludeCapiExperimental is set to 'false'.`
 const SkipWindowsTasksMessage = `Skipping Windows tasks tests (requires diego-release v1.20.0 and above)`
 const SkipNoAlternateStacksMessage = `Skipping this test because config.Stacks is empty.`
+const SkipNonOSSStackMessage = `Skipping this test because none of the configured config.Stacks are a known OSS stack (cflinuxfs3, cflinuxfs4, cflinuxfs5).`
 const SkipVolumeServicesMessage = `Skipping this test because config.IncludeVolumeServices is set to 'false'.
 NOTE: Ensure that volume services are enabled on your platform and volume service broker is registered before running this test.`
 const SkipVolumeServicesDockerEnabledMessage = `Skipping this test because config.IncludeDocker is set to 'true'`

--- a/internet_dependent/git_buildpack.go
+++ b/internet_dependent/git_buildpack.go
@@ -1,6 +1,8 @@
 package internet_dependent_test
 
 import (
+	"slices"
+
 	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -9,9 +11,12 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
 	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
 )
+
+var ossStacks = []string{"cflinuxfs3", "cflinuxfs4", "cflinuxfs5"}
 
 var _ = InternetDependentDescribe("GitBuildpack", func() {
 	var (
@@ -19,11 +24,20 @@ var _ = InternetDependentDescribe("GitBuildpack", func() {
 	)
 
 	It("uses a buildpack from a git url", func() {
+		ossStackIndex := slices.IndexFunc(Config.GetStacks(), func(stack string) bool {
+			return slices.Contains(ossStacks, stack)
+		})
+		if ossStackIndex == -1 {
+			Skip(skip_messages.SkipNonOSSStackMessage)
+		}
+		stack := Config.GetStacks()[ossStackIndex]
+
 		appName = random_name.CATSRandomName("APP")
 		Expect(cf.Cf("push", appName,
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Node,
 			"-b", "https://github.com/cloudfoundry/nodejs-buildpack.git#v1.8.6",
+			"-s", stack,
 		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 
 		Eventually(func() string {


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._

### What is this change about?

_Describe the change and why it's needed._

Only run the git-buildpack test when the configured stacks include a known OSS stack (cflinuxfs3, cflinuxfs4, cflinuxfs5), so it doesn't run against proprietary stacks like tanzucflinuxfs1.

### Please provide contextual information.

We have stacks that don't confirm to this pattern but still want to run CATS. The OSS buildpacks won't work on these custom stacks so I want to skip this test for stacks that aren't OSS supported ones

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

0 extra, reduces test runtime by a bit when test is skipped


### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
