### PR TITLE
Clean the zip in case a run has not exited properly

### DIFF
--- a/cats_suite_test.go
+++ b/cats_suite_test.go
@@ -125,6 +125,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		doraFileNames = append(doraFileNames, assets.NewAssets().Dora+"/"+doraFile.Name())
 	}
 	zip := archiver.NewZip()
+	os.Remove(assets.NewAssets().DoraZip)
 	err = zip.Archive(doraFileNames, assets.NewAssets().DoraZip)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
### What is this change about?

Previously this raised "file already exists: assets/dora.zip" error

### Please provide contextual information.

I am running this test suite locally with [cats.sh script of kind-deployment](https://github.com/cloudfoundry/kind-deployment/blob/02168a2b659aa7fc7d87d3f11c1bd051266d5ab8/scripts/cats.sh), which basically wraps [bin/test](https://github.com/cloudfoundry/cf-acceptance-tests/blob/develop/bin/test) of this repository. It happens to me from time to time that CATS tests did not exit properly and a file called `dora.zip` prohibited my tests from rerunning due to "file already exists: assets/dora.zip" error.

Verified end-to-end against a live cf-on-kind cluster: run the real suite, `SIGKILL` it once `assets/dora.zip` appears (simulating an interrupted run so `AfterSuite` never cleans up), then re-run.

**Before the fix** — the leaked zip breaks the next run:

```console
$ # run 1: start suite, kill it once assets/dora.zip is created (leaks the zip)
$ ls assets/dora.zip
assets/dora.zip

$ # run 2: re-run with the leaked zip present
$ CONFIG=cats-config.json go run github.com/onsi/ginkgo/v2/ginkgo .
...
file already exists: assets/dora.zip
Test Suite Failed
```

**After the fix** — same leaked zip, the re-run cleans it up and proceeds:

```console
$ ls assets/dora.zip          # leaked from the previous killed run
assets/dora.zip

$ CONFIG=cats-config.json go run github.com/onsi/ginkgo/v2/ginkgo .
Running Suite: CATS
Will run 2 of 286 specs        # past the archive step — no "file already exists"
...
```

No behavior change on a normal run; this only affects re-runs after an interrupted one.

### What version of cf-deployment have you run this cf-acceptance-test change against?

Newest head of develop branch.

### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [x] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [ ] YES
- [x] N/A

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

Less than a second.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@beyhan @cloudfoundry/wg-app-runtime-platform 

---

🤖 Generated with Claude Code (Opus, claude-opus-latest). Human-reviewed before submitting.