### PR TITLE
Allow the dotnet-core asset path to be configured per stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ include_app_syslog_tcp
 
 * `include_service_discovery`: Flag to include test for the service discovery. These tests use `apps.internal` domain, which is the default in `cf-networking-release`. The internal domain is currently not configurable.
 * `stacks`: An array of stacks to test against. Currently `cflinuxfs4` and `cflinuxfs5` stacks are supported. Default is `[cflinuxfs4]`.
+* `dotnet_core_asset_paths`: A map from stack name to a directory holding a published dotnet-core app for that stack. CATs ships assets for `cflinuxfs4` and `cflinuxfs5` only; set this to run the dotnet-core detect test against any other stack listed in `stacks`. Without it, that test is skipped for stacks CATs has no asset for. Assets built for the stacks CATs ships take precedence.
 
 * `include_volume_services`: Flag to include the tests for volume services. The following requirements must be met to run this suite: tcp-routing must be deployed.
 * `volume_service_name`: The name of the volume service provided by the volume service broker.

--- a/detect/buildpacks.go
+++ b/detect/buildpacks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
 	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/skip_messages"
 	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
 	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
 )
@@ -161,8 +162,11 @@ var _ = DetectDescribe("Buildpacks", func() {
 			stack := stack
 			Context(fmt.Sprintf("when using %s stack", stack), func() {
 				It("makes the app reachable via its bound route", func() {
-					assetPath, ok := assets.NewAssets().DotnetCore[stack]
-					Expect(ok).To(BeTrue(), fmt.Sprintf("dotnet-core app is missing asset for %s stack", stack))
+					assetPath, ok := dotnetCoreAssetPath(stack)
+					if !ok {
+						Skip(skip_messages.SkipNoDotnetCoreAssetMessage)
+					}
+
 					Expect(cf.Cf("push", appName, "-m", DEFAULT_MEMORY_LIMIT, "-p", assetPath, "-s", stack).Wait(Config.DetectTimeoutDuration())).To(Exit(0))
 
 					Eventually(func() string {
@@ -250,3 +254,16 @@ var _ = DetectDescribe("Buildpacks", func() {
 		}
 	})
 })
+
+// dotnetCoreAssetPath resolves the published dotnet-core app to push for a
+// stack, preferring the assets CATs ships and falling back to whatever the
+// deployment supplied via the dotnet_core_asset_paths config.
+func dotnetCoreAssetPath(stack string) (string, bool) {
+	if assetPath, ok := assets.NewAssets().DotnetCore[stack]; ok {
+		return assetPath, true
+	}
+
+	assetPath, ok := Config.GetDotnetCoreAssetPaths()[stack]
+
+	return assetPath, ok
+}

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -93,6 +93,7 @@ type CatsConfig interface {
 	Protocol() string
 
 	GetStacks() []string
+	GetDotnetCoreAssetPaths() map[string]string
 
 	GetUseWindowsTestTask() bool
 	GetUseWindowsContextPath() bool

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -112,6 +112,12 @@ type config struct {
 
 	Stacks *[]string `json:"stacks,omitempty"`
 
+	// DotnetCoreAssetPaths maps a stack to a directory holding a published
+	// dotnet-core app for that stack. It supplements the assets CATs ships
+	// itself, so that deployments running a stack CATs does not know about can
+	// still exercise the dotnet-core detect test.
+	DotnetCoreAssetPaths map[string]string `json:"dotnet_core_asset_paths,omitempty"`
+
 	IncludeWindows        *bool   `json:"include_windows"`
 	UseWindowsTestTask    *bool   `json:"use_windows_test_task"`
 	UseWindowsContextPath *bool   `json:"use_windows_context_path"`
@@ -1206,6 +1212,10 @@ func (c *config) GetUnallocatedIPForSecurityGroup() string {
 
 func (c *config) GetStacks() []string {
 	return *c.Stacks
+}
+
+func (c *config) GetDotnetCoreAssetPaths() map[string]string {
+	return c.DotnetCoreAssetPaths
 }
 
 func (c *config) GetUseWindowsTestTask() bool {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -58,6 +58,8 @@ type testConfig struct {
 
 	Stacks *[]string `json:"stacks,omitempty"`
 
+	DotnetCoreAssetPaths map[string]string `json:"dotnet_core_asset_paths,omitempty"`
+
 	VolumeServiceName     *string `json:"volume_service_name,omitempty"`
 	VolumeServicePlanName *string `json:"volume_service_plan_name,omitempty"`
 
@@ -356,6 +358,7 @@ var _ = Describe("Config", func() {
 		Expect(config.GetCredHubLocation()).To(Equal("https://credhub.service.cf.internal:8844"))
 
 		Expect(config.GetStacks()).To(ConsistOf("cflinuxfs4"))
+		Expect(config.GetDotnetCoreAssetPaths()).To(BeEmpty())
 
 		Expect(config.GetBinaryBuildpackName()).To(Equal("binary_buildpack"))
 		Expect(config.GetGoBuildpackName()).To(Equal("go_buildpack"))
@@ -773,6 +776,18 @@ var _ = Describe("Config", func() {
 			config, err := cfg.NewCatsConfig(tmpFilePath)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(config.GetStacks()).To(Equal([]string{"cflinuxfs4", "cflinuxfs5"}))
+		})
+	})
+
+	Context("when providing dotnet_core_asset_paths", func() {
+		BeforeEach(func() {
+			testCfg.DotnetCoreAssetPaths = map[string]string{"my-custom-stack": "assets/dotnet-core/cflinuxfs5"}
+		})
+
+		It("is loaded into the config", func() {
+			config, err := cfg.NewCatsConfig(tmpFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.GetDotnetCoreAssetPaths()).To(Equal(map[string]string{"my-custom-stack": "assets/dotnet-core/cflinuxfs5"}))
 		})
 	})
 

--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -61,6 +61,8 @@ const SkipCapiExperimentalMessage = `Skipping this test because config.IncludeCa
 const SkipWindowsTasksMessage = `Skipping Windows tasks tests (requires diego-release v1.20.0 and above)`
 const SkipNoAlternateStacksMessage = `Skipping this test because config.Stacks is empty.`
 const SkipNonOSSStackMessage = `Skipping this test because none of the configured config.Stacks are a known OSS stack (cflinuxfs4, cflinuxfs5).`
+const SkipNoDotnetCoreAssetMessage = `Skipping this test because CATs has no dotnet-core app asset for this stack.
+NOTE: Set 'dotnet_core_asset_paths' to map the stack to a directory holding a published dotnet-core app in order to run this test.`
 const SkipVolumeServicesMessage = `Skipping this test because config.IncludeVolumeServices is set to 'false'.
 NOTE: Ensure that volume services are enabled on your platform and volume service broker is registered before running this test.`
 const SkipVolumeServicesDockerEnabledMessage = `Skipping this test because config.IncludeDocker is set to 'true'`


### PR DESCRIPTION


### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._

Yes

### What is this change about?

_Describe the change and why it's needed._

The dotnet-core detect test is the only spec that needs a per-stack asset, because it pushes a pre-published self-contained app rather than source. CATs ships those assets for cflinuxfs4 and cflinuxfs5, so configuring any other stack in `stacks` failed the spec outright with "dotnet-core app is missing asset for <stack> stack" — there was no way for a deployment to supply its own asset, and no way to opt out.

Add a `dotnet_core_asset_paths` config mapping a stack to a directory holding a published dotnet-core app. The built-in assets are consulted first, so this cannot silently shadow them. When neither has an asset for the stack, skip rather than fail, matching how GitBuildpack already handles stacks it does not recognise.

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [x] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

No additional time, possibly less time if the test is skipped due to lack of assets

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
