### PR TITLE
Bump the app memory for the Windows app limits tests

### DIFF
--- a/windows/limits.go
+++ b/windows/limits.go
@@ -28,7 +28,7 @@ var _ = WindowsDescribe("App Limits", func() {
 			appName,
 			"-s", Config.GetWindowsStack(),
 			"-b", Config.GetHwcBuildpackName(),
-			"-m", "256m",
+			"-m", "512m",
 			"-p", assets.NewAssets().Nora,
 			"-l", "1K",
 		).Wait(Config.CfPushTimeoutDuration())).To(Exit(0))
@@ -42,7 +42,7 @@ var _ = WindowsDescribe("App Limits", func() {
 	})
 
 	It("does not allow the app to use more memory than allowed", func() {
-		response := helpers.CurlApp(Config, appName, "/leakmemory/300")
+		response := helpers.CurlApp(Config, appName, "/leakmemory/600")
 		Expect(response).To(ContainSubstring("Insufficient memory"))
 	})
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

Double the app memory for the Windows app limits tests.

### Please provide contextual information.

We have seen instances of apps are running out of memory during startup when running against some of our internal test foundations.

### What version of cf-deployment have you run this cf-acceptance-test change against?

N/A

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

N/A

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
