### PR TITLE
Add CATS tests for async recursive delete behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ include_app_syslog_tcp
 * `include_security_groups`: Flag to include tests for security groups. [See below](#container-networking-and-application-security-groups)
 * `dynamic_asgs_enabled`: Defaults to `true`. Set to false if dynamic ASGs are disabled in the test environment.
 * `comma_delim_asgs_enabled`: Defaults to `false`. Set to true if comma delimited ASG destinations are enabled in the test environment.
+* `include_async_recursive_delete`: Flag to include tests that verify async recursive delete behavior (async unbind on `cf delete-service` and `cf delete <app> -f`). Requires `include_services`, an async-capable service broker, and CAPI >= 1.242.0 with `temporary_enable_async_recursive_delete` enabled.
 * `include_services`: Flag to include test for the services API.
 * `include_service_instance_sharing`: Flag to include tests for service instance sharing between spaces. `include_services` must be set for these tests to run. The `service_instance_sharing` feature flag must also be enabled for these tests to pass.
 * `include_service_credential_binding_rotation`: Execute tests for multiple service bindings. See [RFC-0040](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0040-service-binding-rotation.md) for details. This test requires CF CLI v8.18.0 or later. The backend must support at least 2 service bindings per app and service instance.

--- a/cats_suite_helpers/cats_suite_helpers.go
+++ b/cats_suite_helpers/cats_suite_helpers.go
@@ -283,6 +283,20 @@ func ServicesDescribe(description string, callback func()) bool {
 	})
 }
 
