### PR TITLE
Read origin from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,8 +289,8 @@ When a test fails, look for the test group name (`[services]` in the example bel
 If you set a value for `artifacts_directory` in your `$CONFIG` file, then you will be able to capture `cf` trace output from failed test runs, this output may be useful in cases where the normal test output is not enough to debug an issue.  The `cf` trace output for the tests in these specs will be found in `CF-TRACE-Applications-*.txt` in the `artifacts_directory`.
 
 **NOTE:**
-If the default identity provider for your deployment is not UAA, it is
-recommended that you set the `origin` configuration property to UAA, and ensure
+If the default identity provider for your deployment is not `uaa`, it is
+recommended that you set the `origin` configuration property to `uaa`, and ensure
 the user credentials that you provide are registered with UAA.
 
 ## Test Execution

--- a/README.md
+++ b/README.md
@@ -288,6 +288,11 @@ When a test fails, look for the test group name (`[services]` in the example bel
 
 If you set a value for `artifacts_directory` in your `$CONFIG` file, then you will be able to capture `cf` trace output from failed test runs, this output may be useful in cases where the normal test output is not enough to debug an issue.  The `cf` trace output for the tests in these specs will be found in `CF-TRACE-Applications-*.txt` in the `artifacts_directory`.
 
+**NOTE:**
+If the default identity provider for your deployment is not UAA, it is
+recommended that you set the `origin` configuration property to UAA, and ensure
+the user credentials that you provide are registered with UAA.
+
 ## Test Execution
 To execute tests according to your configuration, run the [bin/test](./bin/test)
 script with `$CONFIG` set to your

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -29,6 +29,7 @@ type config struct {
 	ExistingUserPassword *string `json:"existing_user_password"`
 	ShouldKeepUser       *bool   `json:"keep_user_at_suite_end"`
 	UseExistingUser      *bool   `json:"use_existing_user"`
+	Origin               *string `json:"origin"`
 
 	UseExistingOrganization *bool   `json:"use_existing_organization"`
 	ExistingOrganization    *string `json:"existing_organization"`
@@ -953,7 +954,7 @@ func (c *config) GetExistingUserPassword() string {
 }
 
 func (c *config) GetUserOrigin() string {
-	return ""
+	return *c.Origin
 }
 
 func (c *config) GetConfigurableTestPassword() string {
@@ -977,7 +978,7 @@ func (c *config) GetAdminPassword() string {
 }
 
 func (c *config) GetAdminOrigin() string {
-	return ""
+	return *c.Origin
 }
 
 func (c *config) GetApiEndpoint() string {

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -270,6 +270,8 @@ func getDefaults() config {
 
 	defaults.Stacks = &[]string{"cflinuxfs4"}
 
+	defaults.Origin = ptrToString("")
+
 	return defaults
 }
 


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

_All PR's to CATs should be submitted to develop and will be merged to main once they've passed acceptance._

### What is this change about?

This change adds the config parameter 'origin' that needs to be set whenever not the default identity provider should be used. 

### Please provide contextual information.

This was somehow added to the smoke tests years ago. but somehow never added to cats.

see https://github.com/cloudfoundry/cf-smoke-tests/commit/056ece139ac9f814f6d7ab55b19ad1b5e64c711e

### What version of cf-deployment have you run this cf-acceptance-test change against?
_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

### What version of cf-deployment have you run this cf-acceptance-test change against?

v60.1.0

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [X] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

_CATs should validate common operator workflows._
_CATs is not a regression test suite._
_CATs is run by every component team to validate their releases before promotion._

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

0s

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
@pbusko 

