### PR TITLE
Update internet_dependent test

### DIFF
--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -60,7 +60,7 @@ const SkipServiceCredentialBindingRotationMessage = `Skipping this test because 
 const SkipCapiExperimentalMessage = `Skipping this test because config.IncludeCapiExperimental is set to 'false'.`
 const SkipWindowsTasksMessage = `Skipping Windows tasks tests (requires diego-release v1.20.0 and above)`
 const SkipNoAlternateStacksMessage = `Skipping this test because config.Stacks is empty.`
-const SkipNonOSSStackMessage = `Skipping this test because none of the configured config.Stacks are a known OSS stack (cflinuxfs3, cflinuxfs4, cflinuxfs5).`
+const SkipNonOSSStackMessage = `Skipping this test because none of the configured config.Stacks are a known OSS stack (cflinuxfs4, cflinuxfs5).`
 const SkipVolumeServicesMessage = `Skipping this test because config.IncludeVolumeServices is set to 'false'.
 NOTE: Ensure that volume services are enabled on your platform and volume service broker is registered before running this test.`
 const SkipVolumeServicesDockerEnabledMessage = `Skipping this test because config.IncludeDocker is set to 'true'`

--- a/internet_dependent/git_buildpack.go
+++ b/internet_dependent/git_buildpack.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
 )
 
-var ossStacks = []string{"cflinuxfs3", "cflinuxfs4", "cflinuxfs5"}
+var ossStacks = []string{"cflinuxfs4", "cflinuxfs5"}
 
 var _ = InternetDependentDescribe("GitBuildpack", func() {
 	var (
@@ -36,7 +36,7 @@ var _ = InternetDependentDescribe("GitBuildpack", func() {
 		Expect(cf.Cf("push", appName,
 			"-m", DEFAULT_MEMORY_LIMIT,
 			"-p", assets.NewAssets().Node,
-			"-b", "https://github.com/cloudfoundry/nodejs-buildpack.git#v1.8.6",
+			"-b", "https://github.com/cloudfoundry/nodejs-buildpack.git#v1.9.3",
 			"-s", stack,
 		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
 


### PR DESCRIPTION
### What is this change about?

Update to nodejs-buildpack v1.9.3 which supports cflinuxfs5 and remove cflinuxfs3 support.

### Please provide contextual information.

Test is failing because old nodejs-buildpack version does not support cflinuxfs5:
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/fresh-cats/builds/2450
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/experimental-cats/builds/2450

### What version of cf-deployment have you run this cf-acceptance-test change against?

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

No change expected.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