+func AsyncRecursiveDeleteDescribe(description string, callback func()) bool {
+	return Describe("[async_recursive_delete]", func() {
+		BeforeEach(func() {
+			if !Config.GetIncludeServices() {
+				Skip(skip_messages.SkipServicesMessage)
+			}
+			if !Config.GetIncludeAsyncRecursiveDelete() {
+				Skip(skip_messages.SkipAsyncRecursiveDeleteMessage)
+			}
+		})
+		Describe(description, callback)
+	})
+}
+
 func ServiceInstanceSharingDescribe(description string, callback func()) bool {
 	return Describe("[service instance sharing]", func() {
 		BeforeEach(func() {

--- a/example-cats-config.json
+++ b/example-cats-config.json
@@ -31,6 +31,7 @@ IN DEVELOPMENT
   "include_service_discovery": false,
   "include_services": true,
   "include_service_instance_sharing": true,
+  "include_async_recursive_delete": false,
   "include_ssh": true,
   "include_sso": true,
   "include_tasks": true,

--- a/helpers/config/config.go
+++ b/helpers/config/config.go
@@ -15,6 +15,7 @@ type CatsConfig interface {
 	GetIncludeCNB() bool
 	GetIncludeFileBasedServiceBindings() bool
 	GetIncludeIPv6() bool
+	GetIncludeAsyncRecursiveDelete() bool
 	GetIncludeInternetDependent() bool
 	GetIncludePrivateDockerRegistry() bool
 	GetIncludeRouteServices() bool

--- a/helpers/config/config_struct.go
+++ b/helpers/config/config_struct.go
@@ -106,6 +106,7 @@ type config struct {
 	IncludeV3                               *bool   `json:"include_v3"`
 	IncludeVolumeServices                   *bool   `json:"include_volume_services"`
 	IncludeZipkin                           *bool   `json:"include_zipkin"`
+	IncludeAsyncRecursiveDelete             *bool   `json:"include_async_recursive_delete"`
 	IncludeIPv6                             *bool   `json:"include_ipv6"`
 
 	CredhubMode         *string `json:"credhub_mode"`
@@ -223,6 +224,7 @@ func getDefaults() config {
 	defaults.IncludeTCPRouting = ptrToBool(false)
 	defaults.IncludeVolumeServices = ptrToBool(false)
 	defaults.IncludeIPv6 = ptrToBool(false)
+	defaults.IncludeAsyncRecursiveDelete = ptrToBool(false)
 
 	defaults.IncludeWindows = ptrToBool(false)
 	defaults.UseWindowsContextPath = ptrToBool(false)
@@ -552,6 +554,9 @@ func validateConfig(config *config) error {
 	}
 	if config.IncludeIPv6 == nil {
 		errs = errors.Join(errs, fmt.Errorf("* 'include_ipv6' must not be null"))
+	}
+	if config.IncludeAsyncRecursiveDelete == nil {
+		errs = errors.Join(errs, fmt.Errorf("* 'include_async_recursive_delete' must not be null"))
 	}
 
 	return errs
@@ -1132,6 +1137,10 @@ func (c *config) GetIncludeCredhubNonAssisted() bool {
 
 func (c *config) GetIncludeIPv6() bool {
 	return *c.IncludeIPv6
+}
+
+func (c *config) GetIncludeAsyncRecursiveDelete() bool {
+	return *c.IncludeAsyncRecursiveDelete
 }
 
 func (c *config) GetCredHubBrokerClientCredential() string {

--- a/helpers/config/config_test.go
+++ b/helpers/config/config_test.go
@@ -92,6 +92,7 @@ type testConfig struct {
 	IncludeZipkin                   *bool `json:"include_zipkin,omitempty"`
 	IncludeWindows                  *bool `json:"include_windows,omitempty"`
 	IncludeIPv6                     *bool `json:"include_ipv6,omitempty"`
+	IncludeAsyncRecursiveDelete     *bool `json:"include_async_recursive_delete,omitempty"`
 
 	BinaryBuildpackName     *string `json:"binary_buildpack_name,omitempty"`
 	GoBuildpackName         *string `json:"go_buildpack_name,omitempty"`
@@ -181,6 +182,7 @@ type nullConfig struct {
 	IncludeVolumeServices           *bool `json:"include_volume_services"`
 	IncludeTCPIsolationSegments     *bool `json:"include_tcp_isolation_segments"`
 	IncludeAppSyslogTcp             *bool `json:"include_app_syslog_tcp"`
+	IncludeAsyncRecursiveDelete     *bool `json:"include_async_recursive_delete"`
 
 	CredhubMode         *string `json:"credhub_mode"`
 	CredhubLocation     *string `json:"credhub_location"`
@@ -289,6 +291,7 @@ var _ = Describe("Config", func() {
 		Expect(config.GetIncludeDocker()).To(BeFalse())
 		Expect(config.GetIncludeFileBasedServiceBindings()).To(BeFalse())
 		Expect(config.GetIncludeIPv6()).To(BeFalse())
+		Expect(config.GetIncludeAsyncRecursiveDelete()).To(BeFalse())
 		Expect(config.GetIncludeInternetDependent()).To(BeFalse())
 		Expect(config.GetIncludeRouteServices()).To(BeFalse())
 		Expect(config.GetIncludeContainerNetworking()).To(BeFalse())
@@ -444,6 +447,7 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(ContainSubstring("'include_windows' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_service_discovery' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'include_app_syslog_tcp' must not be null"))
+			Expect(err.Error()).To(ContainSubstring("'include_async_recursive_delete' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'public_docker_app_image' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'private_docker_registry_image' must not be null"))
 			Expect(err.Error()).To(ContainSubstring("'private_docker_registry_username' must not be null"))
@@ -483,6 +487,7 @@ var _ = Describe("Config", func() {
 			testCfg.IncludeDocker = ptrToBool(true)
 			testCfg.IncludeFileBasedServiceBindings = ptrToBool(true)
 			testCfg.IncludeIPv6 = ptrToBool(true)
+			testCfg.IncludeAsyncRecursiveDelete = ptrToBool(true)
 			testCfg.IncludeInternetDependent = ptrToBool(true)
 			testCfg.IncludeIsolationSegments = ptrToBool(true)
 			testCfg.IncludePrivateDockerRegistry = ptrToBool(true)
@@ -548,6 +553,7 @@ var _ = Describe("Config", func() {
 			Expect(config.GetIncludeDocker()).To(BeTrue())
 			Expect(config.GetIncludeFileBasedServiceBindings()).To(BeTrue())
 			Expect(config.GetIncludeIPv6()).To(BeTrue())
+			Expect(config.GetIncludeAsyncRecursiveDelete()).To(BeTrue())
 			Expect(config.GetIncludeInternetDependent()).To(BeTrue())
 			Expect(config.GetIncludeIsolationSegments()).To(BeTrue())
 			Expect(config.GetIncludePrivateDockerRegistry()).To(BeTrue())

--- a/helpers/skip_messages/skip_messages.go
+++ b/helpers/skip_messages/skip_messages.go
@@ -68,3 +68,4 @@ NOTE: Set 'dotnet_core_asset_paths' to map the stack to a directory holding a pu
 const SkipVolumeServicesMessage = `Skipping this test because config.IncludeVolumeServices is set to 'false'.
 NOTE: Ensure that volume services are enabled on your platform and volume service broker is registered before running this test.`
 const SkipVolumeServicesDockerEnabledMessage = `Skipping this test because config.IncludeDocker is set to 'true'`
+const SkipAsyncRecursiveDeleteMessage = `Skipping this test because config.IncludeAsyncRecursiveDelete is set to 'false'.`

--- a/services/async_recursive_delete.go
+++ b/services/async_recursive_delete.go
@@ -1,0 +1,197 @@
+package services_test
+
+import (
+	"time"
+
+	. "github.com/cloudfoundry/cf-acceptance-tests/cats_suite_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/app_helpers"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/assets"
+	"github.com/cloudfoundry/cf-acceptance-tests/helpers/random_name"
+	. "github.com/cloudfoundry/cf-acceptance-tests/helpers/services"
+
+	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
+	"github.com/cloudfoundry/cf-test-helpers/v2/workflowhelpers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = AsyncRecursiveDeleteDescribe("Async Recursive Delete", func() {
+	const asyncOperationPollInterval = 5 * time.Second
+
+	targetOrgAndSpace := func() {
+		orgName := TestSetup.RegularUserContext().Org
+		spaceName := TestSetup.RegularUserContext().TestSpace.SpaceName()
+		Expect(cf.Cf("target", "-o", orgName, "-s", spaceName).Wait()).To(Exit(0), "failed targeting org and space")
+	}
+
+	assertServiceNotFound := func(instanceName string) {
+		Eventually(func() *Buffer {
+			session := cf.Cf("service", instanceName).Wait()
+			combinedOutputBytes := append(session.Out.Contents(), session.Err.Contents()...)
+			return BufferWithBytes(combinedOutputBytes)
+		}, Config.AsyncServiceOperationTimeoutDuration(), asyncOperationPollInterval).Should(Say("not found"))
+	}
+
+	assertAppNotFound := func(appName string) {
+		Eventually(func() *Buffer {
+			session := cf.Cf("app", appName).Wait()
+			combinedOutputBytes := append(session.Out.Contents(), session.Err.Contents()...)
+			return BufferWithBytes(combinedOutputBytes)
+		}, Config.AsyncServiceOperationTimeoutDuration(), asyncOperationPollInterval).Should(Say("not found"))
+	}
+
+	Describe("async unbind via cf delete-service and cf delete", func() {
+		var broker ServiceBroker
+		var appName, instanceName string
+
+		BeforeEach(func() {
+			broker = NewServiceBroker(
+				random_name.CATSRandomName("BRKR"),
+				assets.NewAssets().ServiceBroker,
+				TestSetup,
+			)
+			broker.Push(Config)
+			broker.Configure()
+			broker.Create()
+			broker.PublicizePlans()
+
+			appName = random_name.CATSRandomName("APP")
+			instanceName = random_name.CATSRandomName("SVIN")
+
+			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+				orgName := TestSetup.RegularUserContext().Org
+				spaceName := TestSetup.RegularUserContext().TestSpace.SpaceName()
+				Expect(cf.Cf("target", "-o", orgName, "-s", spaceName).Wait()).To(Exit(0), "failed targeting org and space")
+
+				Expect(cf.Cf(app_helpers.CatnipWithArgs(
+					appName,
+					"-m", DEFAULT_MEMORY_LIMIT)...,
+				).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed pushing app")
+
+				createService := cf.Cf("create-service", broker.Service.Name, broker.AsyncPlans[2].Name, instanceName).Wait()
+				Expect(createService).To(Exit(0), "failed creating async service instance")
+
+				Eventually(func() *Session {
+					return cf.Cf("service", instanceName).Wait()
+				}, Config.AsyncServiceOperationTimeoutDuration(), asyncOperationPollInterval).Should(Say("succeeded"))
+
+				Expect(cf.Cf("bind-service", appName, instanceName).Wait()).To(Exit(0), "failed binding service to app")
+
+				Eventually(func() *Session {
+					return cf.Cf("service", instanceName).Wait()
+				}, Config.AsyncServiceOperationTimeoutDuration(), asyncOperationPollInterval).Should(Say(appName + ".*\\ssucceeded"))
+			})
+		})
+
+		AfterEach(func() {
+			app_helpers.AppReport(broker.Name)
+			app_helpers.AppReport(appName)
+
+			broker.Destroy()
+			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+				orgName := TestSetup.RegularUserContext().Org
+				spaceName := TestSetup.RegularUserContext().TestSpace.SpaceName()
+				cf.Cf("target", "-o", orgName, "-s", spaceName).Wait()
+				cf.Cf("unbind-service", appName, instanceName).Wait()
+				cf.Cf("delete-service", instanceName, "-f").Wait()
+				cf.Cf("delete", appName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())
+			})
+		})
+
+		It("deletes a service instance with an async unbind when using cf delete-service", func() {
+			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+				targetOrgAndSpace()
+				deleteService := cf.Cf("delete-service", instanceName, "-f").Wait()
+				Expect(deleteService).To(Exit(0), "failed to delete service instance")
+
+				assertServiceNotFound(instanceName)
+
+				getApp := cf.Cf("app", appName).Wait()
+				Expect(getApp).To(Exit(0), "app should still exist after delete-service")
+			})
+		})
+
+		It("triggers async unbind when deleting a bound app with cf delete -f", func() {
+			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+				targetOrgAndSpace()
+
+				Expect(cf.Cf("delete", appName, "-f").Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "cf delete -f should enqueue successfully")
+
+				Eventually(func() *Session {
+					return cf.Cf("service", instanceName).Wait()
+				}, Config.AsyncServiceOperationTimeoutDuration(), asyncOperationPollInterval).Should(Say("There are no bound apps for this service."))
+
+				assertAppNotFound(appName)
+			})
+		})
+	})
+
+	Describe("synchronous unbind path", func() {
+		var broker ServiceBroker
+		var appName, instanceName string
+
+		BeforeEach(func() {
+			broker = NewServiceBroker(
+				random_name.CATSRandomName("BRKR"),
+				assets.NewAssets().ServiceBroker,
+				TestSetup,
+			)
+			broker.Push(Config)
+			broker.Configure()
+			broker.Create()
+			broker.PublicizePlans()
+
+			appName = random_name.CATSRandomName("APP")
+			instanceName = random_name.CATSRandomName("SVIN")
+
+			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+				orgName := TestSetup.RegularUserContext().Org
+				spaceName := TestSetup.RegularUserContext().TestSpace.SpaceName()
+				Expect(cf.Cf("target", "-o", orgName, "-s", spaceName).Wait()).To(Exit(0), "failed targeting org and space")
+
+				Expect(cf.Cf(app_helpers.CatnipWithArgs(
+					appName,
+					"-m", DEFAULT_MEMORY_LIMIT)...,
+				).Wait(Config.CfPushTimeoutDuration())).To(Exit(0), "failed pushing sync-unbind app")
+
+				createService := cf.Cf("create-service", broker.Service.Name, broker.AsyncPlans[0].Name, instanceName).Wait()
+				Expect(createService).To(Exit(0), "failed creating service instance with sync-unbind plan")
+
+				Eventually(func() *Session {
+					return cf.Cf("service", instanceName).Wait()
+				}, Config.AsyncServiceOperationTimeoutDuration(), asyncOperationPollInterval).Should(Say("succeeded"))
+
+				Expect(cf.Cf("bind-service", appName, instanceName).Wait()).To(Exit(0), "failed binding sync-unbind app")
+			})
+		})
+
+		AfterEach(func() {
+			app_helpers.AppReport(broker.Name)
+			app_helpers.AppReport(appName)
+
+			broker.Destroy()
+			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+				orgName := TestSetup.RegularUserContext().Org
+				spaceName := TestSetup.RegularUserContext().TestSpace.SpaceName()
+				cf.Cf("target", "-o", orgName, "-s", spaceName).Wait()
+				cf.Cf("unbind-service", appName, instanceName).Wait()
+				cf.Cf("delete-service", instanceName, "-f").Wait()
+				cf.Cf("delete", appName, "-f", "-r").Wait(Config.CfPushTimeoutDuration())
+			})
+		})
+
+		It("uses synchronous unbind path (broker returns HTTP 200) when deleting a bound app", func() {
+			workflowhelpers.AsUser(TestSetup.AdminUserContext(), Config.DefaultTimeoutDuration(), func() {
+				targetOrgAndSpace()
+
+				deleteApp := cf.Cf("delete", appName, "-f").Wait(Config.CfPushTimeoutDuration())
+				Expect(deleteApp).To(Exit(0), "cf delete -f should succeed synchronously when unbind is synchronous")
+
+				assertAppNotFound(appName)
+			})
+		})
+	})
+})


### PR DESCRIPTION
### Are you submitting this PR against the [develop branch](https://github.com/cloudfoundry/cf-acceptance-tests/tree/develop)?

Yes

### What is this change about?

It adds acceptance tests that verify CF correctly handles async service unbind when deleting a service instance or app:

  - cf delete-service <instance> -f — completes successfully even when the broker returns 202 for unbind
  - cf delete <app> -f — completes successfully even when the bound service broker returns 202 for unbind
  - A baseline test for the synchronous unbind path (broker returns 200)

  Also wires up the include_async_recursive_delete config flag across the config system, README, and skip messages so the tests can be opted into per environment.

### Please provide contextual information.

issue: https://github.com/cloudfoundry/cloud_controller_ng/issues/3589

### What version of cf-deployment have you run this cf-acceptance-test change against?

cf-deployment v60.5.0


### Please check all that apply for this PR:

- [ ] introduces a new test --- Are you sure everyone should be running this test?
- [ ] changes an existing test
- [ ] requires an update to a CATs integration-config

### Did you update the README as appropriate for this change?

- [X] YES
- [ ] N/A

### If you are introducing a new acceptance test, what is your rationale for including it CATs rather than your own acceptance test suite?

Async service unbind during app/service instance deletion is a common operator workflow — operators regularly delete apps or service instances that have active service bindings. This test validates that CF correctly handles the case where the service broker requires async unbind, which is a cross-component behavior involving CAPI, the CC worker, and the service broker protocol. It belongs in CATs because it exercises the interaction between these components in a real CF deployment.

### How many more (or fewer) seconds of runtime will this change introduce to CATs?

 Each test does: push app + create service + async bind + async unbind/delete + polling. Roughly:
  - Test 1 (cf delete-service): ~3-5 minutes
  - Test 2 (cf delete): ~3-5 minutes
  - Test 3 (sync unbind baseline): ~2-3 minutes

  Total: approximately 8-13 minutes of additional runtime when `include_async_recursive_delete: true`. Since it defaults to false, there is zero runtime impact for environments that don't opt in.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

