### PR TITLE
Fix CSRF token injection for __Host- prefixed cookies

### DIFF
--- a/helpers/services/sso.go
+++ b/helpers/services/sso.go
@@ -119,7 +119,7 @@ func AuthorizeScopes(cookie string, config OAuthConfig) (authCode string) {
 	authorizedScopes := `scope.0=scope.openid&scope.1=scope.cloud_controller_service_permissions.read&user_oauth_approval=true&X-Uaa-Csrf=123456`
 	authorizeScopesUri := fmt.Sprintf("%v/oauth/authorize", config.AuthorizationEndpoint)
 
-	curl := helpers.Curl(Config, authorizeScopesUri, `-i`, `--data`, authorizedScopes, `--cookie`, cookie+`;X-Uaa-Csrf=123456`, `--insecure`, `-v`).Wait()
+	curl := helpers.Curl(Config, authorizeScopesUri, `-i`, `--data`, authorizedScopes, `--cookie`, cookie+`;X-Uaa-Csrf=123456;__Host-X-Uaa-Csrf=123456`, `--insecure`, `-v`).Wait()
 	Expect(curl).To(Exit(0))
 	apiResponse := string(curl.Out.Contents())
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes.

### What is this change about?

This change updates the SSO helper to inject both the legacy X-Uaa-Csrf cookie and the new __Host-X-Uaa-Csrf cookie during the AuthorizeScopes curl request.

Recent changes in UAA (specifically to fix double submit CSRF cookies) introduced the __Host- prefix for the CSRF cookie when running over HTTPS. Because CATs tests run with --insecure, UAA expects the __Host-X-Uaa-Csrf cookie to be present. Injecting both cookie names ensures the test continues to pass regardless of whether the UAA server expects the legacy cookie name or the new __Host- prefixed cookie name.

### Please provide contextual information.

This fixes a test failure caused by UAA commit 5b0deddb3 ("Fix double submit csrf cookie") which enforces the __Host- prefix on the CSRF cookie for secure connections.


### What version of cf-deployment have you run this cf-acceptance-test change against?



### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [X] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [X] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

N/A - fixing an existing test helper.

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

0 seconds.

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
